### PR TITLE
fix: reflector and dropper stages skip entirely in noAutoCompact mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- Reflector and dropper now read from `pending.json` in `noAutoCompact` mode instead of scanning the branch for observation markers that are never written there. Previously the early-exit gates in both stages returned immediately because `latestCoverageMarkerId(entries, OM_OBSERVATIONS_RECORDED)` found nothing in the branch (observations are saved to pending only). This caused the reflector and dropper to skip entirely, leaving the pipeline half-functional — no reflections were ever generated, the dropper never pruned, and the display showed misleading pool values. The fix adds `noAutoCompact`-aware early-exit gates that check `pending.observation`, `pending.reflection`, and `pending.dropped` state, using their `coversUpToId` values to calculate token gaps and gate correctly on `reflectAfterTokens`. Observations and reflections are fed from pending data instead of the empty branch. The notification token-adjustment logic (which already existed for all three stages) is now effective because the stages actually run. ([#6](https://github.com/k0valik/pi-blackhole/pull/6))
+
 ## [0.2.1] - 2026-05-24
 
 ### Fixed

--- a/src/om/consolidation.ts
+++ b/src/om/consolidation.ts
@@ -501,7 +501,9 @@ async function runDropperStage(
 		if (!pendingObs?.length) return "continue";
 		observationCoverageId = pending.observation?.coversUpToId;
 		if (pending.dropped?.coversUpToId) {
+			const obsIdx = entryIndexForId(entries, pending.observation?.coversUpToId ?? "");
 			const dropIdx = entryIndexForId(entries, pending.dropped.coversUpToId);
+			if (obsIdx >= 0 && dropIdx >= 0 && obsIdx <= dropIdx) return "continue";
 			if (dropIdx >= 0) {
 				dropTokens = rawTokensAfterIndex(entries, dropIdx);
 				if (dropTokens < runtime.config.reflectAfterTokens) return "continue";
@@ -549,7 +551,8 @@ async function runDropperStage(
 				folded.activeObservations.filter((o: any) => !newObservations.some((no: any) => no.id === o.id)),
 				Math.floor(runtime.config.dropperInputMaxTokens * 0.2),
 			);
-			const reflectionsForDropper = mergeReflections(folded.reflections, sameRunReflections);
+			const pendingReflections = pending ? ((pending.reflection?.data as any)?.reflections ?? []) : folded.reflections;
+			const reflectionsForDropper = mergeReflections(pendingReflections, sameRunReflections);
 
 			// Resolve thinking level for the specific model (fallbacks may have their own thinking config)
 			const stageModelForThinking = runtime.findCandidateConfig(resolved.model, { model: ctx.model, modelRegistry: ctx.modelRegistry, hasUI: ctx.hasUI, ui: ctx.ui, stageModel: stageModelConfig(runtime, "dropper"), stageFallbacks: stageFallbackModels(runtime, "dropper") });

--- a/src/om/consolidation.ts
+++ b/src/om/consolidation.ts
@@ -390,8 +390,12 @@ async function runReflectorStage(
 			const obsIdx = entryIndexForId(entries, pending.observation?.coversUpToId ?? "");
 			const refIdx = entryIndexForId(entries, pending.reflection.coversUpToId);
 			if (obsIdx >= 0 && refIdx >= 0 && obsIdx <= refIdx) return { outcome: "continue", sameRunReflections: [] };
-			reflectionTokens = rawTokensAfterIndex(entries, refIdx);
-			if (reflectionTokens < runtime.config.reflectAfterTokens) return { outcome: "continue", sameRunReflections: [] };
+			if (refIdx >= 0) {
+				reflectionTokens = rawTokensAfterIndex(entries, refIdx);
+				if (reflectionTokens < runtime.config.reflectAfterTokens) return { outcome: "continue", sameRunReflections: [] };
+			} else {
+				reflectionTokens = rawTokensSinceObservationCoverage(entries);
+			}
 		} else {
 			reflectionTokens = rawTokensSinceObservationCoverage(entries);
 		}
@@ -567,7 +571,9 @@ async function runDropperStage(
 				maxTurns: runtime.config.agentMaxTurns,
 				thinkingLevel: stageThinkingLevel(runtime, "dropper", stageModelForThinking),
 			});
-			const latestReflectionCoverageId = latestCoverageMarkerId(entries, OM_REFLECTIONS_RECORDED);
+			const latestReflectionCoverageId = runtime.config.noAutoCompact
+				? pending?.reflection?.coversUpToId
+				: latestCoverageMarkerId(entries, OM_REFLECTIONS_RECORDED);
 			const effectiveReflectionCoverageId = sameRunReflectionCoverageId ?? latestReflectionCoverageId;
 			const coversUpToId = earlierCoverageMarkerId(entries, observationCoverageId, effectiveReflectionCoverageId);
 			const data = coversUpToId && droppedIds ? buildObservationsDroppedData(droppedIds, coversUpToId) : undefined;

--- a/src/om/consolidation.ts
+++ b/src/om/consolidation.ts
@@ -415,7 +415,7 @@ async function runReflectorStage(
 		const pending = runtime.config.noAutoCompact ? readPendingState(sessionId) : undefined;
 		const lastReflectionIdx = pending ? -1 : latestCoverageIndex(entries, OM_REFLECTIONS_RECORDED);
 		const newObservations = pending ? ((pending.observation?.data as any)?.observations ?? []) : observationsCreatedAfterIndex(entries, lastReflectionIdx);
-		const newReflections = pending ? ((pending.reflection?.data as any)?.reflections ?? []) : reflectionsCreatedAfterIndex(entries, lastReflectionIdx);
+		const newReflections = pending ? [] : reflectionsCreatedAfterIndex(entries, lastReflectionIdx);
 		const newItemsTokens = Math.ceil(
 			(newObservations.reduce((s: number, o: any) => s + o.content.length, 0) +
 				newReflections.reduce((s: number, r: any) => s + r.content.length, 0)) / 4

--- a/src/om/consolidation.ts
+++ b/src/om/consolidation.ts
@@ -379,11 +379,28 @@ async function runReflectorStage(
 ): Promise<ReflectorStageResult> {
 	const sessionId = ctx.sessionManager.getSessionId();
 	const entries = ctx.sessionManager.getBranch() as Entry[];
-	const reflectionTokens = rawTokensSinceReflectionCoverage(entries);
-	if (reflectionTokens < runtime.config.reflectAfterTokens) return { outcome: "continue", sameRunReflections: [] };
-
-	const observationCoverageId = latestCoverageMarkerId(entries, OM_OBSERVATIONS_RECORDED);
-	if (!observationCoverageId) return { outcome: "continue", sameRunReflections: [] };
+	let reflectionTokens: number;
+	let observationCoverageId: string | undefined;
+	if (runtime.config.noAutoCompact) {
+		const pending = readPendingState(sessionId);
+		const pendingObs = (pending.observation?.data as any)?.observations;
+		if (!pendingObs?.length) return { outcome: "continue", sameRunReflections: [] };
+		observationCoverageId = pending.observation?.coversUpToId;
+		if (pending.reflection?.coversUpToId) {
+			const obsIdx = entryIndexForId(entries, pending.observation?.coversUpToId ?? "");
+			const refIdx = entryIndexForId(entries, pending.reflection.coversUpToId);
+			if (obsIdx >= 0 && refIdx >= 0 && obsIdx <= refIdx) return { outcome: "continue", sameRunReflections: [] };
+			reflectionTokens = rawTokensAfterIndex(entries, refIdx);
+			if (reflectionTokens < runtime.config.reflectAfterTokens) return { outcome: "continue", sameRunReflections: [] };
+		} else {
+			reflectionTokens = rawTokensSinceObservationCoverage(entries);
+		}
+	} else {
+		reflectionTokens = rawTokensSinceReflectionCoverage(entries);
+		if (reflectionTokens < runtime.config.reflectAfterTokens) return { outcome: "continue", sameRunReflections: [] };
+		observationCoverageId = latestCoverageMarkerId(entries, OM_OBSERVATIONS_RECORDED);
+		if (!observationCoverageId) return { outcome: "continue", sameRunReflections: [] };
+	}
 
 	for (let attempt = 0; attempt < MAX_STAGE_ATTEMPTS; attempt++) {
 		const resolved = await resolveModel("reflector");
@@ -391,12 +408,13 @@ async function runReflectorStage(
 
 		// Compute ahead for an accurate notification
 		const folded = foldLedger(entries);
-		const lastReflectionIdx = latestCoverageIndex(entries, OM_REFLECTIONS_RECORDED);
-		const newObservations = observationsCreatedAfterIndex(entries, lastReflectionIdx);
-		const newReflections = reflectionsCreatedAfterIndex(entries, lastReflectionIdx);
+		const pending = runtime.config.noAutoCompact ? readPendingState(sessionId) : undefined;
+		const lastReflectionIdx = pending ? -1 : latestCoverageIndex(entries, OM_REFLECTIONS_RECORDED);
+		const newObservations = pending ? ((pending.observation?.data as any)?.observations ?? []) : observationsCreatedAfterIndex(entries, lastReflectionIdx);
+		const newReflections = pending ? ((pending.reflection?.data as any)?.reflections ?? []) : reflectionsCreatedAfterIndex(entries, lastReflectionIdx);
 		const newItemsTokens = Math.ceil(
-			(newObservations.reduce((s, o) => s + o.content.length, 0) +
-				newReflections.reduce((s, r) => s + r.content.length, 0)) / 4
+			(newObservations.reduce((s: number, o: any) => s + o.content.length, 0) +
+				newReflections.reduce((s: number, r: any) => s + r.content.length, 0)) / 4
 		);
 		const summaryBudget = Math.floor(runtime.config.reflectorInputMaxTokens * 0.15) * 2;
 		const reflectorInputTokens = Math.min(newItemsTokens + summaryBudget, runtime.config.reflectorInputMaxTokens);
@@ -420,7 +438,7 @@ async function runReflectorStage(
 				Math.floor(runtime.config.reflectorInputMaxTokens * 0.15),
 			);
 			const existingObservationsSummary = buildExistingObservationsSummary(
-				folded.activeObservations.filter(o => !newObservations.some(no => no.id === o.id)),
+				folded.activeObservations.filter((o: any) => !newObservations.some((no: any) => no.id === o.id)),
 				Math.floor(runtime.config.reflectorInputMaxTokens * 0.15),
 			);
 
@@ -437,6 +455,7 @@ async function runReflectorStage(
 			});
 
 			if (!reflections || reflections.length === 0) return { outcome: "continue", sameRunReflections: [] };
+			if (!observationCoverageId) return { outcome: "continue", sameRunReflections: [] };
 
 			const data = buildReflectionsRecordedData(reflections, observationCoverageId);
 			if (!data) return { outcome: "continue", sameRunReflections: [] };
@@ -474,11 +493,30 @@ async function runDropperStage(
 ): Promise<StageOutcome> {
 	const sessionId = ctx.sessionManager.getSessionId();
 	const entries = ctx.sessionManager.getBranch() as Entry[];
-	const dropTokens = rawTokensSinceDropCoverage(entries);
-	if (dropTokens < runtime.config.reflectAfterTokens) return "continue";
-
-	const observationCoverageId = latestCoverageMarkerId(entries, OM_OBSERVATIONS_RECORDED);
-	if (!observationCoverageId) return "continue";
+	let dropTokens: number;
+	let observationCoverageId: string | undefined;
+	if (runtime.config.noAutoCompact) {
+		const pending = readPendingState(sessionId);
+		const pendingObs = (pending.observation?.data as any)?.observations;
+		if (!pendingObs?.length) return "continue";
+		observationCoverageId = pending.observation?.coversUpToId;
+		if (pending.dropped?.coversUpToId) {
+			const dropIdx = entryIndexForId(entries, pending.dropped.coversUpToId);
+			if (dropIdx >= 0) {
+				dropTokens = rawTokensAfterIndex(entries, dropIdx);
+				if (dropTokens < runtime.config.reflectAfterTokens) return "continue";
+			} else {
+				dropTokens = rawTokensSinceDropCoverage(entries);
+			}
+		} else {
+			dropTokens = rawTokensSinceDropCoverage(entries);
+		}
+	} else {
+		dropTokens = rawTokensSinceDropCoverage(entries);
+		if (dropTokens < runtime.config.reflectAfterTokens) return "continue";
+		observationCoverageId = latestCoverageMarkerId(entries, OM_OBSERVATIONS_RECORDED);
+		if (!observationCoverageId) return "continue";
+	}
 
 	for (let attempt = 0; attempt < MAX_STAGE_ATTEMPTS; attempt++) {
 		const resolved = await resolveModel("dropper");
@@ -486,10 +524,11 @@ async function runDropperStage(
 
 		// Compute ahead for an accurate notification
 		const folded = foldLedger(entries);
-		const lastDropIdx = latestCoverageIndex(entries, OM_OBSERVATIONS_DROPPED);
-		const newObservations = observationsCreatedAfterIndex(entries, lastDropIdx);
+		const pending = runtime.config.noAutoCompact ? readPendingState(sessionId) : undefined;
+		const lastDropIdx = pending ? -1 : latestCoverageIndex(entries, OM_OBSERVATIONS_DROPPED);
+		const newObservations = pending ? ((pending.observation?.data as any)?.observations ?? []) : observationsCreatedAfterIndex(entries, lastDropIdx);
 		const dropperNewObsTokens = Math.ceil(
-			newObservations.reduce((s, o) => s + o.content.length, 0) / 4
+			newObservations.reduce((s: number, o: any) => s + o.content.length, 0) / 4
 		);
 		const dropperSummaryBudget = Math.floor(runtime.config.dropperInputMaxTokens * 0.2);
 		const dropperInputTokens = Math.min(dropperNewObsTokens + dropperSummaryBudget, runtime.config.dropperInputMaxTokens);
@@ -507,7 +546,7 @@ async function runDropperStage(
 		try {
 			// Existing active observations summary for context (capped)
 			const existingObservationsSummary = buildExistingObservationsSummary(
-				folded.activeObservations.filter(o => !newObservations.some(no => no.id === o.id)),
+				folded.activeObservations.filter((o: any) => !newObservations.some((no: any) => no.id === o.id)),
 				Math.floor(runtime.config.dropperInputMaxTokens * 0.2),
 			);
 			const reflectionsForDropper = mergeReflections(folded.reflections, sameRunReflections);


### PR DESCRIPTION
## Summary

In `noAutoCompact` mode, the reflector and dropper stages have been entirely non-functional since the feature was introduced. Observation markers are written to `pending.json` (not the branch) to prevent triggering auto-compaction, but the reflector and dropper only scanned the branch for those markers — found none — and skipped immediately.

This PR makes the second and third OM pipeline stages `noAutoCompact`-aware by reading pending state directly, matching the pattern already established in the observer stage.

## Problem

The `noAutoCompact` mode (added in a prior release) correctly prevents automatic compaction by saving observations to a per-session `pending.json` instead of appending `OM_OBSERVATIONS_RECORDED` markers to the branch. However, the change was incomplete:

1. `runReflectorStage` gates on `latestCoverageMarkerId(entries, OM_OBSERVATIONS_RECORDED)` — always `undefined` in `noAutoCompact` mode → returns immediately
2. `runDropperStage` has the identical gate → returns immediately
3. Both stages therefore never collect observations, never call the LLM, and never produce output

The notification token-adjustment code (`effectiveReflectionTokens`, `effectiveDropTokens`) already existed and correctly factored in pending coverage — but was dead code because neither stage ever reached it.

## Root Cause

When `noAutoCompact` was implemented, only the observer's save path was modified (line ~324: `if (noAutoCompact) savePendingObservation else appendEntry`). The reflector and dropper's read path was not updated — they continued scanning the branch for markers that `noAutoCompact` deliberately avoids writing there.

## Changes

### `src/om/consolidation.ts` — 4 targeted modifications in `runReflectorStage` and `runDropperStage`

**Early-exit gates** (2 changes):
- In `noAutoCompact` mode, check `pending.observation.data.observations` length instead of `OM_OBSERVATIONS_RECORDED` markers in the branch
- Use `pending.reflection.coversUpToId` / `pending.dropped.coversUpToId` to calculate token gaps via `rawTokensAfterIndex`, gating on the existing `reflectAfterTokens` config
- Fall back to `rawTokensSinceObservationCoverage` / `rawTokensSinceDropCoverage` for first-run scenarios (no prior pending state)

**Data sources for LLM calls** (2 changes):
- Feed observations and reflections from `pending.observation.data` and `pending.reflection.data` instead of `observationsCreatedAfterIndex` / `reflectionsCreatedAfterIndex` (which scan the branch)
- The existing existing-summaries code (`buildExistingReflectionsSummary`, `buildExistingObservationsSummary`) still operates on branch-folded data, which is empty in `noAutoCompact` — acceptable because pending already contains the latest batch

### `CHANGELOG.md`

Added `[Unreleased]` section with `### Fixed` entry describing the change.

## Testing

- Verified with `tsc --noEmit` — no type errors
- A fresh testing session is needed to confirm the pipeline runs end-to-end

## Impact

- **autoCompact mode (default)**: Zero impact — `else` branches preserve the original logic unchanged
- **noAutoCompact mode**: Reflector and dropper now run when their token thresholds are met, producing real reflections and drops instead of skipping silently
- **No extra LLM calls**: The pipeline already fires every turn via `anyStageDue()` (which returns true in `noAutoCompact` because branch markers are absent). Each stage still skips via its own gate if no work is needed

## Follow-up

- The observer's "replace, not accumulate" behavior for pending observations is preserved — the front-trim accumulating array design can be layered on top if pool growth becomes an issue
- The dropper display bar cosmetic fix is independent and not included here
