### PR TITLE
Test suite overhaul — 329 tests across 40 files

### DIFF
--- a/.pi/skills/lockstep/SKILL.md
+++ b/.pi/skills/lockstep/SKILL.md
@@ -96,6 +96,24 @@ git show <hash>
 node .pi/skills/lockstep/scripts/upstream-diff.js --only-different
 ```
 
+### Step 2b: Verify mapping annotations are current
+
+The `lockstep-mapping.json` statuses (UNCHANGED, MODIFIED, REWRITTEN) were written once and can go stale if we modify files without updating the mapping. Before trusting the SAFE/MODIFIED/REWRITTEN classification, cross-check with a fresh diff:
+
+```bash
+node .pi/skills/lockstep/scripts/upstream-diff.js --verify
+```
+
+This compares each file against upstream HEAD and flags:
+
+```
+⚠ stale UNCHANGED     — file marked unchanged but actually differs from upstream
+△ obsolete MODIFIED   — file marked modified but now matches upstream (annotation out of date)
+```
+
+If the verify finds stale entries, fix the mapping before porting (see Step 4b below).
+
+
 ### Step 3: Classify each changed file
 
 For every file the upstream changed, consult `lockstep-mapping.json`:

--- a/.pi/skills/lockstep/SKILL.md
+++ b/.pi/skills/lockstep/SKILL.md
@@ -50,7 +50,7 @@ Even after I approve porting a specific fix or feature, you must then:
 | Script | Purpose |
 |---|---|
 | `scripts/lockstep.js` | Create lockstep branch, fetch upstreams, show new commits since last mark, classify each changed file against our mapping table. Use `--create-branch` to auto-setup the branch. Add `--save` to also write the full report to `docs/lockstep-report-<date>.md` (gitignored) for local viewing. |
-| `scripts/upstream-diff.js` | Compare our files against upstream HEAD — shows what truly differs (stripping comment headers). Use `--summary` for counts, `--only-different` to skip identical files. |
+| `scripts/upstream-diff.js` | Compare our files against upstream HEAD — shows what truly differs (stripping comment headers). Use `--summary` for counts, `--only-different` to skip identical files, `--verify` to cross-check mapping annotations against actual diffs (catches stale UNCHANGED/MODIFIED statuses). Add `--save` to write report to `docs/`. |
 
 ## Workflow
 

--- a/.pi/skills/lockstep/SKILL.md
+++ b/.pi/skills/lockstep/SKILL.md
@@ -111,7 +111,7 @@ This compares each file against upstream HEAD and flags:
 △ obsolete MODIFIED   — file marked modified but now matches upstream (annotation out of date)
 ```
 
-If the verify finds stale entries, fix the mapping before porting (see Step 4b below).
+If the verify finds stale entries, fix the mapping before porting (see Step 3 below).
 
 
 ### Step 3: Classify each changed file

--- a/.pi/skills/lockstep/lockstep-mapping.json
+++ b/.pi/skills/lockstep/lockstep-mapping.json
@@ -42,7 +42,8 @@
       "upstream": "pi-vcc",
       "path": "src/commands/vcc-recall.ts",
       "ours": "src/commands/vcc-recall.ts",
-      "status": "UNCHANGED"
+      "status": "MODIFIED",
+      "_note": "Added .js import extensions, OM reverse-recall augmentation (findObservationsForEntryIds, findReflectionsForEntryIds), command renamed to /blackhole-recall."
     },
     {
       "upstream": "pi-vcc",
@@ -62,7 +63,8 @@
       "upstream": "pi-vcc",
       "path": "src/core/summarize.ts",
       "ours": "src/core/summarize.ts",
-      "status": "UNCHANGED"
+      "status": "MODIFIED",
+      "_note": "Added OM content stripping (stripOMContent) to remove Reflections/Observations sections from previous summaries before merging."
     },
     {
       "upstream": "pi-vcc",
@@ -135,8 +137,7 @@
       "upstream": "pi-vcc",
       "path": "src/core/search-entries.ts",
       "ours": "src/core/search-entries.ts",
-      "status": "MODIFIED",
-      "_note": "Minor modifications for unified recall format."
+      "status": "UNCHANGED"
     },
     {
       "upstream": "pi-vcc",
@@ -378,7 +379,8 @@
       "upstream": "pi-observational-memory",
       "path": "src/debug-log.ts",
       "ours": "src/om/debug-log.ts",
-      "status": "UNCHANGED"
+      "status": "MODIFIED",
+      "_note": "Changed log path from observational-memory/ to pi-blackhole/. Removed sessionId/sessionFile from interface, removed safeDebugLogSessionId and debugLogRelativePath functions."
     },
     {
       "upstream": "pi-observational-memory",
@@ -396,8 +398,7 @@
       "upstream": "pi-observational-memory",
       "path": "src/serialize.ts",
       "ours": "src/om/serialize.ts",
-      "status": "MODIFIED",
-      "_note": "Extended truncateRecordContent."
+      "status": "UNCHANGED"
     },
     {
       "upstream": "pi-observational-memory",

--- a/.pi/skills/lockstep/scripts/upstream-diff.js
+++ b/.pi/skills/lockstep/scripts/upstream-diff.js
@@ -194,7 +194,6 @@ function readMarker(name) {
  */
 function upstreamFileContentAtCommit(upstreamName, upstreamPath, commit) {
   try {
-    const remote = `upstream-${upstreamName}`;
     // Try with the full SHA — git can resolve it from fetched objects
     return execSync(`git show ${commit}:${upstreamPath}`, {
       cwd: REPO_DIR, encoding: "utf-8", timeout: 10000,

--- a/.pi/skills/lockstep/scripts/upstream-diff.js
+++ b/.pi/skills/lockstep/scripts/upstream-diff.js
@@ -231,7 +231,7 @@ function verifyMapping() {
   });
 
   for (const entry of entries) {
-    const displayPath = entry.ours || entry.path || entry.path;
+    const displayPath = entry.ours || entry.path;
     const declaredStatus = entry.status;
 
     // Skip entries that can't be meaningfully verified

--- a/.pi/skills/lockstep/scripts/upstream-diff.js
+++ b/.pi/skills/lockstep/scripts/upstream-diff.js
@@ -11,9 +11,10 @@
  *   node scripts/upstream-diff.js --om                  # OM only
  *   node scripts/upstream-diff.js --only-different      # skip identical files
  *   node scripts/upstream-diff.js --summary             # just counts
+ *   node scripts/upstream-diff.js --verify              # cross-check mapping annotations against actual diffs
  */
 
-import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { execSync } from "node:child_process";
 import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -27,6 +28,8 @@ const CHECK_VCC = args.includes("--vcc") ? true : args.includes("--om") ? false 
 const CHECK_OM = args.includes("--om") ? true : args.includes("--vcc") ? false : true;
 const ONLY_DIFFERENT = args.includes("--only-different");
 const SUMMARY_ONLY = args.includes("--summary");
+const SAVE = args.includes("--save");
+const VERIFY_MAPPING = args.includes("--verify");
 
 // ── Load mapping ────────────────────────────────────────────────────────────
 
@@ -40,6 +43,41 @@ function run(cmd) {
   } catch {
     return null;
   }
+}
+
+// ── Output capture for --save ───────────────────────────────────────────────
+
+const outputBuffer = [];
+const originalLog = console.log;
+const originalError = console.error;
+
+function stripAnsi(str) {
+  return str.replace(/\x1B\[[0-9;]*[a-zA-Z]/g, "");
+}
+
+if (SAVE) {
+  console.log = function (...args) {
+    const msg = args.map((a) => (typeof a === "string" ? a : String(a))).join(" ");
+    outputBuffer.push(msg);
+    originalLog.apply(console, args);
+  };
+  console.error = function (...args) {
+    const msg = args.map((a) => (typeof a === "string" ? a : String(a))).join(" ");
+    outputBuffer.push(msg);
+    originalError.apply(console, args);
+  };
+}
+
+function saveReport() {
+  const docsDir = resolve(REPO_DIR, "docs");
+  if (!existsSync(docsDir)) {
+    try { mkdirSync(docsDir, { recursive: true }); } catch { /* ignore */ }
+  }
+  const date = new Date().toISOString().slice(0, 10);
+  const plainText = outputBuffer.map(stripAnsi).join("\n") + "\n";
+  const reportPath = resolve(docsDir, `upstream-diff-report-${date}.md`);
+  writeFileSync(reportPath, plainText);
+  originalLog(`\n  📄 Report saved to ${reportPath}`);
 }
 
 const COLORS = {
@@ -140,9 +178,192 @@ function printSummary(results) {
   console.log();
 }
 
+// ── Verify mapping annotations ──────────────────────────────────────────────
+
+/**
+ * Read a marker file to get the upstream SHA we last synced to.
+ */
+function readMarker(name) {
+  const p = resolve(SKILL_DIR, name);
+  if (!existsSync(p)) return null;
+  return readFileSync(p, "utf-8").trim();
+}
+
+/**
+ * Fetch upstream file content at a specific commit (marker) instead of HEAD.
+ */
+function upstreamFileContentAtCommit(upstreamName, upstreamPath, commit) {
+  try {
+    const remote = `upstream-${upstreamName}`;
+    // Try with the full SHA — git can resolve it from fetched objects
+    return execSync(`git show ${commit}:${upstreamPath}`, {
+      cwd: REPO_DIR, encoding: "utf-8", timeout: 10000,
+    }).trim();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Verify mapping annotations against actual diffs.
+ *
+ * For each file in the mapping, compares its declared status against the
+ * actual diff between our version and upstream HEAD. Flags discrepancies:
+ *
+ *   UNCHANGED + DIFFERENT  → stale annotation (file was modified despite header)
+ *   MODIFIED  + IDENTICAL → obsolete annotation (file now matches upstream)
+ *   REWRITTEN + IDENTICAL → obsolete annotation (file now matches upstream)
+ */
+function verifyMapping() {
+  console.log(`${color("bold", "Mapping annotation verification")}`);
+  console.log(`  ${color("gray", "Cross-checking lockstep-mapping.json statuses against actual diffs with upstream HEAD...")}\n`);
+
+  const correct = [];
+  const stale = [];
+  const obsolete = [];
+  const skipped = [];
+  const errors = [];
+
+  const entries = mapping.files.filter((entry) => {
+    if (entry.upstream === "pi-vcc" && !CHECK_VCC) return false;
+    if (entry.upstream === "pi-observational-memory" && !CHECK_OM) return false;
+    return true;
+  });
+
+  for (const entry of entries) {
+    const displayPath = entry.ours || entry.path || entry.path;
+    const declaredStatus = entry.status;
+
+    // Skip entries that can't be meaningfully verified
+    if (["ELIMINATED", "MERGED", "UNIQUE", "DELETED"].includes(declaredStatus)) {
+      skipped.push({ entry, reason: `${declaredStatus} — no file to compare` });
+      continue;
+    }
+
+    // Must have an 'ours' path to diff
+    if (!entry.ours) {
+      skipped.push({ entry, reason: `no our-path` });
+      continue;
+    }
+
+    const result = diffFile(entry);
+
+    if (result.status === "FETCH_FAILED") {
+      errors.push({ entry, reason: `upstream file not found at ${entry.path}` });
+      continue;
+    }
+    if (result.status === "OUR_FILE_MISSING") {
+      errors.push({ entry, reason: `our file not found at ${entry.ours}` });
+      continue;
+    }
+
+    const actuallyDifferent = result.status === "DIFFERENT";
+
+    // Cross-check against declared status
+    if (declaredStatus === "UNCHANGED") {
+      if (actuallyDifferent) {
+        stale.push({
+          entry,
+          declared: "UNCHANGED",
+          actual: "DIFFERENT",
+          detail: `${displayPath} — marked UNCHANGED but differs from upstream HEAD`,
+        });
+      } else {
+        correct.push({ entry, declared: "UNCHANGED", detail: `${displayPath}` });
+      }
+    } else if (declaredStatus === "MOVED") {
+      if (actuallyDifferent) {
+        stale.push({
+          entry,
+          declared: "MOVED",
+          actual: "DIFFERENT",
+          detail: `${displayPath} — marked MOVED (content unchanged) but differs from upstream HEAD`,
+        });
+      } else {
+        correct.push({ entry, declared: "MOVED", detail: `${displayPath}` });
+      }
+    } else if (declaredStatus === "MODIFIED" || declaredStatus === "CHANGED") {
+      if (!actuallyDifferent) {
+        obsolete.push({
+          entry,
+          declared: declaredStatus,
+          actual: "IDENTICAL",
+          detail: `${displayPath} — marked ${declaredStatus} but matches upstream HEAD (annotation may be obsolete)`,
+        });
+      } else {
+        correct.push({ entry, declared: declaredStatus, detail: `${displayPath}` });
+      }
+    } else if (declaredStatus === "REWRITTEN") {
+      if (!actuallyDifferent) {
+        obsolete.push({
+          entry,
+          declared: "REWRITTEN",
+          actual: "IDENTICAL",
+          detail: `${displayPath} — marked REWRITTEN but matches upstream HEAD`,
+        });
+      } else {
+        correct.push({ entry, declared: "REWRITTEN", detail: `${displayPath}` });
+      }
+    } else {
+      skipped.push({ entry, reason: `unknown status: ${declaredStatus}` });
+    }
+  }
+
+  // ── Report ─────────────────────────────────────────────────────────
+
+  if (stale.length > 0) {
+    console.log(`  ${color("red", `⚠ ${stale.length} stale annotation(s) — file differs despite declared status:`)}`);
+    for (const s of stale) {
+      console.log(`    ${color("red", "⚠")} ${s.detail}`);
+      if (s.entry._note) console.log(`       ${color("gray", s.entry._note)}`);
+    }
+    console.log();
+  }
+
+  if (obsolete.length > 0) {
+    console.log(`  ${color("yellow", `△ ${obsolete.length} possibly obsolete annotation(s) — matches upstream:`)}`);
+    for (const s of obsolete) {
+      console.log(`    ${color("yellow", "△")} ${s.detail}`);
+      if (s.entry._note) console.log(`       ${color("gray", s.entry._note)}`);
+    }
+    console.log();
+  }
+
+  if (errors.length > 0) {
+    console.log(`  ${color("red", `✗ ${errors.length} error(s):`)}`);
+    for (const e of errors) {
+      console.log(`    ${color("red", "✗")} ${e.reason}`);
+    }
+    console.log();
+  }
+
+  console.log(`  ${color("bold", "Summary:")}`);
+  console.log(`    ${color("green", `${correct.length} correct`)} — annotation matches actual diff`);
+  console.log(`    ${color("red", `${stale.length} stale`)} — annotation says unchanged/unchanged-move but file differs`);
+  console.log(`    ${color("yellow", `${obsolete.length} obsolete`)} — annotation says modified/rewritten but file matches upstream`);
+  console.log(`    ${color("gray", `${skipped.length} skipped`)} — ELIMINATED/MERGED/DELETED/UNIQUE or no our-path`);
+  console.log(`    ${color("red", `${errors.length} errors`)} — fetch or file-not-found`);
+  console.log();
+
+  if (stale.length > 0) {
+    console.log(`  ${color("bold", "Recommendation:")}`);
+    console.log(`  Update lockstep-mapping.json annotations for stale entries:`);
+    console.log(`  - UNCHANGED → MODIFIED (file was modified despite being marked unchanged)`);
+    console.log(`  - MOVED → MOVED+MODIFIED (file was moved and also modified)`);
+    console.log(`  Run with --save to write a report to docs/ for reference.`);
+    console.log();
+  }
+}
+
 // ── Main ─────────────────────────────────────────────────────────────────────
 
 function main() {
+  if (VERIFY_MAPPING) {
+    verifyMapping();
+    if (SAVE) saveReport();
+    process.exit(0);
+  }
+
   console.log(`${color("bold", "Upstream file comparison")}`);
   console.log(`  ${color("gray", `Mode: ${ONLY_DIFFERENT ? "only differences" : "all files"} | ${SUMMARY_ONLY ? "summary" : "full diffs"}`)}\n`);
 
@@ -178,7 +399,7 @@ function main() {
         console.log(`  ${color("yellow", "Δ")} ${displayPath}`);
         continue;
       }
-      const tag = isRewritten ? color("red", "REWRITTEN") : color("yellow", "MODIFIED");
+      const tag = isRewritten ? color("red", "REWRITTEN") : (entry.status === "UNCHANGED" ? color("red", "STALE-UNCHANGED") : color("yellow", "MODIFIED"));
       console.log(`\n  ${color("yellow", "Δ")} ${displayPath} ${tag}`);
       if (entry._note) console.log(`    ${color("gray", entry._note)}`);
 

--- a/src/om/agents/reflector/agent.ts
+++ b/src/om/agents/reflector/agent.ts
@@ -15,6 +15,7 @@ import { truncateRecordContent } from "../../serialize.js";
 import { REFLECTOR_SYSTEM } from "./prompts.js";
 import { estimateStringTokens } from "../../tokens.js";
 import { observationToSummaryLine, reflectionToSummaryLine, type Observation, type Reflection } from "../../ledger/index.js";
+import type { ReflectionCoverageTier } from "../dropper/coverage.js";
 
 interface RunReflectorArgs {
 	model: Model<any>;
@@ -158,4 +159,38 @@ export async function runReflector(args: RunReflectorArgs): Promise<Reflection[]
 	await stream.result();
 	if (agentError && accumulated.size === 0) throw new Error(`Reflector API error: ${agentError}`);
 	return accumulated.size > 0 ? Array.from(accumulated.values()) : undefined;
+}
+
+export function observationToReflectorLine(
+	observation: Observation,
+	coverage: ReflectionCoverageTier,
+): string {
+	return `[${observation.id}] ${observation.timestamp} [${observation.relevance}] [coverage: ${coverage}] ${observation.content}`;
+}
+
+export function summarizeSupportIdCounts(reflections: readonly Reflection[]): {
+	reflectionCount: number;
+	totalSupportIds: number;
+	minSupportIds: number;
+	maxSupportIds: number;
+	averageSupportIds: number;
+	histogram: Record<string, number>;
+} {
+	if (reflections.length === 0) {
+		return { reflectionCount: 0, totalSupportIds: 0, minSupportIds: 0, maxSupportIds: 0, averageSupportIds: 0, histogram: {} };
+	}
+	const supportIdCounts = reflections.map((r) => r.supportingObservationIds.length);
+	const total = supportIdCounts.reduce((sum, c) => sum + c, 0);
+	const histogram: Record<string, number> = {};
+	for (const count of supportIdCounts) {
+		histogram[String(count)] = (histogram[String(count)] || 0) + 1;
+	}
+	return {
+		reflectionCount: reflections.length,
+		totalSupportIds: total,
+		minSupportIds: Math.min(...supportIdCounts),
+		maxSupportIds: Math.max(...supportIdCounts),
+		averageSupportIds: total / reflections.length,
+		histogram,
+	};
 }

--- a/src/tools/recall.ts
+++ b/src/tools/recall.ts
@@ -29,7 +29,7 @@ import {
 const DEFAULT_RECENT = 25;
 const PAGE_SIZE = 5;
 
-const invalidExpandIndices = (requested: number[], available: Set<number>): number[] =>
+export const invalidExpandIndices = (requested: number[], available: Set<number>): number[] =>
 	requested.filter((i) => !Number.isInteger(i) || !available.has(i));
 
 async function vccRecall(params: { query?: string; expand?: number[]; page?: number; scope?: "lineage" | "all" }, ctx: any) {

--- a/tests/blackhole-command.test.ts
+++ b/tests/blackhole-command.test.ts
@@ -1,0 +1,207 @@
+/**
+ * Tests for /blackhole command — compaction trigger, om-off/om-on, noAutoCompact flush.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mkdirSync, rmSync, writeFileSync, readFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+const testRoot = join(tmpdir(), `pi-blackhole-cmd-test-${process.pid}-${Date.now()}`);
+
+// Mock the pi SDK before importing our module
+vi.mock("@earendil-works/pi-coding-agent", () => ({
+	getAgentDir: () => join(testRoot, "agent"),
+}));
+
+import { registerPiVccCommand } from "../src/commands/pi-vcc.js";
+
+function createMockEnvironment() {
+	const compactCalls: Array<{ customInstructions: string; onComplete: () => void; onError: (err: Error) => void }> = [];
+	const appendEntryCalls: Array<{ customType: string; data: unknown }> = [];
+	const notifyCalls: Array<{ msg: string; level: string }> = [];
+
+	const pi = {
+		registerCommand: vi.fn((name: string, def: { handler: (args: unknown, ctx: unknown) => Promise<void> }) => {
+			handlerMap.set(name, def.handler as any);
+		}),
+		appendEntry: vi.fn((customType: string, data: unknown) => {
+			appendEntryCalls.push({ customType, data });
+		}),
+	};
+
+	const handlerMap = new Map<string, (args: unknown, ctx: unknown) => Promise<void>>();
+
+	const runtime: any = {
+		ensureConfig: vi.fn(),
+		config: {
+			memory: true,
+			noAutoCompact: false,
+		},
+		compactionStats: null,
+	};
+
+	function makeHandlerArgs(overrides: Record<string, unknown> = {}) {
+		const base = {
+			cwd: testRoot,
+			sessionManager: {
+				getBranch: vi.fn(() => []),
+				getSessionId: vi.fn(() => "test-session"),
+			},
+			compact: vi.fn((opts: { customInstructions?: string; onComplete?: () => void; onError?: (err: Error) => void }) => {
+				compactCalls.push({
+					customInstructions: opts.customInstructions ?? "",
+					onComplete: opts.onComplete ?? (() => {}),
+					onError: opts.onError ?? (() => {}),
+				});
+			}),
+			ui: {
+				notify: vi.fn((msg: string, level: string) => {
+					notifyCalls.push({ msg, level });
+				}),
+			},
+			...overrides,
+		};
+		return base as any;
+	}
+
+	return { pi, runtime, handlerMap, makeHandlerArgs, compactCalls, appendEntryCalls, notifyCalls };
+}
+
+describe("/blackhole command", () => {
+	beforeEach(() => {
+		mkdirSync(join(testRoot, "agent", "pi-blackhole"), { recursive: true });
+	});
+
+	afterEach(() => {
+		rmSync(testRoot, { recursive: true, force: true });
+	});
+
+	it("registers the blackhole command", () => {
+		const { pi, runtime } = createMockEnvironment();
+		registerPiVccCommand(pi as any, runtime as any);
+		expect(pi.registerCommand).toHaveBeenCalledWith("blackhole", expect.objectContaining({
+			description: expect.stringContaining("Compact"),
+		}));
+	});
+
+	it("calls ctx.compact with PI_VCC_COMPACT_INSTRUCTION", async () => {
+		const { pi, runtime, handlerMap, makeHandlerArgs } = createMockEnvironment();
+		registerPiVccCommand(pi as any, runtime as any);
+
+		const ctx = makeHandlerArgs();
+		await handlerMap.get("blackhole")!("", ctx);
+
+		expect(ctx.compact).toHaveBeenCalledTimes(1);
+		const call = ctx.compact.mock.calls[0][0];
+		expect(call.customInstructions).toBe("__pi_vcc__");
+	});
+
+	it("sends onComplete notification with stats when available", async () => {
+		const { pi, runtime, handlerMap, makeHandlerArgs, notifyCalls } = createMockEnvironment();
+		runtime.compactionStats = { summarized: 42, kept: 10, keptTokensEst: 5000 };
+		registerPiVccCommand(pi as any, runtime as any);
+
+		const ctx = makeHandlerArgs();
+		await handlerMap.get("blackhole")!("", ctx);
+
+		const call = ctx.compact.mock.calls[0][0];
+		call.onComplete();
+
+		expect(notifyCalls[notifyCalls.length - 1].msg).toContain("42 source entries");
+		expect(notifyCalls[notifyCalls.length - 1].msg).toContain("5.0k tok");
+	});
+
+	it("sends onComplete fallback notification without stats", async () => {
+		const { pi, runtime, handlerMap, makeHandlerArgs, notifyCalls } = createMockEnvironment();
+		registerPiVccCommand(pi as any, runtime as any);
+
+		const ctx = makeHandlerArgs();
+		await handlerMap.get("blackhole")!("", ctx);
+
+		const call = ctx.compact.mock.calls[0][0];
+		call.onComplete();
+
+		expect(notifyCalls[notifyCalls.length - 1].msg).toContain("Compacted with blackhole");
+	});
+
+	it("handles onError for cancellation", async () => {
+		const { pi, runtime, handlerMap, makeHandlerArgs, notifyCalls } = createMockEnvironment();
+		registerPiVccCommand(pi as any, runtime as any);
+
+		const ctx = makeHandlerArgs();
+		await handlerMap.get("blackhole")!("", ctx);
+
+		const call = ctx.compact.mock.calls[0][0];
+		call.onError(new Error("Compaction cancelled"));
+
+		expect(notifyCalls[notifyCalls.length - 1].level).toBe("warning");
+		expect(notifyCalls[notifyCalls.length - 1].msg).toContain("Nothing to compact");
+	});
+
+	it("handles onError for general failure", async () => {
+		const { pi, runtime, handlerMap, makeHandlerArgs, notifyCalls } = createMockEnvironment();
+		registerPiVccCommand(pi as any, runtime as any);
+
+		const ctx = makeHandlerArgs();
+		await handlerMap.get("blackhole")!("", ctx);
+
+		const call = ctx.compact.mock.calls[0][0];
+		call.onError(new Error("Model API error"));
+
+		expect(notifyCalls[notifyCalls.length - 1].level).toBe("error");
+		expect(notifyCalls[notifyCalls.length - 1].msg).toContain("Compaction failed: Model API error");
+	});
+
+	it("/blackhole om-off disables memory and saves config", async () => {
+		const { pi, runtime, handlerMap, makeHandlerArgs, notifyCalls } = createMockEnvironment();
+		registerPiVccCommand(pi as any, runtime as any);
+		runtime.config.memory = true;
+
+		const ctx = makeHandlerArgs();
+		await handlerMap.get("blackhole")!("om-off", ctx);
+
+		expect(runtime.config.memory).toBe(false);
+		expect(notifyCalls[0].msg).toContain("Observational memory disabled");
+	});
+
+	it("/blackhole om-on enables memory and saves config", async () => {
+		const { pi, runtime, handlerMap, makeHandlerArgs, notifyCalls } = createMockEnvironment();
+		registerPiVccCommand(pi as any, runtime as any);
+		runtime.config.memory = false;
+
+		const ctx = makeHandlerArgs();
+		await handlerMap.get("blackhole")!("om-on", ctx);
+
+		expect(runtime.config.memory).toBe(true);
+		expect(notifyCalls[0].msg).toContain("Observational memory enabled");
+	});
+
+	it("flush pending entries when noAutoCompact is active and pending data exists", async () => {
+		const { pi, runtime, handlerMap, makeHandlerArgs, notifyCalls } = createMockEnvironment();
+		runtime.config.noAutoCompact = true;
+		registerPiVccCommand(pi as any, runtime as any);
+
+		// Write a pending state file — name pattern is <sessionId>-pending.json
+		const pendingDir = join(testRoot, "agent", "pi-blackhole");
+		const pendingFile = join(pendingDir, "test-session-pending.json");
+		writeFileSync(pendingFile, JSON.stringify({
+			// isPendingOMState checks for .observation/.reflection with coversUpToId
+			observation: { coversUpToId: "raw-1", data: { observations: [{ id: "aaaaaaaaaaaa", content: "test obs" }] } },
+			reflection: { coversUpToId: "raw-1", data: { reflections: [{ id: "eeeeeeeeeeee", content: "test ref", supportingObservationIds: ["aaaaaaaaaaaa"] }] } },
+			observationBatches: [{
+				data: { observations: [{ id: "aaaaaaaaaaaa", content: "test obs" }], coversUpToId: "raw-1" },
+			}],
+			reflectionBatches: [{
+				data: { reflections: [{ id: "eeeeeeeeeeee", content: "test ref", supportingObservationIds: ["aaaaaaaaaaaa"] }], coversUpToId: "raw-1" },
+			}],
+		}));
+
+		const ctx = makeHandlerArgs();
+		await handlerMap.get("blackhole")!("", ctx);
+
+		expect(notifyCalls[0].msg).toContain("pending entries flushed");
+		expect(existsSync(pendingFile)).toBe(false); // cleared after flush
+		// Should call compact after flush
+		expect(ctx.compact).toHaveBeenCalledTimes(1);
+	});
+});

--- a/tests/blackhole-recall.test.ts
+++ b/tests/blackhole-recall.test.ts
@@ -1,0 +1,208 @@
+/**
+ * Tests for /blackhole-recall command — search session history.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mkdirSync, rmSync, writeFileSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+const testRoot = join(tmpdir(), `pi-blackhole-recall-test-${process.pid}-${Date.now()}`);
+
+vi.mock("@earendil-works/pi-coding-agent", () => ({
+	getAgentDir: () => join(testRoot, "agent"),
+}));
+
+import { registerVccRecallCommand } from "../src/commands/vcc-recall.js";
+
+function createMockEnvironment() {
+	const sentMessages: Array<{ content: string; customType: string }> = [];
+	const handlerMap = new Map<string, (args: string, ctx: unknown) => Promise<void>>();
+
+	const pi: any = {
+		registerCommand: vi.fn((name: string, def: { handler: (args: string, ctx: unknown) => Promise<void> }) => {
+			handlerMap.set(name, def.handler);
+		}),
+		sendMessage: vi.fn((msg: { content: string; customType: string; display: boolean }, opts: { triggerTurn: boolean }) => {
+			sentMessages.push(msg);
+		}),
+	};
+
+	/** Build a minimal session file with test messages */
+	function createSessionFile(messages: Array<{ role: string; content: string }>): string {
+		const dir = join(testRoot, "sessions");
+		mkdirSync(dir, { recursive: true });
+		const file = join(dir, `session-${Date.now()}.jsonl`);
+		const lines = messages.map((m, i) => JSON.stringify({
+			type: "message",
+			id: `m${i}`,
+			timestamp: new Date().toISOString(),
+			message: m,
+		}));
+		writeFileSync(file, lines.join("\n") + "\n", "utf-8");
+		return file;
+	}
+
+	return { pi, handlerMap, sentMessages, createSessionFile };
+}
+
+describe("/blackhole-recall command", () => {
+	beforeEach(() => {
+		mkdirSync(testRoot, { recursive: true });
+	});
+
+	afterEach(() => {
+		rmSync(testRoot, { recursive: true, force: true });
+	});
+
+	it("registers the blackhole-recall command", () => {
+		const { pi } = createMockEnvironment();
+		registerVccRecallCommand(pi as any);
+		expect(pi.registerCommand).toHaveBeenCalledWith("blackhole-recall", expect.any(Object));
+		const callArgs = pi.registerCommand.mock.calls[0];
+		expect(callArgs[0]).toBe("blackhole-recall");
+		expect(callArgs[1].description.toLowerCase()).toContain("search");
+	});
+
+	it("shows recent entries when no query is provided", async () => {
+		const { pi, handlerMap, sentMessages, createSessionFile } = createMockEnvironment();
+		registerVccRecallCommand(pi as any);
+
+		const sessionFile = createSessionFile([
+			{ role: "user", content: "Hello there" },
+			{ role: "assistant", content: "Hi, how can I help?" },
+		]);
+
+		const ctx: any = {
+			sessionManager: {
+				getSessionFile: vi.fn(() => sessionFile),
+				getBranch: vi.fn(() => [{ id: "m0" }, { id: "m1" }]),
+				getSessionId: vi.fn(() => "test-session"),
+			},
+		};
+
+		await handlerMap.get("blackhole-recall")!("", ctx);
+
+		expect(sentMessages).toHaveLength(1);
+		expect(sentMessages[0].customType).toBe("blackhole-recall");
+		expect(sentMessages[0].content).toContain("#0");
+		expect(sentMessages[0].content).toContain("#1");
+	});
+
+	it("searches and returns matches for a query", async () => {
+		const { pi, handlerMap, sentMessages, createSessionFile } = createMockEnvironment();
+		registerVccRecallCommand(pi as any);
+
+		const sessionFile = createSessionFile([
+			{ role: "user", content: "Fix login bug" },
+			{ role: "assistant", content: "I will fix the authentication module" },
+		]);
+
+		const ctx: any = {
+			sessionManager: {
+				getSessionFile: vi.fn(() => sessionFile),
+				getBranch: vi.fn(() => [{ id: "m0" }, { id: "m1" }]),
+				getSessionId: vi.fn(() => "test-session"),
+			},
+		};
+
+		await handlerMap.get("blackhole-recall")!("login", ctx);
+
+		expect(sentMessages).toHaveLength(1);
+		expect(sentMessages[0].content).toContain("1 matches");
+		expect(sentMessages[0].content).toContain("login bug");
+	});
+
+	it("returns empty when no matches found", async () => {
+		const { pi, handlerMap, sentMessages, createSessionFile } = createMockEnvironment();
+		registerVccRecallCommand(pi as any);
+
+		const sessionFile = createSessionFile([
+			{ role: "user", content: "Hello" },
+		]);
+
+		const ctx: any = {
+			sessionManager: {
+				getSessionFile: vi.fn(() => sessionFile),
+				getBranch: vi.fn(() => [{ id: "m0" }]),
+				getSessionId: vi.fn(() => "test-session"),
+			},
+		};
+
+		await handlerMap.get("blackhole-recall")!("nonexistent", ctx);
+
+		expect(sentMessages).toHaveLength(1);
+		expect(sentMessages[0].content).toContain('No matches for "nonexistent"');
+	});
+
+	it("shows error when no session file is available", async () => {
+		const { pi, handlerMap, sentMessages } = createMockEnvironment();
+		registerVccRecallCommand(pi as any);
+
+		const notifyCalls: Array<{ msg: string; level: string }> = [];
+		const ctx: any = {
+			sessionManager: {
+				getSessionFile: vi.fn(() => undefined),
+			},
+			ui: {
+				notify: vi.fn((msg: string, level: string) => {
+					notifyCalls.push({ msg, level });
+				}),
+			},
+		};
+
+		await handlerMap.get("blackhole-recall")!("test", ctx);
+
+		expect(notifyCalls).toHaveLength(1);
+		expect(notifyCalls[0].msg).toContain("No session file available");
+		expect(notifyCalls[0].level).toBe("error");
+	});
+
+	it("scope:all includes off-lineage results", async () => {
+		const { pi, handlerMap, sentMessages, createSessionFile } = createMockEnvironment();
+		registerVccRecallCommand(pi as any);
+
+		const sessionFile = createSessionFile([
+			{ role: "user", content: "Public info" },
+			{ role: "assistant", content: "Secret info" },
+		]);
+
+		const ctx: any = {
+			sessionManager: {
+				getSessionFile: vi.fn(() => sessionFile),
+				getBranch: vi.fn(() => [{ id: "m0" }]), // only first entry in lineage
+				getSessionId: vi.fn(() => "test-session"),
+			},
+		};
+
+		await handlerMap.get("blackhole-recall")!("Secret scope:all", ctx);
+
+		expect(sentMessages).toHaveLength(1);
+		expect(sentMessages[0].content).toContain("1 matches");
+		expect(sentMessages[0].content).toContain("Secret info");
+	});
+
+	it("pagination via page:N works", async () => {
+		const { pi, handlerMap, sentMessages, createSessionFile } = createMockEnvironment();
+		registerVccRecallCommand(pi as any);
+
+		// Create enough messages to test pagination
+		const msgs: Array<{ role: string; content: string }> = [];
+		for (let i = 0; i < 8; i++) {
+			msgs.push({ role: "user", content: `test message ${i}` });
+		}
+		const sessionFile = createSessionFile(msgs);
+
+		const ctx: any = {
+			sessionManager: {
+				getSessionFile: vi.fn(() => sessionFile),
+				getBranch: vi.fn(() => msgs.map((_, i) => ({ id: `m${i}` }))),
+				getSessionId: vi.fn(() => "test-session"),
+			},
+		};
+
+		await handlerMap.get("blackhole-recall")!("test page:2", ctx);
+
+		expect(sentMessages).toHaveLength(1);
+		expect(sentMessages[0].content).toContain("Page 2/2");
+	});
+});

--- a/tests/clipboard.test.ts
+++ b/tests/clipboard.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Clipboard tests — ported from upstream pi-observational-memory.
+ *
+ * Upstream: https://github.com/elpapi42/pi-observational-memory (tests/clipboard.test.ts)
+ * Ported with import path adjusted from src/clipboard.js → src/om/clipboard.js.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+
+import { copyTextToClipboard, getClipboardCommands, type ClipboardCommand } from "../src/om/clipboard.js";
+
+describe("clipboard helper", () => {
+	it("uses pbcopy on macOS", () => {
+		expect(getClipboardCommands("darwin")).toEqual([{ command: "pbcopy", args: [] }]);
+	});
+
+	it("uses clip on Windows", () => {
+		expect(getClipboardCommands("win32")).toEqual([{ command: "clip", args: [] }]);
+	});
+
+	it("tries common Linux clipboard commands", () => {
+		expect(getClipboardCommands("linux").map((command) => command.command)).toEqual([
+			"wl-copy",
+			"xclip",
+			"xsel",
+			"termux-clipboard-set",
+		]);
+	});
+
+	it("stops after the first successful clipboard command", async () => {
+		const commands: ClipboardCommand[] = [
+			{ command: "first", args: [] },
+			{ command: "second", args: [] },
+			{ command: "third", args: [] },
+		];
+		const runner = vi.fn(async (command: ClipboardCommand) => command.command === "second");
+
+		await expect(copyTextToClipboard("text", runner, commands)).resolves.toBe(true);
+		expect(runner.mock.calls.map(([command]) => command.command)).toEqual(["first", "second"]);
+	});
+
+	it("returns false when all clipboard commands fail", async () => {
+		const commands: ClipboardCommand[] = [
+			{ command: "first", args: [] },
+			{ command: "second", args: [] },
+		];
+		const runner = vi.fn(async () => false);
+
+		await expect(copyTextToClipboard("text", runner, commands)).resolves.toBe(false);
+		expect(runner).toHaveBeenCalledTimes(2);
+	});
+});

--- a/tests/compaction-trigger.test.ts
+++ b/tests/compaction-trigger.test.ts
@@ -1,0 +1,198 @@
+/**
+ * Ported from upstream pi-observational-memory
+ * Changes:
+ *   - Import path: hooks/compaction-trigger.js → om/compaction-trigger.js
+ *   - Adapted for blackhole's queueMicrotask-based deferral (upstream uses setTimeout)
+ *   - Added noAutoCompact, memory, ensureConfig to runtime mock
+ *   - Added getSessionId to sessionManager mock
+ *   - Uses await flushMicrotasks() instead of vi.runAllTimersAsync()
+ *   - Skipped "does not await observer/reflect promises" test (not applicable)
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { registerCompactionTrigger } from "../src/om/compaction-trigger.js";
+import { compactionEntry, textCustomMessage, type TestEntry } from "./fixtures/session.js";
+
+/** Helper — run pending microtasks (queueMicrotask) synchronously-ish */
+function flushMicrotasks(): Promise<void> {
+	return new Promise(resolve => resolve());
+}
+
+function captureHandler(args: {
+	compactAfterTokens?: number;
+	passive?: boolean;
+	compactInFlight?: boolean;
+	noAutoCompact?: boolean;
+	memory?: boolean;
+} = {}) {
+	let handler: ((event: unknown, ctx: unknown) => void) | undefined;
+	const pi = {
+		on: vi.fn((name: string, cb: typeof handler) => {
+			expect(name).toBe("agent_end");
+			handler = cb;
+		}),
+	};
+	const runtime = {
+		ensureConfig: vi.fn(),
+		config: {
+			compactAfterTokens: args.compactAfterTokens ?? 3,
+			passive: args.passive ?? false,
+			noAutoCompact: args.noAutoCompact ?? false,
+			memory: args.memory ?? true,
+		},
+		compactInFlight: args.compactInFlight ?? false,
+	};
+	registerCompactionTrigger(pi as any, runtime as any);
+	if (!handler) throw new Error("agent_end handler was not registered");
+	return { handler, runtime };
+}
+
+function agentEnd(errorMessage?: string) {
+	return {
+		type: "agent_end",
+		messages: [
+			{ role: "user", content: "hello" },
+			errorMessage
+				? { role: "assistant", content: [], stopReason: "error", errorMessage }
+				: { role: "assistant", content: "done", stopReason: "end_turn" },
+		],
+	};
+}
+
+function fakeCtx(branches: TestEntry[][], overrides: Record<string, unknown> = {}) {
+	let branchIndex = 0;
+	const sessionId = "test-session-001";
+	const getBranch = vi.fn(() => branches[Math.min(branchIndex++, branches.length - 1)]);
+	return {
+		cwd: "/tmp/project",
+		sessionManager: {
+			getBranch,
+			getSessionId: vi.fn(() => sessionId),
+		},
+		hasUI: true,
+		ui: { notify: vi.fn() },
+		isIdle: vi.fn(() => true),
+		compact: vi.fn(),
+		...overrides,
+	};
+}
+
+const dueBranch = [textCustomMessage("raw-1", "aaaaaaaaaaaa")]; // 3 tokens
+const belowBranch = [textCustomMessage("raw-1", "aaaa")]; // 1 token
+
+describe("V3 compaction trigger (blackhole)", () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("does nothing below compactAfterTokens", async () => {
+		const { handler, runtime } = captureHandler({ compactAfterTokens: 3 });
+		const ctx = fakeCtx([belowBranch]);
+
+		handler(agentEnd(), ctx);
+		await flushMicrotasks();
+
+		expect(runtime.compactInFlight).toBe(false);
+		expect(ctx.compact).not.toHaveBeenCalled();
+	});
+
+	it("calls compact when compactAfterTokens is reached", async () => {
+		const { handler, runtime } = captureHandler({ compactAfterTokens: 3 });
+		const ctx = fakeCtx([dueBranch]);
+
+		handler(agentEnd(), ctx);
+		expect(runtime.compactInFlight).toBe(true);
+		await flushMicrotasks();
+
+		expect(ctx.compact).toHaveBeenCalledTimes(1);
+		expect(ctx.ui.notify).toHaveBeenCalledWith(
+			"Observational memory: compaction threshold reached (~3 tokens); triggering compaction",
+			"info",
+		);
+	});
+
+	it("skips passive mode", async () => {
+		const { handler, runtime } = captureHandler({ passive: true });
+		const ctx = fakeCtx([dueBranch]);
+
+		handler(agentEnd(), ctx);
+		await flushMicrotasks();
+
+		expect(runtime.compactInFlight).toBe(false);
+		expect(ctx.sessionManager.getBranch).not.toHaveBeenCalled();
+		expect(ctx.compact).not.toHaveBeenCalled();
+	});
+
+	it("skips when compaction is already in flight", async () => {
+		const { handler } = captureHandler({ compactInFlight: true });
+		const ctx = fakeCtx([dueBranch]);
+
+		handler(agentEnd(), ctx);
+		await flushMicrotasks();
+
+		expect(ctx.sessionManager.getBranch).not.toHaveBeenCalled();
+		expect(ctx.compact).not.toHaveBeenCalled();
+	});
+
+	it("skips retryable assistant errors", async () => {
+		const { handler, runtime } = captureHandler();
+		const ctx = fakeCtx([dueBranch]);
+
+		handler(agentEnd("fetch failed: connection lost"), ctx);
+		await flushMicrotasks();
+
+		expect(runtime.compactInFlight).toBe(false);
+		expect(ctx.sessionManager.getBranch).not.toHaveBeenCalled();
+		expect(ctx.compact).not.toHaveBeenCalled();
+	});
+
+	it("defers compaction if context is no longer idle", async () => {
+		const { handler, runtime } = captureHandler({ compactAfterTokens: 3 });
+		const ctx = fakeCtx([dueBranch], { isIdle: vi.fn(() => false) });
+
+		handler(agentEnd(), ctx);
+		await flushMicrotasks();
+
+		expect(ctx.compact).not.toHaveBeenCalled();
+		expect(runtime.compactInFlight).toBe(false);
+		expect(ctx.ui.notify).toHaveBeenCalledWith(
+			"Observational memory: compaction deferred — agent became busy before compaction",
+			"info",
+		);
+	});
+
+	it("re-checks threshold after deferral and skips if another compaction already reduced pressure", async () => {
+		const { handler, runtime } = captureHandler({ compactAfterTokens: 3 });
+		const ctx = fakeCtx([dueBranch, belowBranch]);
+
+		handler(agentEnd(), ctx);
+		await flushMicrotasks();
+
+		expect(ctx.compact).not.toHaveBeenCalled();
+		expect(runtime.compactInFlight).toBe(false);
+		expect(ctx.ui.notify).toHaveBeenCalledWith(
+			"Observational memory: compaction skipped — another compaction already ran before deferred compaction",
+			"info",
+		);
+	});
+
+	it("counts raw tokens since the latest Pi compaction using V3 progress helpers", async () => {
+		const { handler } = captureHandler({ compactAfterTokens: 3 });
+		const branch = [
+			textCustomMessage("raw-1", "aaaaaaaaaaaa"),
+			compactionEntry("cmp-1", { firstKeptEntryId: "raw-2" }),
+			textCustomMessage("raw-2", "aaaa"),
+			textCustomMessage("raw-3", "bbbbbbbb"),
+		];
+		const ctx = fakeCtx([branch]);
+
+		handler(agentEnd(), ctx);
+		await flushMicrotasks();
+
+		expect(ctx.compact).toHaveBeenCalledTimes(1);
+	});
+});

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -46,8 +46,8 @@ describe("Config defaults", () => {
 		const config = loadUnifiedConfig(testDir);
 		expect(config.overrideDefaultCompaction).toBe(false);
 		expect(config.debug).toBe(false);
-		expect(config.observeAfterTokens).toBe(10_000);
-		expect(config.reflectAfterTokens).toBe(20_000);
+		expect(config.observeAfterTokens).toBe(15_000); // blackhole default (upstream is 10_000)
+		expect(config.reflectAfterTokens).toBe(25_000); // blackhole default (upstream is 20_000)
 		expect(config.compactAfterTokens).toBe(81_000);
 		expect(config.observationsPoolMaxTokens).toBe(20_000);
 		expect(config.agentMaxTurns).toBe(16);
@@ -284,8 +284,8 @@ describe("Integer fields are validated as positive integers", () => {
 			compactAfterTokens: 81_000,
 		});
 		const config = loadUnifiedConfig(testDir);
-		expect(config.observeAfterTokens).toBe(10_000); // default
-		expect(config.reflectAfterTokens).toBe(20_000); // default (0 is not > 0)
+		expect(config.observeAfterTokens).toBe(15_000); // blackhole default (upstream is 10_000)
+		expect(config.reflectAfterTokens).toBe(25_000); // blackhole default (upstream is 20_000)
 		expect(config.compactAfterTokens).toBe(81_000); // from config
 	});
 });

--- a/tests/debug-log.test.ts
+++ b/tests/debug-log.test.ts
@@ -5,7 +5,8 @@
  * single ndjson file at ~/.pi/agent/pi-blackhole/debug.ndjson with rotation.
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync, statSync, renameSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync, statSync, renameSync, appendFileSync } from "node:fs";
+import fs from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 
@@ -96,9 +97,15 @@ describe("debug-log", () => {
 	});
 
 	it("never throws on write failure", () => {
-		// Make the directory non-writable
-		mkdirSync(join(agentDir, "pi-blackhole"), { recursive: true });
-		writeFileSync(join(agentDir, "pi-blackhole", "debug.ndjson"), "");
+		const spy = vi.spyOn(fs, "appendFileSync").mockImplementation(() => {
+			throw new Error("Write failure");
+		});
+		expect(() => {
+			withDebugLogContext({ enabled: true }, () => {
+				debugLog("test.event");
+			});
+		}).not.toThrow();
+		spy.mockRestore();
 	});
 
 	it("exports known constants", () => {

--- a/tests/debug-log.test.ts
+++ b/tests/debug-log.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Tests for blackhole's debug-log (single-file rotation approach).
+ *
+ * Upstream pi-observational-memory uses per-session debug files; ours is a
+ * single ndjson file at ~/.pi/agent/pi-blackhole/debug.ndjson with rotation.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync, statSync, renameSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+const testRoot = join(tmpdir(), `pi-blackhole-debug-test-${process.pid}-${Date.now()}`);
+const agentDir = join(testRoot, "agent");
+
+vi.mock("@earendil-works/pi-coding-agent", () => ({
+	getAgentDir: () => agentDir,
+}));
+
+import {
+	DEBUG_LOG_MAX_BYTES,
+	DEBUG_LOG_RELATIVE_PATH,
+	debugLog,
+	withDebugLogContext,
+} from "../src/om/debug-log.js";
+
+describe("debug-log", () => {
+	beforeEach(() => {
+		mkdirSync(agentDir, { recursive: true });
+	});
+
+	afterEach(() => {
+		rmSync(testRoot, { recursive: true, force: true });
+	});
+
+	function readLog(): any[] {
+		const logPath = join(agentDir, DEBUG_LOG_RELATIVE_PATH);
+		if (!existsSync(logPath)) return [];
+		return readFileSync(logPath, "utf-8")
+			.trim()
+			.split("\n")
+			.filter(Boolean)
+			.map((line) => JSON.parse(line));
+	}
+
+	it("does not write when context is not enabled", () => {
+		debugLog("test.event", { key: "value" });
+		expect(readLog()).toEqual([]);
+	});
+
+	it("writes enabled events with context metadata", () => {
+		withDebugLogContext({ enabled: true, cwd: "/tmp/project", runId: "run-1" }, () => {
+			debugLog("test.event", { reason: "something" });
+		});
+
+		const entries = readLog();
+		expect(entries).toHaveLength(1);
+		expect(entries[0].event).toBe("test.event");
+		expect(entries[0].cwd).toBe("/tmp/project");
+		expect(entries[0].runId).toBe("run-1");
+		expect(entries[0].data).toEqual({ reason: "something" });
+		expect(entries[0]).toHaveProperty("ts");
+	});
+
+	it("appends multiple events to the same file", () => {
+		withDebugLogContext({ enabled: true, sessionId: "session-1" }, () => {
+			debugLog("obs.start");
+			debugLog("ref.start");
+		});
+
+		const entries = readLog();
+		expect(entries).toHaveLength(2);
+		expect(entries[0].event).toBe("obs.start");
+		expect(entries[1].event).toBe("ref.start");
+	});
+
+	it("uses different log entries for different contexts (inherits parent)", () => {
+		withDebugLogContext({ enabled: true, runId: "parent" }, () => {
+			debugLog("outer");
+			withDebugLogContext({ runId: "child" }, () => {
+				debugLog("inner");
+			});
+		});
+
+		const entries = readLog();
+		expect(entries).toHaveLength(2);
+		expect(entries[0].runId).toBe("parent");
+		// inner context inherits parent's enabled flag and merges runId
+		expect(entries[1].runId).toBe("child");
+	});
+
+	it("writes to debug.ndjson path", () => {
+		withDebugLogContext({ enabled: true }, () => {
+			debugLog("check.path");
+		});
+		expect(existsSync(join(agentDir, "pi-blackhole", "debug.ndjson"))).toBe(true);
+	});
+
+	it("never throws on write failure", () => {
+		// Make the directory non-writable
+		mkdirSync(join(agentDir, "pi-blackhole"), { recursive: true });
+		writeFileSync(join(agentDir, "pi-blackhole", "debug.ndjson"), "");
+	});
+
+	it("exports known constants", () => {
+		expect(DEBUG_LOG_MAX_BYTES).toBe(10 * 1024 * 1024);
+		expect(DEBUG_LOG_RELATIVE_PATH).toBe(join("pi-blackhole", "debug.ndjson"));
+	});
+});

--- a/tests/dropper-coverage.test.ts
+++ b/tests/dropper-coverage.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Dropper coverage tests — ported from upstream pi-observational-memory.
+ *
+ * Upstream: https://github.com/elpapi42/pi-observational-memory (tests/dropper-coverage.test.ts)
+ * Ported with import paths adjusted: coverage functions are in coverage.ts, not agent.ts.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+	observationToDropperLine,
+	reflectionCoverageMap,
+	reflectionCoverageTierForCount,
+	summarizeCoverageByRelevance,
+	summarizeCoverageTransitionsByRelevance,
+} from "../src/om/agents/dropper/coverage.js";
+import { observation, reflection } from "./fixtures/session.js";
+
+describe("V3 dropper reflection coverage helpers", () => {
+	it("maps support counts to deterministic coverage tiers", () => {
+		expect(reflectionCoverageTierForCount(0)).toBe("none");
+		expect(reflectionCoverageTierForCount(1)).toBe("partial");
+		expect(reflectionCoverageTierForCount(2)).toBe("strong");
+		expect(reflectionCoverageTierForCount(10)).toBe("strong");
+	});
+
+	it("computes none, partial, and strong coverage from reflection support ids", () => {
+		const none = observation("aaaaaaaaaaaa");
+		const partial = observation("bbbbbbbbbbbb");
+		const strong = observation("cccccccccccc");
+		const coverage = reflectionCoverageMap([none, partial, strong], [
+			reflection("rrrrrrrrrrr1", ["bbbbbbbbbbbb", "cccccccccccc"]),
+			reflection("rrrrrrrrrrr2", ["cccccccccccc", "cccccccccccc"]),
+		]);
+
+		expect(coverage.get("aaaaaaaaaaaa")).toBe("none");
+		expect(coverage.get("bbbbbbbbbbbb")).toBe("partial");
+		expect(coverage.get("cccccccccccc")).toBe("strong");
+	});
+
+	it("summarizes coverage counts and token totals by relevance", () => {
+		const observations = [
+			observation("aaaaaaaaaaaa", { relevance: "low", tokenCount: 3 }),
+			observation("bbbbbbbbbbbb", { relevance: "critical", tokenCount: 5 }),
+			observation("cccccccccccc", { relevance: "critical", tokenCount: 7 }),
+		];
+		const coverage = reflectionCoverageMap(observations, [
+			reflection("rrrrrrrrrrr1", ["bbbbbbbbbbbb", "cccccccccccc"]),
+			reflection("rrrrrrrrrrr2", ["cccccccccccc"]),
+		]);
+
+		expect(summarizeCoverageByRelevance(observations, coverage)).toMatchObject({
+			low: { none: { count: 1, tokens: 3 } },
+			critical: {
+				partial: { count: 1, tokens: 5 },
+				strong: { count: 1, tokens: 7 },
+			},
+		});
+	});
+
+	it("summarizes coverage transitions by relevance without exposing ids", () => {
+		const observations = [
+			observation("aaaaaaaaaaaa", { relevance: "high", tokenCount: 3 }),
+			observation("bbbbbbbbbbbb", { relevance: "critical", tokenCount: 5 }),
+			observation("cccccccccccc", { relevance: "critical", tokenCount: 7 }),
+		];
+		const before = reflectionCoverageMap(observations, [
+			reflection("rrrrrrrrrrr1", ["bbbbbbbbbbbb"]),
+		]);
+		const after = reflectionCoverageMap(observations, [
+			reflection("rrrrrrrrrrr1", ["bbbbbbbbbbbb"]),
+			reflection("rrrrrrrrrrr2", ["aaaaaaaaaaaa", "bbbbbbbbbbbb", "cccccccccccc"]),
+			reflection("rrrrrrrrrrr3", ["cccccccccccc"]),
+		]);
+
+		expect(summarizeCoverageTransitionsByRelevance(observations, before, after)).toEqual({
+			low: {},
+			medium: {},
+			high: { "none->partial": { count: 1, tokens: 3 } },
+			critical: {
+				"partial->strong": { count: 1, tokens: 5 },
+				"none->strong": { count: 1, tokens: 7 },
+			},
+		});
+	});
+
+	it("renders model-facing observation lines with coverage evidence only", () => {
+		const line = observationToDropperLine(
+			observation("aaaaaaaaaaaa", { relevance: "critical", content: "Important fact" }),
+			"strong",
+		);
+
+		expect(line).toContain("[aaaaaaaaaaaa]");
+		expect(line).toContain("[critical]");
+		expect(line).toContain("[coverage: strong]");
+		expect(line).toContain("Important fact");
+		expect(line).not.toContain("drop-priority");
+		expect(line).not.toContain("drop-resistance");
+	});
+});

--- a/tests/dropper.test.ts
+++ b/tests/dropper.test.ts
@@ -1,0 +1,231 @@
+/**
+ * Dropper agent tests — ported from upstream pi-observational-memory.
+ *
+ * Upstream: https://github.com/elpapi42/pi-observational-memory (tests/dropper.test.ts)
+ * Ported with adaptations for pi-blackhole:
+ *   - budgetTokens instead of targetTokens
+ *   - Import paths adjusted for om/ layout
+ *   - Assertion strings adapted to our display format (still has DropUrgency)
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+	maxDropCountForPool,
+	normalizeDropObservationIds,
+	observationPoolFullness,
+	runDropper,
+	selectDropCandidates,
+} from "../src/om/agents/dropper/agent.js";
+import { observation, reflection } from "./fixtures/session.js";
+
+function fakeAgentLoop(handler: (prompts: any[], context: any, config: any) => Promise<void> | void): any {
+	return ((prompts: any[], context: any, config: any) => ({
+		async *[Symbol.asyncIterator]() {},
+		result: async () => {
+			await handler(prompts, context, config);
+			return {};
+		},
+	})) as any;
+}
+
+describe("V3 dropper agent", () => {
+	const obsA = observation("aaaaaaaaaaaa", { relevance: "medium" });
+	const obsB = observation("bbbbbbbbbbbb", { relevance: "low" });
+	const critical = observation("cccccccccccc", { relevance: "critical" });
+	const baseArgs = {
+		model: {} as any,
+		apiKey: "test",
+		reflections: [reflection("eeeeeeeeeeee", ["aaaaaaaaaaaa"])],
+		observations: [obsA, obsB, critical],
+		budgetTokens: 20,
+	};
+
+	it("computes observation pool fullness defensively", () => {
+		expect(observationPoolFullness(0, 100)).toBe(0);
+		expect(observationPoolFullness(-1, 100)).toBe(0);
+		expect(observationPoolFullness(10, 0)).toBe(0);
+		expect(observationPoolFullness(10, Number.NaN)).toBe(0);
+		expect(observationPoolFullness(25, 100)).toBe(0.25);
+	});
+
+	it("computes max drops from token excess above budget", () => {
+		const observations = Array.from({ length: 10 }, (_, index) =>
+			observation(`${index}`.padStart(12, "a"), { relevance: "low", tokenCount: 10 }),
+		);
+
+		expect(maxDropCountForPool(observations, 100, 100)).toBe(0);
+		expect(maxDropCountForPool(observations, 100, 90)).toBe(1);
+		expect(maxDropCountForPool(observations, 100, 50)).toBe(5);
+		expect(maxDropCountForPool(observations, 100, 0)).toBe(10);
+	});
+
+	it("uses active observation count for budget-return max drops while critical ids remain eligible later", () => {
+		const observations = [
+			observation("aaaaaaaaaaaa", { relevance: "low", tokenCount: 10 }),
+			observation("bbbbbbbbbbbb", { relevance: "medium", tokenCount: 10 }),
+			observation("cccccccccccc", { relevance: "critical", tokenCount: 10 }),
+			observation("dddddddddddd", { relevance: "critical", tokenCount: 10 }),
+		];
+
+		expect(maxDropCountForPool(observations, 40, 20)).toBe(2);
+	});
+
+	it("keeps core dropper safety guidance in V3 terms", async () => {
+		let systemPrompt = "";
+		const loop = fakeAgentLoop((_prompts, context) => {
+			systemPrompt = context.systemPrompt;
+		});
+
+		await runDropper({ ...baseArgs, agentLoop: loop });
+
+		expect(systemPrompt).toContain("Active-memory framing");
+		expect(systemPrompt).toContain("Age-gradient rule");
+		expect(systemPrompt).toContain("critical");
+		expect(systemPrompt).toContain("highest importance and strongest resistance");
+		expect(systemPrompt).toContain("Relevance is importance/resistance, not an absolute keep/drop lock");
+		expect(systemPrompt).toContain("Coverage is evidence, not an automatic decision");
+		expect(systemPrompt).toContain("age alone is not enough");
+		expect(systemPrompt).not.toContain("NEVER drop");
+		expect(systemPrompt).toContain("Preservation floor");
+		expect(systemPrompt).toContain("Do not force drops");
+		expect(systemPrompt).toContain("You cannot merge observations");
+		expect(systemPrompt).toContain("Default action is KEEP");
+		expect(systemPrompt).toContain("When uncertain, keep");
+		expect(systemPrompt).toContain("active observation pool target");
+		expect(systemPrompt).not.toContain("drop freely");
+		expect(systemPrompt).not.toContain("pruner");
+		expect(systemPrompt).not.toContain("drop-priority");
+		expect(systemPrompt).not.toContain("drop-resistance");
+		expect(systemPrompt).not.toContain("Pass strategy");
+		expect(systemPrompt).not.toContain("Urgency guidance");
+	});
+
+	it("passes budget-return max drops as a hard upper bound", async () => {
+		let userText = "";
+		const loop = fakeAgentLoop((prompts) => {
+			userText = prompts[0].content[0].text;
+		});
+
+		await runDropper({ ...baseArgs, agentLoop: loop });
+
+		// pi-blackhole display format: "fullness: ~X%" (no "against target")
+		expect(userText).toContain("[coverage: partial]");
+		expect(userText).toContain("[coverage: none]");
+		expect(userText).toContain("Maximum drops allowed this run:");
+		expect(userText).toContain("hard upper bound, not a target");
+		expect(userText).toContain("Drop fewer or none");
+		// pi-blackhole still uses DropUrgency
+		expect(userText).toContain("Drop urgency");
+		// pi-blackhole doesn't display "over target by ~X tokens" or "sized to move..."
+		expect(userText).not.toContain("drop-priority");
+		expect(userText).not.toContain("drop-resistance");
+	});
+
+	it("normalizes active drop ids, filters invalid ids, dedupes, and accepts critical observations", () => {
+		expect(normalizeDropObservationIds(["bbbbbbbbbbbb", "missing", "bbbbbbbbbbbb", "cccccccccccc", "aaaaaaaaaaaa"], [obsA, obsB, critical])).toEqual(["bbbbbbbbbbbb", "cccccccccccc", "aaaaaaaaaaaa"]);
+		expect(normalizeDropObservationIds(["missing", "cccccccccccc"], [obsA, obsB, critical])).toEqual(["cccccccccccc"]);
+		expect(normalizeDropObservationIds(["missing"], [obsA, obsB, critical])).toBeUndefined();
+	});
+
+	it("selects final candidates by coverage, lower relevance, age, then stable ordering", () => {
+		const highA = observation("aaaaaaaaaaaa", { relevance: "high" });
+		const lowA = observation("bbbbbbbbbbbb", { relevance: "low" });
+		const medium = observation("dddddddddddd", { relevance: "medium" });
+		const lowB = observation("eeeeeeeeeeee", { relevance: "low" });
+		const highB = observation("ffffffffffff", { relevance: "high" });
+		const critical = observation("111111111111", { relevance: "critical" });
+		const observations = [highA, lowA, medium, lowB, highB, critical];
+
+		expect(selectDropCandidates([
+			"aaaaaaaaaaaa",
+			"missing",
+			"111111111111",
+			"bbbbbbbbbbbb",
+			"dddddddddddd",
+			"bbbbbbbbbbbb",
+			"eeeeeeeeeeee",
+			"ffffffffffff",
+		], observations, 3)).toEqual(["bbbbbbbbbbbb", "eeeeeeeeeeee", "dddddddddddd"]);
+
+		const oldHigh = observation("999999999999", { relevance: "high", timestamp: "2026-01-01T00:00:00.000Z" });
+		const newHigh = observation("888888888888", { relevance: "high", timestamp: "2026-02-01T00:00:00.000Z" });
+		expect(selectDropCandidates(["888888888888", "999999999999"], [oldHigh, newHigh], 1)).toEqual(["999999999999"]);
+	});
+
+	it("prefers stronger reflection coverage before relevance when over cap", () => {
+		const strongCritical = observation("aaaaaaaaaaaa", { relevance: "critical", timestamp: "2026-01-01T00:00:00.000Z" });
+		const partialLow = observation("bbbbbbbbbbbb", { relevance: "low", timestamp: "2026-01-01T00:00:00.000Z" });
+		const noneLow = observation("cccccccccccc", { relevance: "low", timestamp: "2026-01-01T00:00:00.000Z" });
+		const observations = [strongCritical, partialLow, noneLow];
+		const reflections = [
+			reflection("rrrrrrrrrrr1", ["aaaaaaaaaaaa", "bbbbbbbbbbbb"]),
+			reflection("rrrrrrrrrrr2", ["aaaaaaaaaaaa"]),
+		];
+
+		expect(selectDropCandidates(["cccccccccccc", "bbbbbbbbbbbb", "aaaaaaaaaaaa"], observations, 2, reflections)).toEqual(["aaaaaaaaaaaa", "bbbbbbbbbbbb"]);
+	});
+
+	it("keeps critical lower priority than lower relevance when coverage is equal", () => {
+		const critical = observation("aaaaaaaaaaaa", { relevance: "critical", timestamp: "2026-01-01T00:00:00.000Z" });
+		const high = observation("bbbbbbbbbbbb", { relevance: "high", timestamp: "2026-01-01T00:00:00.000Z" });
+		const low = observation("cccccccccccc", { relevance: "low", timestamp: "2026-01-01T00:00:00.000Z" });
+		const observations = [critical, high, low];
+		const reflections = [reflection("rrrrrrrrrrr1", ["aaaaaaaaaaaa", "bbbbbbbbbbbb", "cccccccccccc"]), reflection("rrrrrrrrrrr2", ["aaaaaaaaaaaa", "bbbbbbbbbbbb", "cccccccccccc"])];
+
+		expect(selectDropCandidates(["aaaaaaaaaaaa", "bbbbbbbbbbbb", "cccccccccccc"], observations, 2, reflections)).toEqual(["cccccccccccc", "bbbbbbbbbbbb"]);
+	});
+
+	it("returns capped coverage-preferred proposed observation ids", async () => {
+		const loop = fakeAgentLoop(async (_prompts, context) => {
+			await context.tools[0].execute("tool-1", { ids: ["aaaaaaaaaaaa", "missing", "bbbbbbbbbbbb"] });
+		});
+
+		await expect(runDropper({ ...baseArgs, agentLoop: loop })).resolves.toEqual(["aaaaaaaaaaaa"]);
+	});
+
+	it("returns critical proposed ids when they are the selected valid candidates", async () => {
+		const loop = fakeAgentLoop(async (_prompts, context) => {
+			await context.tools[0].execute("tool-1", { ids: ["missing", "cccccccccccc"] });
+		});
+
+		await expect(runDropper({ ...baseArgs, agentLoop: loop })).resolves.toEqual(["cccccccccccc"]);
+	});
+
+	it("returns undefined when only invalid ids are proposed", async () => {
+		const loop = fakeAgentLoop(async (_prompts, context) => {
+			await context.tools[0].execute("tool-1", { ids: ["missing"] });
+		});
+
+		await expect(runDropper({ ...baseArgs, agentLoop: loop })).resolves.toBeUndefined();
+	});
+
+	it("dedupes repeated tool calls and enforces one run-level cap", async () => {
+		const loop = fakeAgentLoop(async (_prompts, context) => {
+			await context.tools[0].execute("tool-1", { ids: ["aaaaaaaaaaaa"] });
+			await context.tools[0].execute("tool-2", { ids: ["bbbbbbbbbbbb", "aaaaaaaaaaaa"] });
+		});
+
+		await expect(runDropper({ ...baseArgs, agentLoop: loop })).resolves.toEqual(["aaaaaaaaaaaa"]);
+	});
+
+	it("returns undefined when no tool call drops observations", async () => {
+		const loop = fakeAgentLoop(() => {});
+		await expect(runDropper({ ...baseArgs, agentLoop: loop })).resolves.toBeUndefined();
+	});
+
+	it("skips the model at or below the budget", async () => {
+		let called = false;
+		const loop = fakeAgentLoop(() => {
+			called = true;
+		});
+
+		await expect(runDropper({
+			...baseArgs,
+			observations: [observation("aaaaaaaaaaaa", { relevance: "low", tokenCount: 10 })],
+			budgetTokens: 10,
+			agentLoop: loop,
+		})).resolves.toBeUndefined();
+		expect(called).toBe(false);
+	});
+});

--- a/tests/dropper.test.ts
+++ b/tests/dropper.test.ts
@@ -49,18 +49,25 @@ describe("V3 dropper agent", () => {
 		expect(observationPoolFullness(25, 100)).toBe(0.25);
 	});
 
-	it("computes max drops from token excess above budget", () => {
+	it("computes max drops from pool fullness ratio (blackhole algorithm)", () => {
 		const observations = Array.from({ length: 10 }, (_, index) =>
 			observation(`${index}`.padStart(12, "a"), { relevance: "low", tokenCount: 10 }),
 		);
 
-		expect(maxDropCountForPool(observations, 100, 100)).toBe(0);
-		expect(maxDropCountForPool(observations, 100, 90)).toBe(1);
-		expect(maxDropCountForPool(observations, 100, 50)).toBe(5);
-		expect(maxDropCountForPool(observations, 100, 0)).toBe(10);
+		// Below skip threshold (fullness < 0.10) → 0 drops
+		expect(maxDropCountForPool(observations, 5, 100)).toBe(0);
+
+		// At budget (fullness = 1.0) → max ratio 0.50 → floor(10 × 0.50) = 5
+		expect(maxDropCountForPool(observations, 100, 100)).toBe(5);
+
+		// Over budget (fullness > 1.0) → capped at 1.0 → same max ratio
+		expect(maxDropCountForPool(observations, 200, 100)).toBe(5);
+
+		// Budget ≤ 0 → guarded, returns 0
+		expect(maxDropCountForPool(observations, 100, 0)).toBe(0);
 	});
 
-	it("uses active observation count for budget-return max drops while critical ids remain eligible later", () => {
+	it("respects critical relevance in droppableCount — critical obs are never counted as droppable", () => {
 		const observations = [
 			observation("aaaaaaaaaaaa", { relevance: "low", tokenCount: 10 }),
 			observation("bbbbbbbbbbbb", { relevance: "medium", tokenCount: 10 }),
@@ -68,7 +75,9 @@ describe("V3 dropper agent", () => {
 			observation("dddddddddddd", { relevance: "critical", tokenCount: 10 }),
 		];
 
-		expect(maxDropCountForPool(observations, 40, 20)).toBe(2);
+		// tokens=40, budget=20 → fullness=2.0 → capped 1.0 → dropRatio 0.50
+		// droppableCount=2 (only low and medium) → floor(2 × 0.50) = 1, max(1,1) = 1
+		expect(maxDropCountForPool(observations, 40, 20)).toBe(1);
 	});
 
 	it("keeps core dropper safety guidance in V3 terms", async () => {
@@ -214,16 +223,17 @@ describe("V3 dropper agent", () => {
 		await expect(runDropper({ ...baseArgs, agentLoop: loop })).resolves.toBeUndefined();
 	});
 
-	it("skips the model at or below the budget", async () => {
+	it("skips the model when pool fullness is below the skip threshold", async () => {
 		let called = false;
 		const loop = fakeAgentLoop(() => {
 			called = true;
 		});
 
+		// 1 observation × 10 tokens, budget=200 → fullness=0.05 < DROP_SKIP_FULLNESS(0.10)
 		await expect(runDropper({
 			...baseArgs,
 			observations: [observation("aaaaaaaaaaaa", { relevance: "low", tokenCount: 10 })],
-			budgetTokens: 10,
+			budgetTokens: 200,
 			agentLoop: loop,
 		})).resolves.toBeUndefined();
 		expect(called).toBe(false);

--- a/tests/fixtures/session.ts
+++ b/tests/fixtures/session.ts
@@ -1,0 +1,282 @@
+/**
+ * Test fixtures — helpers for building test observations, reflections, and session entries.
+ *
+ * Upstream: https://github.com/elpapi42/pi-observational-memory (tests/fixtures/session.ts)
+ * Ported and adapted for pi-blackhole.
+ */
+
+export type TestEntry = {
+	type: string;
+	id: string;
+	parentId: string | null;
+	timestamp: string;
+	message?: unknown;
+	content?: unknown;
+	customType?: string;
+	summary?: unknown;
+	data?: unknown;
+	details?: unknown;
+	firstKeptEntryId?: string;
+	fromId?: string;
+};
+
+export type TestObservation = {
+	id: string;
+	content: string;
+	timestamp: string;
+	relevance: "low" | "medium" | "high" | "critical";
+	sourceEntryIds: string[];
+	tokenCount: number;
+};
+
+export type TestReflection = {
+	id: string;
+	content: string;
+	supportingObservationIds: string[];
+	tokenCount: number;
+};
+
+export const V3_OBSERVATIONS_RECORDED = "om.observations.recorded";
+export const V3_REFLECTIONS_RECORDED = "om.reflections.recorded";
+export const V3_OBSERVATIONS_DROPPED = "om.observations.dropped";
+export const V3_FOLDED = "om.folded";
+export const V2_OBSERVATION = "om.observation";
+export const V2_DETAILS_TYPE = "observational-memory";
+
+const DEFAULT_TIMESTAMP = "2026-05-02T10:00:00.000Z";
+
+export function rawMessage(
+	id: string,
+	text: string,
+	overrides: Partial<TestEntry> = {},
+): TestEntry {
+	return {
+		type: "message",
+		id,
+		parentId: null,
+		timestamp: DEFAULT_TIMESTAMP,
+		message: { role: "user", content: [{ type: "text", text }] },
+		...overrides,
+	};
+}
+
+export function customMessage(
+	id: string,
+	content: unknown,
+	overrides: Partial<TestEntry> = {},
+): TestEntry {
+	return {
+		type: "custom_message",
+		id,
+		parentId: null,
+		timestamp: DEFAULT_TIMESTAMP,
+		content,
+		...overrides,
+	};
+}
+
+export function textCustomMessage(
+	id: string,
+	text: string,
+	overrides: Partial<TestEntry> = {},
+): TestEntry {
+	return customMessage(id, text, overrides);
+}
+
+export function branchSummary(
+	id: string,
+	summary: string,
+	overrides: Partial<TestEntry> = {},
+): TestEntry {
+	return {
+		type: "branch_summary",
+		id,
+		parentId: null,
+		timestamp: DEFAULT_TIMESTAMP,
+		summary,
+		...overrides,
+	};
+}
+
+export function compactionEntry(
+	id: string,
+	args: { firstKeptEntryId?: string; details?: unknown; summary?: string } = {},
+	overrides: Partial<TestEntry> = {},
+): TestEntry {
+	return {
+		type: "compaction",
+		id,
+		parentId: null,
+		timestamp: DEFAULT_TIMESTAMP,
+		firstKeptEntryId: args.firstKeptEntryId,
+		summary: args.summary ?? "compacted memory",
+		details: args.details,
+		...overrides,
+	};
+}
+
+export function memoryDetails(
+	args: {
+		fullFold?: boolean;
+		observations?: TestObservation[];
+		reflections?: TestReflection[];
+	} = {},
+): unknown {
+	return {
+		type: V3_FOLDED,
+		version: 1,
+		fullFold: args.fullFold ?? false,
+		observations: args.observations ?? [],
+		reflections: args.reflections ?? [],
+	};
+}
+
+export function observation(
+	id: string,
+	overrides: Partial<TestObservation> = {},
+): TestObservation {
+	return {
+		id,
+		content: `Observation ${id}`,
+		timestamp: DEFAULT_TIMESTAMP,
+		relevance: "medium",
+		sourceEntryIds: ["raw-1"],
+		tokenCount: 10,
+		...overrides,
+	};
+}
+
+export function reflection(
+	id: string,
+	supportingObservationIds: string[] = ["obs-1"],
+	overrides: Partial<TestReflection> = {},
+): TestReflection {
+	return {
+		id,
+		content: `Reflection ${id}`,
+		supportingObservationIds,
+		tokenCount: 5,
+		...overrides,
+	};
+}
+
+export function observationsRecordedEntry(
+	id: string,
+	args: { observations: TestObservation[]; coversUpToId: string },
+	overrides: Partial<TestEntry> = {},
+): TestEntry {
+	return {
+		type: "custom",
+		id,
+		parentId: null,
+		timestamp: DEFAULT_TIMESTAMP,
+		customType: V3_OBSERVATIONS_RECORDED,
+		data: args,
+		...overrides,
+	};
+}
+
+export function reflectionsRecordedEntry(
+	id: string,
+	args: { reflections: TestReflection[]; coversUpToId: string },
+	overrides: Partial<TestEntry> = {},
+): TestEntry {
+	return {
+		type: "custom",
+		id,
+		parentId: null,
+		timestamp: DEFAULT_TIMESTAMP,
+		customType: V3_REFLECTIONS_RECORDED,
+		data: args,
+		...overrides,
+	};
+}
+
+export function observationsDroppedEntry(
+	id: string,
+	args: { observationIds: string[]; coversUpToId: string },
+	overrides: Partial<TestEntry> = {},
+): TestEntry {
+	return {
+		type: "custom",
+		id,
+		parentId: null,
+		timestamp: DEFAULT_TIMESTAMP,
+		customType: V3_OBSERVATIONS_DROPPED,
+		data: args,
+		...overrides,
+	};
+}
+
+export function oldV2ObservationEntry(
+	id: string,
+	args: { records?: unknown[]; coversFromId?: string; coversUpToId?: string; tokenCount?: number } = {},
+	overrides: Partial<TestEntry> = {},
+): TestEntry {
+	return {
+		type: "custom",
+		id,
+		parentId: null,
+		timestamp: DEFAULT_TIMESTAMP,
+		customType: V2_OBSERVATION,
+		data: {
+			records: args.records ?? [observation("v2-obs")],
+			coversFromId: args.coversFromId ?? "raw-1",
+			coversUpToId: args.coversUpToId ?? "raw-1",
+			tokenCount: args.tokenCount ?? 10,
+		},
+		...overrides,
+	};
+}
+
+export function oldV2CompactionDetails(
+	args: { observations?: unknown[]; reflections?: unknown[] } = {},
+): unknown {
+	return {
+		type: V2_DETAILS_TYPE,
+		version: 4,
+		observations: args.observations ?? [observation("v2-obs")],
+		reflections: args.reflections ?? [],
+	};
+}
+
+export function fakeSessionContext(initialEntries: TestEntry[] = []) {
+	let entries = [...initialEntries];
+	return {
+		appended: [] as Array<{ customType: string; data: unknown }>,
+		sessionManager: {
+			getBranch: () => entries,
+			setBranch: (next: TestEntry[]) => {
+				entries = next;
+			},
+			getLeafId: () => entries.at(-1)?.id,
+		},
+		appendEntry(customType: string, data: unknown) {
+			this.appended.push({ customType, data });
+			const entry = {
+				type: "custom",
+				id: `appended-${this.appended.length}`,
+				parentId: entries.at(-1)?.id ?? null,
+				timestamp: DEFAULT_TIMESTAMP,
+				customType,
+				data,
+			};
+			entries = [...entries, entry];
+			return entry.id;
+		},
+	};
+}
+
+export function fakeCompactionContext(entries: TestEntry[]) {
+	return {
+		cwd: "/tmp/pi-observational-memory-test",
+		sessionManager: {
+			getBranch: () => entries,
+		},
+		isIdle: () => true,
+		compactCalls: [] as unknown[],
+		compact(arg?: unknown) {
+			this.compactCalls.push(arg ?? true);
+		},
+	};
+}

--- a/tests/memory-command.test.ts
+++ b/tests/memory-command.test.ts
@@ -1,0 +1,316 @@
+/**
+ * Tests for the /blackhole-memory command (status, view, full).
+ */
+import { describe, it, expect, vi } from "vitest";
+import { registerMemoryCommand } from "../src/commands/memory.js";
+import {
+	observation,
+	observationsRecordedEntry,
+	reflection,
+	reflectionsRecordedEntry,
+	observationsDroppedEntry,
+	textCustomMessage,
+	type TestEntry,
+} from "./fixtures/session.js";
+
+/** Build a minimal mock pi + runtime for testing commands */
+function createMockEnvironment() {
+	const notifyCalls: Array<{ msg: string; level: string }> = [];
+	const handlerMap = new Map<string, (event: unknown, ctx: unknown) => unknown>();
+
+	const pi = {
+		registerCommand: vi.fn((name: string, def: { handler: (args: unknown, ctx: unknown) => Promise<void> }) => {
+			handlerMap.set(name, def.handler as any);
+		}),
+	};
+
+	const runtime = {
+		ensureConfig: vi.fn(),
+		config: {
+			observeAfterTokens: 15_000,
+			reflectAfterTokens: 25_000,
+			compactAfterTokens: 81_000,
+			observationsPoolMaxTokens: 20_000,
+			observerChunkMaxTokens: 40_000,
+			observerPreambleMaxTokens: 0,
+			passive: false,
+			noAutoCompact: false,
+		},
+		consolidationInFlight: false,
+		compactInFlight: false,
+		compactHookInFlight: false,
+		lastObserverError: undefined,
+		lastReflectorError: undefined,
+		lastDropperError: undefined,
+	};
+
+	const ui = {
+		notify: vi.fn((msg: string, level: string) => {
+			notifyCalls.push({ msg, level });
+		}),
+	};
+
+	/** Helper: build a basic branch with some observations and reflections */
+	function buildBranch(overrides: Partial<{ observations: number; reflections: number; drops: number }> = {}) {
+		const { observations = 2, reflections = 1, drops = 0 } = overrides;
+		const entries: TestEntry[] = [
+			textCustomMessage("raw-1", "aaaa"),
+		];
+		if (observations > 0) {
+			const obsList = Array.from({ length: observations }, (_, i) =>
+				observation(`${"a".repeat(12 - String(i).length)}${i}`, { relevance: "medium", tokenCount: 10 }),
+			);
+			entries.push(observationsRecordedEntry("om-obs", { observations: obsList, coversUpToId: "raw-1" }));
+		}
+		if (reflections > 0) {
+			const refList = Array.from({ length: reflections }, (_, i) =>
+				reflection(`${"e".repeat(12 - String(i).length)}${i}`, ["aaaaaaaaaaaa"]),
+			);
+			entries.push(reflectionsRecordedEntry("om-ref", { reflections: refList, coversUpToId: "raw-1" }));
+		}
+		if (drops > 0) {
+			entries.push(observationsDroppedEntry("om-drop", {
+				observationIds: ["aaaaaaaaaaaa"],
+				coversUpToId: "om-obs",
+			}));
+		}
+		return entries;
+	}
+
+	return {
+		pi,
+		runtime,
+		ui,
+		notifyCalls,
+		handlerMap,
+		buildBranch,
+	};
+}
+
+function invokeMemory(handlerMap: Map<string, unknown>, args: unknown, ctxOverrides: Record<string, unknown> = {}) {
+	const handler = handlerMap.get("blackhole-memory") as ((args: unknown, ctx: unknown) => Promise<void>) | undefined;
+	if (!handler) throw new Error("blackhole-memory command not registered");
+	return handler(args, {
+		cwd: "/tmp/test",
+		sessionManager: {
+			getBranch: vi.fn(() => []),
+			getSessionId: vi.fn(() => "test-session"),
+		},
+		ui: { notify: vi.fn() },
+		...ctxOverrides,
+	});
+}
+
+describe("/blackhole-memory command", () => {
+	it("registers the command on pi", () => {
+		const { pi, runtime } = createMockEnvironment();
+		registerMemoryCommand(pi as any, runtime as any);
+		expect(pi.registerCommand).toHaveBeenCalledWith("blackhole-memory", expect.objectContaining({
+			description: expect.stringContaining("memory"),
+		}));
+	});
+
+	it("shows status with pipeline counters for default config", async () => {
+		const { pi, runtime, handlerMap, buildBranch } = createMockEnvironment();
+		registerMemoryCommand(pi as any, runtime as any);
+
+		const ui = { notify: vi.fn() };
+		const entries = buildBranch({ observations: 3, reflections: 2 });
+
+		await handlerMap.get("blackhole-memory")!([], {
+			cwd: "/tmp/test",
+			sessionManager: {
+				getBranch: vi.fn(() => entries),
+				getSessionId: vi.fn(() => "test-session"),
+			},
+			ui,
+		});
+
+		expect(ui.notify).toHaveBeenCalledTimes(1);
+		const msg = (ui.notify as any).mock.calls[0][0] as string;
+		expect(msg).toContain("Memory");
+		expect(msg).toContain("Observations:");
+		expect(msg).toContain("Reflections:");
+		expect(msg).toContain("Observer:");
+		expect(msg).toContain("Reflector:");
+		expect(msg).toContain("Dropper:");
+		expect(msg).toContain("Compaction:");
+		expect(msg).toContain("Obs pool:");
+		expect(msg).toContain("Reflect pool:");
+	});
+
+	it("status shows recorded / dropped / visible counts", async () => {
+		const { pi, runtime, handlerMap, buildBranch } = createMockEnvironment();
+		registerMemoryCommand(pi as any, runtime as any);
+
+		const ui = { notify: vi.fn() };
+		// 2 observations, 1 reflection, 1 dropped
+		const entries = buildBranch({ observations: 2, reflections: 1, drops: 1 });
+
+		await handlerMap.get("blackhole-memory")!([], {
+			cwd: "/tmp/test",
+			sessionManager: {
+				getBranch: vi.fn(() => entries),
+				getSessionId: vi.fn(() => "test-session"),
+			},
+			ui,
+		});
+
+		const msg = (ui.notify as any).mock.calls[0][0] as string;
+		expect(msg).toContain("2 recorded");
+		expect(msg).toContain("1 dropped");
+		expect(msg).toContain("1 visible");
+	});
+
+	it("shows passive mode indicator when config.passive is true", async () => {
+		const { pi, runtime, handlerMap } = createMockEnvironment();
+		runtime.config.passive = true;
+		registerMemoryCommand(pi as any, runtime as any);
+
+		const ui = { notify: vi.fn() };
+
+		await handlerMap.get("blackhole-memory")!([], {
+			cwd: "/tmp/test",
+			sessionManager: {
+				getBranch: vi.fn(() => []),
+				getSessionId: vi.fn(() => "test-session"),
+			},
+			ui,
+		});
+
+		const msg = (ui.notify as any).mock.calls[0][0] as string;
+		expect(msg).toContain("Passive:");
+		expect(msg).toContain("automatic memory workers and auto-compaction disabled");
+	});
+
+	it("shows in-flight indicators when consolidation is running", async () => {
+		const { pi, runtime, handlerMap } = createMockEnvironment();
+		runtime.consolidationInFlight = true;
+		runtime.compactInFlight = true;
+		registerMemoryCommand(pi as any, runtime as any);
+
+		const ui = { notify: vi.fn() };
+
+		await handlerMap.get("blackhole-memory")!([], {
+			cwd: "/tmp/test",
+			sessionManager: {
+				getBranch: vi.fn(() => []),
+				getSessionId: vi.fn(() => "test-session"),
+			},
+			ui,
+		});
+
+		const msg = (ui.notify as any).mock.calls[0][0] as string;
+		expect(msg).toContain("In flight");
+		expect(msg).toContain("Consolidation: running");
+		expect(msg).toContain("Auto-compaction: running");
+	});
+
+	it("shows last errors when present", async () => {
+		const { pi, runtime, handlerMap } = createMockEnvironment();
+		runtime.lastObserverError = "Model unavailable";
+		runtime.lastDropperError = "Budget exceeded";
+		registerMemoryCommand(pi as any, runtime as any);
+
+		const ui = { notify: vi.fn() };
+
+		await handlerMap.get("blackhole-memory")!([], {
+			cwd: "/tmp/test",
+			sessionManager: {
+				getBranch: vi.fn(() => []),
+				getSessionId: vi.fn(() => "test-session"),
+			},
+			ui,
+		});
+
+		const msg = (ui.notify as any).mock.calls[0][0] as string;
+		expect(msg).toContain("Last error");
+		expect(msg).toContain("Observer: Model unavailable");
+		expect(msg).toContain("Dropper: Budget exceeded");
+	});
+
+	it("view mode renders visible observations and reflections", async () => {
+		const { pi, runtime, handlerMap, buildBranch } = createMockEnvironment();
+		registerMemoryCommand(pi as any, runtime as any);
+
+		const ui = { notify: vi.fn() };
+		const entries = buildBranch({ observations: 2, reflections: 1 });
+
+		await handlerMap.get("blackhole-memory")!(["view"], {
+			cwd: "/tmp/test",
+			sessionManager: {
+				getBranch: vi.fn(() => entries),
+				getSessionId: vi.fn(() => "test-session"),
+			},
+			ui,
+		});
+
+		expect(ui.notify).toHaveBeenCalledTimes(1);
+		const msg = (ui.notify as any).mock.calls[0][0] as string;
+		expect(msg).toContain("Reflections");
+		expect(msg).toContain("Observations");
+		expect(msg).toContain("Copied to clipboard.");
+	});
+
+	it("full mode renders all recorded observations and reflections", async () => {
+		const { pi, runtime, handlerMap, buildBranch } = createMockEnvironment();
+		registerMemoryCommand(pi as any, runtime as any);
+
+		const ui = { notify: vi.fn() };
+		const entries = buildBranch({ observations: 2, reflections: 1 });
+
+		await handlerMap.get("blackhole-memory")!(["full"], {
+			cwd: "/tmp/test",
+			sessionManager: {
+				getBranch: vi.fn(() => entries),
+				getSessionId: vi.fn(() => "test-session"),
+			},
+			ui,
+		});
+
+		expect(ui.notify).toHaveBeenCalledTimes(1);
+		const msg = (ui.notify as any).mock.calls[0][0] as string;
+		expect(msg).toContain("Reflections");
+		expect(msg).toContain("Observations");
+	});
+
+	it("shows usage message for invalid mode", async () => {
+		const { pi, runtime, handlerMap } = createMockEnvironment();
+		registerMemoryCommand(pi as any, runtime as any);
+
+		const ui = { notify: vi.fn() };
+
+		await handlerMap.get("blackhole-memory")!(["invalid-mode"], {
+			cwd: "/tmp/test",
+			sessionManager: {
+				getBranch: vi.fn(() => []),
+				getSessionId: vi.fn(() => "test-session"),
+			},
+			ui,
+		});
+
+		const msg = (ui.notify as any).mock.calls[0][0] as string;
+		expect(msg).toContain("Usage:");
+	});
+
+	it("noAutoCompact shows auto-disabled marker and preamble cap info", async () => {
+		const { pi, runtime, handlerMap } = createMockEnvironment();
+		runtime.config.noAutoCompact = true;
+		registerMemoryCommand(pi as any, runtime as any);
+
+		const ui = { notify: vi.fn() };
+
+		await handlerMap.get("blackhole-memory")!([], {
+			cwd: "/tmp/test",
+			sessionManager: {
+				getBranch: vi.fn(() => []),
+				getSessionId: vi.fn(() => "test-session"),
+			},
+			ui,
+		});
+
+		const msg = (ui.notify as any).mock.calls[0][0] as string;
+		expect(msg).toContain("auto-disabled");
+		// Pending section and Preamble cap only show when pending data exists on disk
+	});
+});

--- a/tests/memory-command.test.ts
+++ b/tests/memory-command.test.ts
@@ -87,19 +87,7 @@ function createMockEnvironment() {
 	};
 }
 
-function invokeMemory(handlerMap: Map<string, unknown>, args: unknown, ctxOverrides: Record<string, unknown> = {}) {
-	const handler = handlerMap.get("blackhole-memory") as ((args: unknown, ctx: unknown) => Promise<void>) | undefined;
-	if (!handler) throw new Error("blackhole-memory command not registered");
-	return handler(args, {
-		cwd: "/tmp/test",
-		sessionManager: {
-			getBranch: vi.fn(() => []),
-			getSessionId: vi.fn(() => "test-session"),
-		},
-		ui: { notify: vi.fn() },
-		...ctxOverrides,
-	});
-}
+
 
 describe("/blackhole-memory command", () => {
 	it("registers the command on pi", () => {

--- a/tests/observer.test.ts
+++ b/tests/observer.test.ts
@@ -1,0 +1,174 @@
+/**
+ * Observer agent tests — ported from upstream pi-observational-memory.
+ *
+ * Upstream: https://github.com/elpapi42/pi-observational-memory (tests/observer.test.ts)
+ * Ported with import paths adjusted for om/ layout.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { normalizeSourceEntryIds, OBSERVATION_TIMESTAMP_PATTERN, runObserver } from "../src/om/agents/observer/agent.js";
+import { estimateStringTokens } from "../src/om/tokens.js";
+
+function fakeAgentLoop(handler: (prompts: any[], context: any, config: any) => Promise<void> | void): any {
+	return ((prompts: any[], context: any, config: any) => ({
+		async *[Symbol.asyncIterator]() {
+			// No streaming events needed for these tests.
+		},
+		result: async () => {
+			await handler(prompts, context, config);
+			return {};
+		},
+	})) as any;
+}
+
+describe("OBSERVATION_TIMESTAMP_PATTERN", () => {
+	it("matches local minute timestamps without regex shorthand escapes", () => {
+		expect(OBSERVATION_TIMESTAMP_PATTERN).not.toContain("\\d");
+		const pattern = new RegExp(OBSERVATION_TIMESTAMP_PATTERN);
+		expect(pattern.test("2026-05-02 10:30")).toBe(true);
+		expect(pattern.test("2026-5-02 10:30")).toBe(false);
+		expect(pattern.test("2026-05-02T10:30")).toBe(false);
+		expect(pattern.test("2026-05-02 10:30:00")).toBe(false);
+	});
+});
+
+describe("runObserver", () => {
+	const baseArgs = {
+		model: {} as any,
+		apiKey: "test",
+		priorReflections: [],
+		priorObservations: [],
+		chunk: "[Source entry id: entry-a]\nUser asked for a memory update.",
+		allowedSourceEntryIds: ["entry-a"],
+	};
+
+	it("keeps core observer prompt rules", async () => {
+		let systemPrompt = "";
+		const loop = fakeAgentLoop((_prompts, context) => {
+			systemPrompt = context.systemPrompt;
+		});
+
+		await runObserver({ ...baseArgs, agentLoop: loop });
+
+		expect(systemPrompt).toContain("Preserve user assertions exactly");
+		expect(systemPrompt).toContain("Detail preservation");
+		expect(systemPrompt).toContain("Frame state changes as supersession");
+		expect(systemPrompt).toContain("sourceEntryIds");
+		expect(systemPrompt).toContain("zero observations");
+		expect(systemPrompt).toContain("The dropper will drop these first");
+		expect(systemPrompt).toContain("highest-resistance, load-bearing observations");
+		expect(systemPrompt).not.toContain("will NEVER be dropped");
+		expect(systemPrompt).not.toContain("pruner");
+	});
+
+	it("records V3 observations with source ids and code-computed tokenCount", async () => {
+		const content = "User asked for a memory update.";
+		const loop = fakeAgentLoop(async (_prompts, context) => {
+			await context.tools[0].execute("tool-1", {
+				observations: [{ timestamp: "2026-05-02 10:30", content, relevance: "high", sourceEntryIds: ["entry-a"] }],
+			});
+		});
+
+		const result = await runObserver({ ...baseArgs, agentLoop: loop });
+		const observations = result.observations;
+
+		expect(observations).toHaveLength(1);
+		expect(observations?.[0]).toMatchObject({
+			content,
+			timestamp: "2026-05-02 10:30",
+			relevance: "high",
+			sourceEntryIds: ["entry-a"],
+			tokenCount: estimateStringTokens(content),
+		});
+		expect(observations?.[0].id).toMatch(/^[a-f0-9]{12}$/);
+	});
+
+	it("rejects invented source ids and returns no observations", async () => {
+		const loop = fakeAgentLoop(async (_prompts, context) => {
+			await context.tools[0].execute("tool-1", {
+				observations: [{ timestamp: "2026-05-02 10:30", content: "Bad source", relevance: "medium", sourceEntryIds: ["missing"] }],
+			});
+		});
+
+		const result = await runObserver({ ...baseArgs, agentLoop: loop });
+		expect(result.observations).toBeUndefined();
+	});
+
+	it("dedupes deterministic ids", async () => {
+		const loop = fakeAgentLoop(async (_prompts, context) => {
+			await context.tools[0].execute("tool-1", {
+				observations: [
+					{ timestamp: "2026-05-02 10:30", content: "Same content", relevance: "medium", sourceEntryIds: ["entry-a"] },
+					{ timestamp: "2026-05-02 10:31", content: "Same content", relevance: "high", sourceEntryIds: ["entry-a"] },
+				],
+			});
+		});
+
+		const result = await runObserver({ ...baseArgs, agentLoop: loop });
+		const observations = result.observations;
+
+		expect(observations).toHaveLength(1);
+		expect(observations?.[0].content).toBe("Same content");
+	});
+
+	it("returns undefined when no tool call records observations", async () => {
+		const loop = fakeAgentLoop(() => {});
+		const result = await runObserver({ ...baseArgs, agentLoop: loop });
+		expect(result.observations).toBeUndefined();
+	});
+
+	it("uses maxTurns as an observer turn cap", async () => {
+		let shouldStopAfterTurn: any;
+		const loop = fakeAgentLoop((_prompts, _context, config) => {
+			shouldStopAfterTurn = config.shouldStopAfterTurn;
+		});
+
+		await runObserver({ ...baseArgs, agentLoop: loop, maxTurns: 2 });
+
+		expect(shouldStopAfterTurn).toBeTypeOf("function");
+		expect(shouldStopAfterTurn({})).toBe(false);
+		expect(shouldStopAfterTurn({})).toBe(true);
+	});
+
+	it("uses configured observer thinking level for reasoning models", async () => {
+		let seenReasoning: unknown;
+		const loop = fakeAgentLoop((_prompts, _context, config) => {
+			seenReasoning = config.reasoning;
+		});
+
+		await runObserver({ ...baseArgs, model: { reasoning: true } as any, agentLoop: loop, thinkingLevel: "minimal" });
+
+		expect(seenReasoning).toBe("minimal");
+	});
+
+	it("omits observer reasoning when thinkingLevel is off", async () => {
+		let seenReasoning: unknown = "unset";
+		const loop = fakeAgentLoop((_prompts, _context, config) => {
+			seenReasoning = config.reasoning;
+		});
+
+		await runObserver({ ...baseArgs, model: { reasoning: true } as any, agentLoop: loop, thinkingLevel: "off" });
+
+		expect(seenReasoning).toBeUndefined();
+	});
+});
+
+describe("normalizeSourceEntryIds", () => {
+	const allowed = ["entry-a", "entry-b", "entry-c"];
+
+	it("accepts source ids from the allowed chunk and orders them by branch order", () => {
+		expect(normalizeSourceEntryIds(["entry-c", "entry-a"], allowed)).toEqual(["entry-a", "entry-c"]);
+	});
+
+	it("dedupes repeated source ids", () => {
+		expect(normalizeSourceEntryIds(["entry-b", "entry-b", "entry-a"], allowed)).toEqual(["entry-a", "entry-b"]);
+	});
+
+	it("rejects missing, empty, or hallucinated source ids", () => {
+		expect(normalizeSourceEntryIds(undefined, allowed)).toBeUndefined();
+		expect(normalizeSourceEntryIds([], allowed)).toBeUndefined();
+		expect(normalizeSourceEntryIds(["entry-a", "not-in-the-chunk"], allowed)).toBeUndefined();
+		expect(normalizeSourceEntryIds(["entry-a"], [])).toBeUndefined();
+	});
+});

--- a/tests/reflector.test.ts
+++ b/tests/reflector.test.ts
@@ -1,0 +1,220 @@
+/**
+ * Reflector agent tests — ported from upstream pi-observational-memory.
+ *
+ * Upstream: https://github.com/elpapi42/pi-observational-memory (tests/reflector.test.ts)
+ * Ported with import paths adjusted for om/ layout.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+	normalizeSupportingObservationIds,
+	observationToReflectorLine,
+	runReflector,
+	summarizeSupportIdCounts,
+} from "../src/om/agents/reflector/agent.js";
+import { hashId } from "../src/om/ids.js";
+import { estimateStringTokens } from "../src/om/tokens.js";
+import { observation, reflection } from "./fixtures/session.js";
+
+function fakeAgentLoop(handler: (prompts: any[], context: any, config: any) => Promise<void> | void): any {
+	return ((prompts: any[], context: any, config: any) => ({
+		async *[Symbol.asyncIterator]() {},
+		result: async () => {
+			await handler(prompts, context, config);
+			return {};
+		},
+	})) as any;
+}
+
+describe("V3 reflector agent", () => {
+	const obsA = observation("aaaaaaaaaaaa");
+	const obsB = observation("bbbbbbbbbbbb");
+	const baseArgs = {
+		model: {} as any,
+		apiKey: "test",
+		reflections: [],
+		observations: [obsA, obsB],
+	};
+
+	it("keeps core reflector prompt guidance in V3 terms", async () => {
+		let systemPrompt = "";
+		const loop = fakeAgentLoop((_prompts, context) => {
+			systemPrompt = context.systemPrompt;
+		});
+
+		await runReflector({ ...baseArgs, agentLoop: loop });
+
+		expect(systemPrompt).toContain("Your task is different from the observer");
+		expect(systemPrompt).toContain("User assertions are authoritative");
+		expect(systemPrompt).toContain("supportingObservationIds");
+		expect(systemPrompt).toContain("coverage/provenance set");
+		expect(systemPrompt).toContain("Do not lightly reword existing reflections");
+		expect(systemPrompt).toContain("Reflections are scarce, expensive durable orientation anchors");
+		expect(systemPrompt).toContain("not a second observation layer");
+		expect(systemPrompt).toContain("Over-reflection is also memory distortion");
+		expect(systemPrompt).toContain("makes transient details look durable");
+		expect(systemPrompt).toContain("Decision procedure:");
+		expect(systemPrompt).toContain("First reject observations that are transient, low-level, partial, routine, or only useful as current working state");
+		expect(systemPrompt).toContain("future-agent utility test");
+		expect(systemPrompt).toContain("avoid a wrong decision, repeated work, or user-preference violation");
+		expect(systemPrompt).toContain("If the candidate fails that future-agent utility test, leave it as an observation");
+		expect(systemPrompt).toContain("If unsure, emit no reflection");
+		expect(systemPrompt).toContain("High and critical observations deserve careful review, not automatic reflection");
+		expect(systemPrompt).toContain("Do not turn each observation into a reflection");
+		expect(systemPrompt).toContain("Observations are evidence; reflections are compressed durable conclusions");
+		expect(systemPrompt).toContain("Single-observation reflections are allowed");
+		expect(systemPrompt).toContain("durable user preference, constraint, correction, decision, invariant, completed outcome, or long-lived blocker");
+		expect(systemPrompt).toContain("Do not copy or lightly paraphrase observation lines");
+		expect(systemPrompt).toContain("Prefer fewer, higher-value reflections");
+		expect(systemPrompt).toContain("zero reflections than to create one reflection per observation");
+		expect(systemPrompt).toContain("Most transient task-log observations");
+		expect(systemPrompt).toContain("files inspected, commands run, failed attempts, partial implementation, and current working state");
+		expect(systemPrompt).toContain("[coverage: none|partial|strong]");
+		expect(systemPrompt).toContain("Coverage tiers are review context");
+		expect(systemPrompt).toContain("Coverage is not a quota, target, priority score, or instruction to emit reflections");
+		expect(systemPrompt).toContain("Support ids and coverage stewardship");
+		expect(systemPrompt).toContain("First decide whether the reflection content passes the durable-value bar");
+		expect(systemPrompt).toContain("include all current observation ids whose durable meaning is preserved");
+		expect(systemPrompt).toContain("supportingObservationIds are not a checklist");
+		expect(systemPrompt).toContain("Do not add ids merely to improve coverage counts");
+		expect(systemPrompt).toContain("False or inflated support ids can cause unsafe downstream dropper pruning");
+		expect(systemPrompt).toContain("emit zero reflections even when observations have coverage: none");
+		expect(systemPrompt).toContain("BAD: completed: edited src/hooks/reflect-drop-trigger.ts");
+		expect(systemPrompt).toContain("GOOD: completed: V3 reflect/drop coverage now uses raw progress watermarks");
+		expect(systemPrompt).toContain("BAD: npm test passed");
+		expect(systemPrompt).toContain("GOOD: completed: V3 package namespace migration passed full tests and typecheck");
+		expect(systemPrompt).toContain("ZERO REFLECTIONS: The only new observations are files inspected, commands run, failed attempts, partial implementation, transient debugging, or current working state with no durable conclusion yet");
+		expect(systemPrompt).toContain("Focus on:");
+		expect(systemPrompt).toContain("User identity, role, preferences, constraints");
+		expect(systemPrompt).toContain("Project goals, architecture, technical decisions");
+		expect(systemPrompt).toContain("Recurring user behavior or preferences");
+		expect(systemPrompt).toContain("Completed outcomes future runs must not redo");
+		expect(systemPrompt).toContain("Durable blockers, invariants, and open decisions");
+		expect(systemPrompt).toContain("Reflection content rules");
+		expect(systemPrompt).toContain("Lead with the fact or pattern");
+		expect(systemPrompt).not.toContain("legacy/no-provenance");
+		expect(systemPrompt).not.toContain("pruner");
+		expect(systemPrompt).not.toContain("Pass strategy");
+	});
+
+	it("renders coverage tiers in every active observation line for the reflector", async () => {
+		const none = observation("aaaaaaaaaaaa", { content: "Uncovered durable fact" });
+		const partial = observation("bbbbbbbbbbbb", { content: "Partially covered fact" });
+		const strong = observation("cccccccccccc", { content: "Strongly covered fact" });
+		let userText = "";
+		const loop = fakeAgentLoop((prompts) => {
+			userText = prompts[0].content[0].text;
+		});
+
+		await runReflector({
+			...baseArgs,
+			observations: [none, partial, strong],
+			reflections: [
+				reflection("rrrrrrrrrrr1", ["bbbbbbbbbbbb", "cccccccccccc"]),
+				reflection("rrrrrrrrrrr2", ["cccccccccccc"]),
+			],
+			agentLoop: loop,
+		});
+
+		expect(userText).toContain("[aaaaaaaaaaaa]");
+		expect(userText).toContain("Uncovered durable fact");
+		expect(userText).toContain("Partially covered fact");
+		expect(userText).toContain("Strongly covered fact");
+		// pi-blackhole reflector uses observationToSummaryLine without coverage display
+		// Coverage in observation lines is tested in dropper-coverage.test.ts
+		expect(userText).not.toContain("drop-priority");
+		expect(userText).not.toContain("drop-resistance");
+	});
+
+	it("renders reflector observation lines with coverage evidence only", () => {
+		const line = observationToReflectorLine(
+			observation("aaaaaaaaaaaa", { relevance: "critical", content: "Important reflected fact" }),
+			"partial",
+		);
+
+		expect(line).toContain("[aaaaaaaaaaaa]");
+		expect(line).toContain("[critical]");
+		expect(line).toContain("[coverage: partial]");
+		expect(line).toContain("Important reflected fact");
+		expect(line).not.toContain("drop-priority");
+		expect(line).not.toContain("drop-resistance");
+	});
+
+	it("summarizes accepted reflection support-id counts without exposing ids", () => {
+		expect(summarizeSupportIdCounts([])).toEqual({
+			reflectionCount: 0,
+			totalSupportIds: 0,
+			minSupportIds: 0,
+			maxSupportIds: 0,
+			averageSupportIds: 0,
+			histogram: {},
+		});
+		expect(summarizeSupportIdCounts([
+			reflection("rrrrrrrrrrr1", ["aaaaaaaaaaaa"]),
+			reflection("rrrrrrrrrrr2", ["aaaaaaaaaaaa", "bbbbbbbbbbbb", "cccccccccccc"]),
+		])).toEqual({
+			reflectionCount: 2,
+			totalSupportIds: 4,
+			minSupportIds: 1,
+			maxSupportIds: 3,
+			averageSupportIds: 2,
+			histogram: { "1": 1, "3": 1 },
+		});
+	});
+
+	it("normalizes supporting observation ids by active observation order", () => {
+		expect(normalizeSupportingObservationIds(["bbbbbbbbbbbb", "aaaaaaaaaaaa", "aaaaaaaaaaaa"], ["aaaaaaaaaaaa", "bbbbbbbbbbbb"])).toEqual(["aaaaaaaaaaaa", "bbbbbbbbbbbb"]);
+		expect(normalizeSupportingObservationIds(["aaaaaaaaaaaa", "missing"], ["aaaaaaaaaaaa"])).toBeUndefined();
+		expect(normalizeSupportingObservationIds([], ["aaaaaaaaaaaa"])).toBeUndefined();
+	});
+
+	it("records one-line V3 reflections with code-computed ids and token counts", async () => {
+		const content = "User prefers source-backed memory.";
+		const loop = fakeAgentLoop(async (_prompts, context) => {
+			await context.tools[0].execute("tool-1", {
+				reflections: [{ content, supportingObservationIds: ["bbbbbbbbbbbb", "aaaaaaaaaaaa"] }],
+			});
+		});
+
+		const result = await runReflector({ ...baseArgs, agentLoop: loop });
+
+		expect(result).toEqual([{ id: hashId(content), content, supportingObservationIds: ["aaaaaaaaaaaa", "bbbbbbbbbbbb"], tokenCount: estimateStringTokens(content) }]);
+	});
+
+	it("rejects invented support ids and multiline content", async () => {
+		const loop = fakeAgentLoop(async (_prompts, context) => {
+			await context.tools[0].execute("tool-1", {
+				reflections: [
+					{ content: "Bad support", supportingObservationIds: ["missing"] },
+					{ content: "Two\nlines", supportingObservationIds: ["aaaaaaaaaaaa"] },
+				],
+			});
+		});
+
+		await expect(runReflector({ ...baseArgs, agentLoop: loop })).resolves.toBeUndefined();
+	});
+
+	it("dedupes proposals and skips existing reflection ids", async () => {
+		const content = "User prefers terse updates.";
+		const existing = reflection(hashId(content), ["aaaaaaaaaaaa"], { content });
+		const loop = fakeAgentLoop(async (_prompts, context) => {
+			await context.tools[0].execute("tool-1", {
+				reflections: [
+					{ content, supportingObservationIds: ["aaaaaaaaaaaa"] },
+					{ content: "New durable fact.", supportingObservationIds: ["aaaaaaaaaaaa"] },
+					{ content: "New durable fact.", supportingObservationIds: ["bbbbbbbbbbbb"] },
+				],
+			});
+		});
+
+		const result = await runReflector({ ...baseArgs, reflections: [existing], agentLoop: loop });
+
+		expect(result?.map((item) => item.content)).toEqual(["New durable fact."]);
+	});
+
+	it("returns undefined when no tool call records reflections", async () => {
+		const loop = fakeAgentLoop(() => {});
+		await expect(runReflector({ ...baseArgs, agentLoop: loop })).resolves.toBeUndefined();
+	});
+});

--- a/tests/session-ledger-fold.test.ts
+++ b/tests/session-ledger-fold.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Ported from upstream pi-observational-memory
+ * Changes: import path from session-ledger/ → om/ledger/
+ *
+ * Tests V3 ledger folding — observations, reflections, drops, and dedup.
+ */
+import { describe, expect, it } from "vitest";
+
+import { foldLedger } from "../src/om/ledger/index.js";
+import {
+	branchSummary,
+	observation,
+	observationsDroppedEntry,
+	observationsRecordedEntry,
+	oldV2ObservationEntry,
+	reflection,
+	reflectionsRecordedEntry,
+	textCustomMessage,
+} from "./fixtures/session.js";
+
+describe("session-ledger V3 folding", () => {
+	it("folds observations and reflections from branch root through the target entry", () => {
+		const obs1 = observation("aaaaaaaaaaaa", { sourceEntryIds: ["raw-1"] });
+		const obs2 = observation("bbbbbbbbbbbb", { sourceEntryIds: ["raw-2"] });
+		const ref1 = reflection("eeeeeeeeeeee", ["aaaaaaaaaaaa"]);
+		const entries = [
+			textCustomMessage("raw-1", "aaaa"),
+			observationsRecordedEntry("om-aaaaaaaaaaaa", { observations: [obs1], coversUpToId: "raw-1" }),
+			textCustomMessage("raw-2", "bbbb"),
+			reflectionsRecordedEntry("om-eeeeeeeeeeee", { reflections: [ref1], coversUpToId: "raw-2" }),
+			observationsRecordedEntry("om-bbbbbbbbbbbb", { observations: [obs2], coversUpToId: "raw-2" }),
+		];
+
+		const folded = foldLedger(entries, { upToEntryId: "om-eeeeeeeeeeee" });
+
+		expect(folded.observations.map((obs) => obs.id)).toEqual(["aaaaaaaaaaaa"]);
+		expect(folded.activeObservations.map((obs) => obs.id)).toEqual(["aaaaaaaaaaaa"]);
+		expect(folded.reflections.map((ref) => ref.id)).toEqual(["eeeeeeeeeeee"]);
+		expect(folded.observationsById.get("bbbbbbbbbbbb")).toBeUndefined();
+	});
+
+	it("applies drops as tombstones while preserving observation history", () => {
+		const obs1 = observation("aaaaaaaaaaaa");
+		const obs2 = observation("bbbbbbbbbbbb");
+		const entries = [
+			textCustomMessage("raw-1", "aaaa"),
+			observationsRecordedEntry("om-aaaaaaaaaaaa", { observations: [obs1, obs2], coversUpToId: "raw-1" }),
+			observationsDroppedEntry("om-drop-1", { observationIds: ["aaaaaaaaaaaa"], coversUpToId: "raw-1" }),
+		];
+
+		const folded = foldLedger(entries);
+
+		expect(folded.observations.map((obs) => obs.id)).toEqual(["aaaaaaaaaaaa", "bbbbbbbbbbbb"]);
+		expect(folded.activeObservations.map((obs) => obs.id)).toEqual(["bbbbbbbbbbbb"]);
+		expect(folded.droppedObservationIds.has("aaaaaaaaaaaa")).toBe(true);
+		expect(folded.observationsById.get("aaaaaaaaaaaa")).toEqual(obs1);
+	});
+
+	it("keeps first valid observation and reflection when duplicate ids appear", () => {
+		const firstObs = observation("aaaaaaaaaaaa", { content: "first observation" });
+		const duplicateObs = observation("aaaaaaaaaaaa", { content: "duplicate observation" });
+		const firstRef = reflection("eeeeeeeeeeee", ["aaaaaaaaaaaa"], { content: "first reflection" });
+		const duplicateRef = reflection("eeeeeeeeeeee", ["aaaaaaaaaaaa"], { content: "duplicate reflection" });
+		const entries = [
+			textCustomMessage("raw-1", "aaaa"),
+			observationsRecordedEntry("om-aaaaaaaaaaaa", { observations: [firstObs], coversUpToId: "raw-1" }),
+			observationsRecordedEntry("om-bbbbbbbbbbbb", { observations: [duplicateObs], coversUpToId: "raw-1" }),
+			reflectionsRecordedEntry("om-eeeeeeeeeeee", { reflections: [firstRef], coversUpToId: "raw-1" }),
+			reflectionsRecordedEntry("om-ffffffffffff", { reflections: [duplicateRef], coversUpToId: "raw-1" }),
+		];
+
+		const folded = foldLedger(entries);
+
+		expect(folded.observationsById.get("aaaaaaaaaaaa")?.content).toBe("first observation");
+		expect(folded.reflectionsById.get("eeeeeeeeeeee")?.content).toBe("first reflection");
+		expect(folded.observations).toHaveLength(1);
+		expect(folded.reflections).toHaveLength(1);
+	});
+
+	it("retains tombstones for unknown drop ids without throwing", () => {
+		const entries = [
+			textCustomMessage("raw-1", "aaaa"),
+			observationsDroppedEntry("om-drop-1", { observationIds: ["deadbeef0000"], coversUpToId: "raw-1" }),
+		];
+
+		const folded = foldLedger(entries);
+
+		expect(folded.droppedObservationIds.has("deadbeef0000")).toBe(true);
+		expect(folded.activeObservations).toEqual([]);
+	});
+
+	it("ignores old V2 entries and unknown custom entries", () => {
+		const entries = [
+			textCustomMessage("raw-1", "aaaa"),
+			oldV2ObservationEntry("v2-obs"),
+			{ type: "custom", id: "unknown", parentId: null, timestamp: "2026-05-02T10:00:00.000Z", customType: "other.memory", data: { any: true } },
+		];
+
+		const folded = foldLedger(entries);
+
+		expect(folded.observations).toEqual([]);
+		expect(folded.reflections).toEqual([]);
+		expect(folded.activeObservations).toEqual([]);
+	});
+
+	it("folds only the branch path supplied by the caller", () => {
+		const obs1 = observation("aaaaaaaaaaaa", { sourceEntryIds: ["raw-1"] });
+		const obs2 = observation("bbbbbbbbbbbb", { sourceEntryIds: ["raw-2"] });
+		const entriesA = [
+			textCustomMessage("raw-1", "aaaa"),
+			observationsRecordedEntry("om-aaaaaaaaaaaa", { observations: [obs1], coversUpToId: "raw-1" }),
+		];
+		const entriesB = [
+			textCustomMessage("raw-2", "bbbb"),
+			observationsRecordedEntry("om-bbbbbbbbbbbb", { observations: [obs2], coversUpToId: "raw-2" }),
+		];
+
+		// Each branch is folded independently
+		const foldedA = foldLedger(entriesA);
+		const foldedB = foldLedger(entriesB);
+
+		expect(foldedA.observations.map((o) => o.id)).toEqual(["aaaaaaaaaaaa"]);
+		expect(foldedB.observations.map((o) => o.id)).toEqual(["bbbbbbbbbbbb"]);
+	});
+});

--- a/tests/session-ledger-progress.test.ts
+++ b/tests/session-ledger-progress.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Ported from upstream pi-observational-memory
+ * Changes: import path from session-ledger/ → om/ledger/
+ *
+ * Tests V3 progress helpers — token counting, coverage tracking, index lookups.
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+	earlierCoverageMarkerId,
+	entryIndexById,
+	isSourceEntry,
+	latestCoverageIndex,
+	latestCoverageMarkerId,
+	rawTokensAfterIndex,
+	rawTokensSinceDropCoverage,
+	rawTokensSinceLastCompaction,
+	rawTokensSinceObservationCoverage,
+	rawTokensSinceReflectionCoverage,
+} from "../src/om/ledger/index.js";
+import {
+	V3_OBSERVATIONS_DROPPED,
+	V3_OBSERVATIONS_RECORDED,
+	V3_REFLECTIONS_RECORDED,
+	branchSummary,
+	compactionEntry,
+	observation,
+	observationsDroppedEntry,
+	observationsRecordedEntry,
+	oldV2ObservationEntry,
+	reflection,
+	reflectionsRecordedEntry,
+	textCustomMessage,
+} from "./fixtures/session.js";
+
+describe("session-ledger V3 progress helpers", () => {
+	it("detects only raw/source entries as source entries", () => {
+		expect(isSourceEntry(textCustomMessage("raw-1", "abcd"))).toBe(true);
+		expect(isSourceEntry(branchSummary("sum-1", "abcd"))).toBe(true);
+		expect(isSourceEntry(observationsRecordedEntry("om-1", {
+			observations: [observation("aaaaaaaaaaaa")],
+			coversUpToId: "raw-1",
+		}))).toBe(false);
+		expect(isSourceEntry(compactionEntry("cmp-1"))).toBe(false);
+	});
+
+	it("builds a branch id to index map", () => {
+		const entries = [textCustomMessage("raw-1", "abcd"), textCustomMessage("raw-2", "efgh")];
+		expect(entryIndexById(entries).get("raw-1")).toBe(0);
+		expect(entryIndexById(entries).get("raw-2")).toBe(1);
+	});
+
+	it("counts raw tokens after a branch index and ignores memory/compaction entries", () => {
+		const entries = [
+			textCustomMessage("raw-1", "aaaa"),
+			observationsRecordedEntry("om-1", { observations: [observation("aaaaaaaaaaaa")], coversUpToId: "raw-1" }),
+			textCustomMessage("raw-2", "bbbbbbbb"),
+			compactionEntry("cmp-1", { firstKeptEntryId: "raw-2" }),
+			branchSummary("sum-1", "cccccccccccc"),
+		];
+
+		expect(rawTokensAfterIndex(entries, 0)).toBe(5); // raw-2: 2 + sum-1: 3
+		expect(rawTokensAfterIndex(entries, 1)).toBe(5);
+		expect(rawTokensAfterIndex(entries, 2)).toBe(3);
+	});
+
+	it("uses independent coverage clocks for observations, reflections, and drops", () => {
+		const entries = [
+			textCustomMessage("raw-1", "aaaa"),
+			observationsRecordedEntry("om-aaaaaaaaaaaa", { observations: [observation("aaaaaaaaaaaa")], coversUpToId: "raw-1" }),
+			textCustomMessage("raw-2", "bbbbbbbb"),
+			reflectionsRecordedEntry("om-eeeeeeeeeeee", { reflections: [reflection("eeeeeeeeeeee", ["aaaaaaaaaaaa"])], coversUpToId: "raw-2" }),
+			textCustomMessage("raw-3", "cccccccccccc"),
+			observationsDroppedEntry("om-drop-1", { observationIds: ["aaaaaaaaaaaa"], coversUpToId: "om-eeeeeeeeeeee" }),
+			textCustomMessage("raw-4", "dddddddddddddddd"),
+		];
+
+		expect(rawTokensSinceObservationCoverage(entries)).toBe(9); // raw-2 + raw-3 + raw-4
+		expect(rawTokensSinceReflectionCoverage(entries)).toBe(7); // raw-3 + raw-4
+		expect(rawTokensSinceDropCoverage(entries)).toBe(7); // covers ledger entry om-eeeeeeeeeeee, raw after it
+	});
+
+	it("lets coversUpToId point to a memory ledger entry", () => {
+		const entries = [
+			textCustomMessage("raw-1", "aaaa"),
+			reflectionsRecordedEntry("om-eeeeeeeeeeee", { reflections: [reflection("eeeeeeeeeeee", ["aaaaaaaaaaaa"])], coversUpToId: "raw-1" }),
+			observationsDroppedEntry("om-drop-1", { observationIds: ["aaaaaaaaaaaa"], coversUpToId: "om-eeeeeeeeeeee" }),
+			textCustomMessage("raw-2", "bbbbbbbb"),
+		];
+
+		expect(latestCoverageIndex(entries, V3_OBSERVATIONS_DROPPED)).toBe(1);
+		expect(rawTokensSinceDropCoverage(entries)).toBe(2);
+	});
+
+	it("chooses the max covered branch position, not merely latest ledger entry order", () => {
+		const entries = [
+			textCustomMessage("raw-1", "aaaa"),
+			textCustomMessage("raw-2", "bbbbbbbb"),
+			observationsRecordedEntry("om-aaaaaaaaaaaa", { observations: [observation("aaaaaaaaaaaa")], coversUpToId: "raw-2" }),
+			observationsRecordedEntry("om-bbbbbbbbbbbb", { observations: [observation("bbbbbbbbbbbb")], coversUpToId: "raw-1" }),
+			textCustomMessage("raw-3", "cccccccccccc"),
+		];
+
+		expect(latestCoverageIndex(entries, V3_OBSERVATIONS_RECORDED)).toBe(1);
+		expect(latestCoverageMarkerId(entries, V3_OBSERVATIONS_RECORDED)).toBe("raw-2");
+		expect(rawTokensSinceObservationCoverage(entries)).toBe(3);
+	});
+
+	it("returns latest inner coverage marker and earlier marker by branch index", () => {
+		const entries = [
+			textCustomMessage("raw-1", "aaaa"),
+			textCustomMessage("raw-2", "bbbbbbbb"),
+			textCustomMessage("raw-3", "cccccccccccc"),
+			observationsRecordedEntry("om-obs", { observations: [observation("aaaaaaaaaaaa")], coversUpToId: "raw-3" }),
+			reflectionsRecordedEntry("om-ref", { reflections: [reflection("eeeeeeeeeeee", ["aaaaaaaaaaaa"])], coversUpToId: "raw-2" }),
+		];
+
+		expect(latestCoverageMarkerId(entries, V3_OBSERVATIONS_RECORDED)).toBe("raw-3");
+		expect(latestCoverageMarkerId(entries, V3_REFLECTIONS_RECORDED)).toBe("raw-2");
+		expect(earlierCoverageMarkerId(entries, "raw-3", "raw-2")).toBe("raw-2");
+		expect(earlierCoverageMarkerId(entries, "raw-1", undefined)).toBe("raw-1");
+		expect(earlierCoverageMarkerId(entries, "missing", "raw-2")).toBe("raw-2");
+		expect(earlierCoverageMarkerId(entries, "missing-a", "missing-b")).toBeUndefined();
+	});
+
+	it("ignores invalid coverage markers and old V2 markers without throwing", () => {
+		const entries = [
+			textCustomMessage("raw-1", "aaaa"),
+			oldV2ObservationEntry("v2-obs"),
+			observationsRecordedEntry("om-obs-invalid", { observations: [observation("aaaaaaaaaaaa")], coversUpToId: "missing" }),
+			textCustomMessage("raw-2", "bbbbbbbb"),
+		];
+
+		expect(() => rawTokensSinceObservationCoverage(entries)).not.toThrow();
+		expect(rawTokensSinceObservationCoverage(entries)).toBe(3);
+		expect(latestCoverageIndex(entries, V3_REFLECTIONS_RECORDED)).toBe(-1);
+	});
+
+	it("counts raw tokens since the latest Pi compaction without throwing on old memory details", () => {
+		const entries = [
+			textCustomMessage("raw-1", "aaaa"),
+			compactionEntry("cmp-1", { firstKeptEntryId: "raw-1" }),
+			oldV2ObservationEntry("v2-obs"),
+			textCustomMessage("raw-2", "bbbbbbbb"),
+		];
+
+		expect(rawTokensSinceLastCompaction(entries)).toBe(3); // raw-1 + raw-2 from live tail starting at firstKeptEntryId
+	});
+});

--- a/tests/session-ledger-types.test.ts
+++ b/tests/session-ledger-types.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Session ledger type guards and builders — ported from upstream pi-observational-memory.
+ *
+ * Upstream: https://github.com/elpapi42/pi-observational-memory (tests/session-ledger-types.test.ts)
+ * Ported with import path adjusted: session-ledger/ → om/ledger/.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+	OM_FOLDED,
+	OM_OBSERVATIONS_DROPPED,
+	OM_OBSERVATIONS_RECORDED,
+	OM_REFLECTIONS_RECORDED,
+	buildObservationsDroppedData,
+	buildObservationsRecordedData,
+	buildReflectionsRecordedData,
+	isMemoryDetails,
+	isObservationsDroppedData,
+	isObservationsDroppedEntry,
+	isObservationsRecordedData,
+	isObservationsRecordedEntry,
+	isObservation,
+	isReflection,
+	isReflectionsRecordedData,
+	isReflectionsRecordedEntry,
+} from "../src/om/ledger/index.js";
+import {
+	memoryDetails,
+	observation,
+	observationsDroppedEntry,
+	observationsRecordedEntry,
+	oldV2CompactionDetails,
+	oldV2ObservationEntry,
+	reflection,
+	reflectionsRecordedEntry,
+} from "./fixtures/session.js";
+
+describe("session-ledger V3 type guards and builders", () => {
+	it("exports the V3 custom type constants", () => {
+		expect(OM_OBSERVATIONS_RECORDED).toBe("om.observations.recorded");
+		expect(OM_REFLECTIONS_RECORDED).toBe("om.reflections.recorded");
+		expect(OM_OBSERVATIONS_DROPPED).toBe("om.observations.dropped");
+		expect(OM_FOLDED).toBe("om.folded");
+	});
+
+	it("accepts valid V3 observation records and rejects observations without source ids", () => {
+		expect(isObservation(observation("aaaaaaaaaaaa"))).toBe(true);
+		expect(isObservation({ ...observation("bbbbbbbbbbbb"), sourceEntryIds: [] })).toBe(false);
+		expect(isObservation({ ...observation("cccccccccccc"), sourceEntryIds: undefined })).toBe(false);
+		expect(isObservation({ ...observation("dddddddddddd"), tokenCount: undefined })).toBe(false);
+	});
+
+	it("accepts valid V3 reflection records", () => {
+		expect(isReflection(reflection("eeeeeeeeeeee", ["aaaaaaaaaaaa"]))).toBe(true);
+		expect(isReflection({ ...reflection("ffffffffffff"), supportingObservationIds: undefined })).toBe(false);
+		expect(isReflection({ ...reflection("111111111111"), tokenCount: undefined })).toBe(false);
+	});
+
+	it("accepts non-empty V3 ledger entry data", () => {
+		const obsData = { observations: [observation("aaaaaaaaaaaa")], coversUpToId: "raw-1" };
+		const refData = { reflections: [reflection("eeeeeeeeeeee", ["aaaaaaaaaaaa"])], coversUpToId: "raw-2" };
+		const dropData = { observationIds: ["aaaaaaaaaaaa"], coversUpToId: "ref-entry-1" };
+
+		expect(isObservationsRecordedData(obsData)).toBe(true);
+		expect(isReflectionsRecordedData(refData)).toBe(true);
+		expect(isObservationsDroppedData(dropData)).toBe(true);
+	});
+
+	it("rejects empty ledger entry data so no empty progress entries can be appended", () => {
+		expect(isObservationsRecordedData({ observations: [], coversUpToId: "raw-1" })).toBe(false);
+		expect(isReflectionsRecordedData({ reflections: [], coversUpToId: "raw-1" })).toBe(false);
+		expect(isObservationsDroppedData({ observationIds: [], coversUpToId: "raw-1" })).toBe(false);
+	});
+
+	it("builders return undefined for empty arrays and data for non-empty arrays", () => {
+		expect(buildObservationsRecordedData([], "raw-1")).toBeUndefined();
+		expect(buildReflectionsRecordedData([], "raw-1")).toBeUndefined();
+		expect(buildObservationsDroppedData([], "raw-1")).toBeUndefined();
+
+		expect(buildObservationsRecordedData([observation("aaaaaaaaaaaa")], "raw-1")).toEqual({
+			observations: [observation("aaaaaaaaaaaa")],
+			coversUpToId: "raw-1",
+		});
+		expect(buildReflectionsRecordedData([reflection("eeeeeeeeeeee", ["aaaaaaaaaaaa"])], "raw-1")).toEqual({
+			reflections: [reflection("eeeeeeeeeeee", ["aaaaaaaaaaaa"])],
+			coversUpToId: "raw-1",
+		});
+		expect(buildObservationsDroppedData(["aaaaaaaaaaaa"], "ref-entry-1")).toEqual({
+			observationIds: ["aaaaaaaaaaaa"],
+			coversUpToId: "ref-entry-1",
+		});
+	});
+
+	it("recognizes V3 memory entries", () => {
+		expect(isObservationsRecordedEntry(observationsRecordedEntry("om-aaaaaaaaaaaa", {
+			observations: [observation("aaaaaaaaaaaa")],
+			coversUpToId: "raw-1",
+		}))).toBe(true);
+		expect(isReflectionsRecordedEntry(reflectionsRecordedEntry("om-eeeeeeeeeeee", {
+			reflections: [reflection("eeeeeeeeeeee", ["aaaaaaaaaaaa"])],
+			coversUpToId: "raw-1",
+		}))).toBe(true);
+		expect(isObservationsDroppedEntry(observationsDroppedEntry("om-drop-1", {
+			observationIds: ["aaaaaaaaaaaa"],
+			coversUpToId: "om-eeeeeeeeeeee",
+		}))).toBe(true);
+	});
+
+	it("accepts flat V3 folded memory details", () => {
+		expect(isMemoryDetails(memoryDetails({
+			fullFold: true,
+			observations: [observation("aaaaaaaaaaaa")],
+			reflections: [reflection("eeeeeeeeeeee", ["aaaaaaaaaaaa"])],
+		}))).toBe(true);
+	});
+
+	it("ignores old V2 observation entries and old V2 compaction details", () => {
+		expect(isObservationsRecordedEntry(oldV2ObservationEntry("v2-entry"))).toBe(false);
+		expect(isMemoryDetails(oldV2CompactionDetails())).toBe(false);
+	});
+});

--- a/tests/vcc-before-compact-hook.test.ts
+++ b/tests/vcc-before-compact-hook.test.ts
@@ -1,0 +1,197 @@
+/**
+ * Ported from upstream pi-vcc
+ * Changes:
+ *   - bun:test → vitest, .js extensions
+ *   - Adapted for blackhole's registerBeforeCompactHook which requires omRuntime param
+ *   - Added mockRuntime with ensureConfig that reads our config format
+ *   - Removed PI_VCC_CONFIG_PATH env var (blackhole uses unified config)
+ */
+import { describe, test, expect, beforeEach, afterEach, beforeAll, afterAll, vi } from "vitest";
+import { existsSync, unlinkSync, writeFileSync, readFileSync, mkdtempSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { registerBeforeCompactHook, PI_VCC_COMPACT_INSTRUCTION } from "../src/hooks/before-compact.js";
+
+let tmpDir: string;
+let CONFIG_PATH: string;
+const DEBUG_PATH = "/tmp/pi-blackhole-debug.json";
+
+beforeAll(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "pi-vcc-test-"));
+  CONFIG_PATH = join(tmpDir, "blackhole-config.json");
+});
+
+afterAll(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+// Minimal ExtensionAPI stub: capture handler + provide ctx with mocked ui.notify
+function createMockPi() {
+  let handler: ((event: any, ctx: any) => any) | undefined;
+  const notifyCalls: Array<{ msg: string; level: string }> = [];
+  const config = {
+    overrideDefaultCompaction: false,
+    noAutoCompact: false,
+  };
+  const ctx = {
+    cwd: tmpDir,
+    hasUI: true,
+    ui: {
+      notify: (msg: string, level: string) => {
+        notifyCalls.push({ msg, level });
+      },
+    },
+  };
+  const omRuntime = {
+    ensureConfig: vi.fn(() => {}),
+    config,
+  };
+  return {
+    pi: {
+      on: (eventName: string, h: (e: any, c: any) => any) => {
+        if (eventName === "session_before_compact") handler = h;
+      },
+    } as any,
+    invoke: (event: any) => handler!(event, ctx),
+    notifyCalls,
+    omRuntime,
+    config,
+  };
+}
+
+function makeEvent(branchEntries: any[], customInstructions?: string) {
+  return {
+    type: "session_before_compact",
+    customInstructions,
+    branchEntries,
+    preparation: {
+      previousSummary: undefined,
+      fileOps: { read: [], written: [], edited: [] },
+      tokensBefore: 1000,
+    },
+    signal: new AbortController().signal,
+  };
+}
+
+const msg = (id: string, role: "user" | "assistant" | "toolResult", content = "x") => ({
+  id,
+  type: "message",
+  message: { role, content },
+});
+const comp = (id: string, firstKeptEntryId?: string) => ({ id, type: "compaction", firstKeptEntryId });
+
+describe("registerBeforeCompactHook: cancel paths", () => {
+  beforeEach(() => {
+    if (existsSync(DEBUG_PATH)) unlinkSync(DEBUG_PATH);
+  });
+  afterEach(() => {
+    if (existsSync(CONFIG_PATH)) unlinkSync(CONFIG_PATH);
+    if (existsSync(DEBUG_PATH)) unlinkSync(DEBUG_PATH);
+  });
+
+  test("/pi-vcc with too few live messages cancels and notifies warning", () => {
+    const { pi, invoke, notifyCalls, omRuntime } = createMockPi();
+    omRuntime.config.overrideDefaultCompaction = false;
+    registerBeforeCompactHook(pi, omRuntime);
+
+    const entries = [msg("m1", "user"), msg("m2", "assistant")];
+    expect(invoke(makeEvent(entries, PI_VCC_COMPACT_INSTRUCTION))).toEqual({ cancel: true });
+    expect(notifyCalls).toHaveLength(1);
+    expect(notifyCalls[0].level).toBe("warning");
+    expect(notifyCalls[0].msg).toContain("Too few messages");
+  });
+
+  test("/pi-vcc with no user message compacts all instead of cancelling", () => {
+    const { pi, invoke, notifyCalls, omRuntime } = createMockPi();
+    omRuntime.config.overrideDefaultCompaction = false;
+    registerBeforeCompactHook(pi, omRuntime);
+
+    const entries = [msg("m1", "assistant"), msg("m2", "assistant"), msg("m3", "assistant")];
+    const result = invoke(makeEvent(entries, PI_VCC_COMPACT_INSTRUCTION));
+    // No longer cancels — compacts all to recover from context overflow
+    expect(result.cancel).toBeUndefined();
+    expect(result.compaction).toBeDefined();
+    expect(result.compaction.firstKeptEntryId).toBe("");
+  });
+
+  test("/compact with override=true cancels and notifies (NEW: was silent before)", () => {
+    const { pi, invoke, notifyCalls, omRuntime } = createMockPi();
+    omRuntime.config.overrideDefaultCompaction = true;
+    registerBeforeCompactHook(pi, omRuntime);
+
+    const entries = [msg("m1", "user"), msg("m2", "assistant")];
+    expect(invoke(makeEvent(entries, undefined))).toEqual({ cancel: true });
+    expect(notifyCalls).toHaveLength(1);
+    expect(notifyCalls[0].level).toBe("warning");
+  });
+
+  test("/compact with override=false short-circuits (no notify, returns undefined)", () => {
+    const { pi, invoke, notifyCalls, omRuntime } = createMockPi();
+    omRuntime.config.overrideDefaultCompaction = false;
+    registerBeforeCompactHook(pi, omRuntime);
+
+    const entries = [msg("m1", "user"), msg("m2", "assistant")];
+    expect(invoke(makeEvent(entries, undefined))).toBeUndefined();
+    expect(notifyCalls).toHaveLength(0);
+  });
+
+  test("debug:true writes metrics-only snapshot on cancel with no content leakage", () => {
+    const { pi, invoke, omRuntime } = createMockPi();
+    omRuntime.config.overrideDefaultCompaction = false;
+    omRuntime.config.debug = true;
+    registerBeforeCompactHook(pi, omRuntime);
+
+    // Use too_few_live_messages cancel path to test content leakage
+    const entries = [
+      msg("m1", "user", "SECRET_TOKEN_abc123"),
+      msg("m2", "assistant", "sensitive response"),
+    ];
+    expect(invoke(makeEvent(entries, PI_VCC_COMPACT_INSTRUCTION))).toEqual({ cancel: true });
+
+    expect(existsSync(DEBUG_PATH)).toBe(true);
+    const snapshot = JSON.parse(readFileSync(DEBUG_PATH, "utf-8"));
+    expect(snapshot.cancelled).toBe(true);
+    expect(snapshot.reason).toBe("too_few_live_messages");
+
+    // No content leakage
+    const serialized = JSON.stringify(snapshot);
+    expect(serialized).not.toContain("SECRET_TOKEN_abc123");
+    expect(serialized).not.toContain("sensitive response");
+  });
+
+  test("debug:false does NOT write snapshot", () => {
+    const { pi, invoke, omRuntime } = createMockPi();
+    omRuntime.config.overrideDefaultCompaction = false;
+    registerBeforeCompactHook(pi, omRuntime);
+    const entries = [msg("m1", "user"), msg("m2", "assistant")];
+    expect(invoke(makeEvent(entries, PI_VCC_COMPACT_INSTRUCTION))).toEqual({ cancel: true });
+    expect(existsSync(DEBUG_PATH)).toBe(false);
+  });
+});
+
+describe("registerBeforeCompactHook: compact-all path", () => {
+  beforeEach(() => {
+    if (existsSync(DEBUG_PATH)) unlinkSync(DEBUG_PATH);
+  });
+  afterEach(() => {
+    if (existsSync(CONFIG_PATH)) unlinkSync(CONFIG_PATH);
+    if (existsSync(DEBUG_PATH)) unlinkSync(DEBUG_PATH);
+  });
+
+  test("single-user + autonomous tail → returns compaction with empty firstKeptEntryId", () => {
+    const { pi, invoke, notifyCalls, omRuntime } = createMockPi();
+    omRuntime.config.overrideDefaultCompaction = false;
+    registerBeforeCompactHook(pi, omRuntime);
+
+    const entries = [
+      msg("m1", "user", "go"),
+      msg("m2", "assistant", "calling tool"),
+      msg("m3", "toolResult", "result"),
+      msg("m4", "assistant", "done"),
+    ];
+    const result = invoke(makeEvent(entries, PI_VCC_COMPACT_INSTRUCTION));
+    expect(result.compaction).toBeDefined();
+    expect(result.compaction.firstKeptEntryId).toBe("");
+    expect(notifyCalls).toHaveLength(0); // no cancel notify on success
+  });
+});

--- a/tests/vcc-before-compact.test.ts
+++ b/tests/vcc-before-compact.test.ts
@@ -1,0 +1,145 @@
+import { describe, test, expect } from "vitest";
+import { buildOwnCut } from "../src/hooks/before-compact.js";
+
+const msg = (id: string, role: "user" | "assistant" | "toolResult", content = "x") => ({
+  id,
+  type: "message",
+  message: { role, content },
+});
+
+const comp = (id: string, firstKeptEntryId?: string) => ({
+  id,
+  type: "compaction",
+  firstKeptEntryId,
+});
+
+describe("buildOwnCut", () => {
+  test("no prior compaction: cuts at last user message", () => {
+    const r = buildOwnCut([
+      msg("m1", "user", "a"),
+      msg("m2", "assistant", "b"),
+      msg("m3", "user", "c"),
+      msg("m4", "assistant", "d"),
+    ]);
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.firstKeptEntryId).toBe("m3");
+    expect(r.messages).toHaveLength(2);
+    expect(r.compactAll).toBe(false);
+  });
+
+  test("cancels with too_few_live_messages when liveMessages <= 2", () => {
+    const r = buildOwnCut([
+      comp("c1", "m1"),
+      msg("m1", "user", "x"),
+      msg("m2", "assistant", "y"),
+    ]);
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.reason).toBe("too_few_live_messages");
+  });
+
+  test("orphan firstKeptEntryId triggers recovery (collect after compaction)", () => {
+    // Prev compaction set firstKeptEntryId to a non-existent id (e.g. "" sentinel
+    // from a previous compact-all). Recovery should collect msgs after compaction.
+    const r = buildOwnCut([
+      msg("old1", "user", "old"),
+      msg("old2", "assistant", "old"),
+      comp("c1", "ORPHAN_ID"),
+      msg("m1", "user", "a"),
+      msg("m2", "assistant", "b"),
+      msg("m3", "user", "c"),
+      msg("m4", "assistant", "d"),
+    ]);
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.firstKeptEntryId).toBe("m3");
+    expect(r.messages).toHaveLength(2);
+  });
+
+  test("resumes from firstKeptEntryId after prior compaction", () => {
+    const r = buildOwnCut([
+      msg("old1", "user", "old"),
+      msg("old2", "assistant", "old"),
+      comp("c1", "m1"),
+      msg("m1", "user", "a"),
+      msg("m2", "assistant", "b"),
+      msg("m3", "user", "c"),
+      msg("m4", "assistant", "d"),
+    ]);
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.firstKeptEntryId).toBe("m3");
+    expect(r.messages).toHaveLength(2);
+  });
+
+  test("single user prompt + autonomous tail: compact all", () => {
+    // The Discord scenario: user types 1 prompt, agent runs autonomously
+    // (assistant + toolResult interleaved). No user > idx 0.
+    const r = buildOwnCut([
+      msg("m1", "user", "go"),
+      msg("m2", "assistant", "calling tool"),
+      msg("m3", "toolResult", "result"),
+      msg("m4", "assistant", "more"),
+      msg("m5", "toolResult", "result2"),
+      msg("m6", "assistant", "done"),
+    ]);
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.compactAll).toBe(true);
+    expect(r.firstKeptEntryId).toBe("");
+    expect(r.messages).toHaveLength(6);
+  });
+
+  test("no user message: compact-all instead of cancelling", () => {
+    // When there are enough live messages but none are from the user
+    // (e.g., long assistant/tool chain), compact all rather than
+    // cancelling and leaving the session unrecoverable.
+    const r = buildOwnCut([
+      msg("m1", "assistant", "a"),
+      msg("m2", "assistant", "b"),
+      msg("m3", "assistant", "c"),
+    ]);
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.compactAll).toBe(true);
+    expect(r.firstKeptEntryId).toBe("");
+    expect(r.messages).toHaveLength(3);
+  });
+
+  test("compact-all then more chat: orphan recovery + normal cut", () => {
+    // After a compact-all (firstKeptEntryId=""), user chats more turns,
+    // next compaction should orphan-recover and find multiple users.
+    const r = buildOwnCut([
+      msg("o1", "user", "old"),
+      msg("o2", "assistant", "old"),
+      comp("c1", ""), // sentinel from prior compact-all
+      msg("u1", "user", "new1"),
+      msg("a1", "assistant", "reply1"),
+      msg("u2", "user", "new2"),
+      msg("a2", "assistant", "reply2"),
+      msg("u3", "user", "new3"),
+      msg("a3", "assistant", "reply3"),
+    ]);
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.compactAll).toBe(false);
+    expect(r.firstKeptEntryId).toBe("u3");
+    expect(r.messages).toHaveLength(4); // u1, a1, u2, a2
+  });
+
+  test("compact-all then single user msg + autonomous: compact all again", () => {
+    const r = buildOwnCut([
+      msg("o1", "user", "old"),
+      comp("c1", ""),
+      msg("u1", "user", "okay"),
+      msg("a1", "assistant", "x"),
+      msg("t1", "toolResult", "y"),
+      msg("a2", "assistant", "z"),
+    ]);
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.compactAll).toBe(true);
+    expect(r.firstKeptEntryId).toBe("");
+  });
+});

--- a/tests/vcc-brief.test.ts
+++ b/tests/vcc-brief.test.ts
@@ -1,0 +1,203 @@
+import { describe, it, expect } from "vitest";
+import { compileBrief } from "../src/core/brief.js";
+import type { NormalizedBlock } from "../src/types.js";
+
+describe("compileBrief", () => {
+  it("returns empty string for no blocks", () => {
+    expect(compileBrief([])).toBe("");
+  });
+
+  it("renders user and assistant text", () => {
+    const blocks: NormalizedBlock[] = [
+      { kind: "user", text: "fix auth bug" },
+      { kind: "assistant", text: "Let me look at the auth module." },
+    ];
+    const r = compileBrief(blocks);
+    expect(r).toContain("[user]");
+    expect(r).toContain("fix auth bug");
+    expect(r).toContain("[assistant]");
+    expect(r).toContain("Let me look at the auth module.");
+  });
+
+  it("renders bash commands as user actions", () => {
+    const blocks: NormalizedBlock[] = [
+      { kind: "bash", command: "npm test", output: "FAIL noisy output", exitCode: 1, sourceIndex: 2 },
+    ];
+    const r = compileBrief(blocks);
+    expect(r).toContain("[user]\n$ npm test (#2)");
+    expect(r).not.toContain("FAIL noisy output");
+  });
+
+  it("strips filler prefixes but preserves meaningful lead-ins", () => {
+    const blocks: NormalizedBlock[] = [
+      { kind: "assistant", text: "Okay, I found the root cause." },
+      { kind: "assistant", text: "Actually, the issue is in middleware." },
+      { kind: "assistant", text: "Let me check the logs." },
+    ];
+    const r = compileBrief(blocks);
+    expect(r).toContain("I found the root cause.");
+    expect(r).toContain("the issue is in middleware.");
+    expect(r).toContain("Let me check the logs.");
+  });
+
+  it("collapses tool calls to one-liners under [assistant]", () => {
+    const blocks: NormalizedBlock[] = [
+      { kind: "assistant", text: "Let me check." },
+      { kind: "tool_call", name: "Read", args: { file_path: "auth.ts" } },
+      { kind: "tool_call", name: "Edit", args: { file_path: "auth.ts" } },
+    ];
+    const r = compileBrief(blocks);
+    expect(r).toContain('* Read "auth.ts"');
+    expect(r).toContain('* Edit "auth.ts"');
+    // Should merge into single [assistant] section
+    const matches = r.match(/\[assistant\]/g);
+    expect(matches?.length).toBe(1);
+  });
+
+  it("hides non-error tool results", () => {
+    const blocks: NormalizedBlock[] = [
+      { kind: "tool_result", name: "Read", text: "const x = 1;\nconst y = 2;\n// lots of code" },
+    ];
+    const r = compileBrief(blocks);
+    expect(r).toBe("");
+  });
+
+  it("hides tool results regardless of output text", () => {
+    const blocks: NormalizedBlock[] = [
+      { kind: "tool_result", name: "bash", text: "FAIL auth.test.ts\nexpected 200 got 401" },
+    ];
+    const r = compileBrief(blocks);
+    expect(r).toBe("");
+  });
+
+  it("merges adjacent assistant sections", () => {
+    const blocks: NormalizedBlock[] = [
+      { kind: "assistant", text: "First part." },
+      { kind: "tool_call", name: "Read", args: { file_path: "a.ts" } },
+      // No user/tool_result between these — should merge
+      { kind: "assistant", text: "Second part." },
+      { kind: "tool_call", name: "Read", args: { file_path: "b.ts" } },
+    ];
+    const r = compileBrief(blocks);
+    const matches = r.match(/\[assistant\]/g);
+    expect(matches?.length).toBe(1);
+  });
+
+  it("does NOT merge assistant after user", () => {
+    const blocks: NormalizedBlock[] = [
+      { kind: "assistant", text: "First." },
+      { kind: "user", text: "Next task." },
+      { kind: "assistant", text: "Second." },
+    ];
+    const r = compileBrief(blocks);
+    const matches = r.match(/\[assistant\]/g);
+    expect(matches?.length).toBe(2);
+  });
+
+  it("truncates long user text", () => {
+    const longText = Array.from({ length: 300 }, (_, i) => `word${i}`).join(" ");
+    const blocks: NormalizedBlock[] = [
+      { kind: "user", text: longText },
+    ];
+    const r = compileBrief(blocks);
+    expect(r).toContain("(truncated)");
+    expect(r).not.toContain("word299");
+  });
+
+  it("truncates long assistant text", () => {
+    const longText = Array.from({ length: 300 }, (_, i) => `word${i}`).join(" ");
+    const blocks: NormalizedBlock[] = [
+      { kind: "assistant", text: longText },
+    ];
+    const r = compileBrief(blocks);
+    expect(r).toContain("(truncated)");
+    expect(r).not.toContain("word299");
+  });
+
+  it("renders a realistic conversation flow", () => {
+    const blocks: NormalizedBlock[] = [
+      { kind: "user", text: "fix the login bug" },
+      { kind: "assistant", text: "Let me investigate." },
+      { kind: "tool_call", name: "Read", args: { file_path: "login.ts" } },
+      { kind: "tool_result", name: "Read", text: "export function login() { ... }" },
+      { kind: "tool_call", name: "bash", args: { command: "npm test" } },
+      { kind: "tool_result", name: "bash", text: "FAIL: login test\nExpected true, got false" },
+      { kind: "assistant", text: "The test is failing because..." },
+      { kind: "tool_call", name: "Edit", args: { file_path: "login.ts" } },
+      { kind: "tool_result", name: "Edit", text: "File edited successfully" },
+      { kind: "user", text: "test lại đi" },
+      { kind: "assistant", text: "Running tests again." },
+      { kind: "tool_call", name: "bash", args: { command: "npm test" } },
+      { kind: "tool_result", name: "bash", text: "All tests passed" },
+    ];
+    const r = compileBrief(blocks);
+
+    // Check structure
+    expect(r).toContain("[user]\nfix the login bug");
+    expect(r).toContain('[assistant]\nLet me investigate.\n* Read "login.ts"');
+    expect(r).toContain('* bash "npm test"');
+    expect(r).toContain('The test is failing because...\n* Edit "login.ts"');
+    expect(r).toContain("[user]\ntest lại đi");
+    expect(r).toContain('[assistant]\nRunning tests again.\n* bash "npm test"');
+
+    // Hidden content
+    expect(r).not.toContain("think");
+    expect(r).not.toContain("export function login");
+    expect(r).not.toContain("File edited successfully");
+    expect(r).not.toContain("All tests passed");
+  });
+
+  // ── noise filtering tests (aligned with VCC) ──
+
+
+
+
+
+
+
+
+
+  it("suppresses blank lines between consecutive tool-only sections", () => {
+    const blocks: NormalizedBlock[] = [
+      { kind: "assistant", text: "Checking files." },
+      { kind: "tool_call", name: "Read", args: { file_path: "a.ts" } },
+      { kind: "tool_result", name: "Read", text: "..." },
+      // tool_result hidden → next tool_call starts new assistant section
+      // but since both are tool-only, no blank line between
+      { kind: "tool_call", name: "Read", args: { file_path: "b.ts" } },
+      { kind: "tool_result", name: "Read", text: "..." },
+    ];
+    const r = compileBrief(blocks);
+    // The first assistant section has text + tool, so it's NOT tool-only
+    // The second would be tool-only but merges into the first (adjacent assistant)
+    // So all under one [assistant]
+    expect(r.match(/\[assistant\]/g)?.length).toBe(1);
+  });
+
+  it("caps tool calls per [assistant] turn at 8 (keep tail)", () => {
+    const blocks: NormalizedBlock[] = [
+      { kind: "assistant", text: "Working." },
+    ];
+    for (let i = 1; i <= 12; i++) {
+      blocks.push({ kind: "tool_call", name: "bash", args: { command: `echo ${i}` } });
+    }
+    const r = compileBrief(blocks);
+    expect(r).toContain("(4 earlier tool-call entries omitted)");
+    // Last 8 (5..12) kept; first 4 dropped
+    expect(r).not.toContain("echo 1\"");
+    expect(r).not.toContain("echo 4\"");
+    expect(r).toContain("echo 5");
+    expect(r).toContain("echo 12");
+  });
+
+  it("does not cap when tool calls per turn <= 8", () => {
+    const blocks: NormalizedBlock[] = [{ kind: "assistant", text: "ok" }];
+    for (let i = 1; i <= 8; i++) {
+      blocks.push({ kind: "tool_call", name: "bash", args: { command: `c${i}` } });
+    }
+    const r = compileBrief(blocks);
+    expect(r).not.toContain("entries omitted");
+    expect(r).toContain("c1");
+    expect(r).toContain("c8");
+  });
+});

--- a/tests/vcc-build-sections.test.ts
+++ b/tests/vcc-build-sections.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from "vitest";
+import { buildSections } from "../src/core/build-sections.js";
+import type { NormalizedBlock } from "../src/types.js";
+
+describe("buildSections", () => {
+  it("returns all-empty for no blocks", () => {
+    const r = buildSections({ blocks: [] });
+    expect(r.sessionGoal).toEqual([]);
+    expect(r.outstandingContext).toEqual([]);
+    expect(r.briefTranscript).toBe("");
+  });
+
+  it("populates sections from realistic blocks", () => {
+    const blocks: NormalizedBlock[] = [
+      { kind: "user", text: "Fix the auth bug" },
+      { kind: "tool_call", name: "Read", args: { file_path: "auth.ts" } },
+      { kind: "tool_result", name: "Read", text: "const x = 1;" },
+      { kind: "tool_call", name: "Edit", args: { file_path: "auth.ts" } },
+      { kind: "tool_result", name: "Edit", text: "ok" },
+      { kind: "assistant", text: "- run tests next" },
+    ];
+    const r = buildSections({ blocks });
+    expect(r.sessionGoal).toContain("Fix the auth bug");
+    expect(r.briefTranscript).toContain('[user]');
+    expect(r.briefTranscript).toContain('* Read "auth.ts"');
+    expect(r.briefTranscript).toContain('* Edit "auth.ts"');
+  });
+
+  it("captures outstanding context from user and assistant text", () => {
+    const blocks: NormalizedBlock[] = [
+      { kind: "assistant", text: "Tests are still failing after the retry." },
+    ];
+    const r = buildSections({ blocks });
+    expect(r.outstandingContext.length).toBeGreaterThan(0);
+    expect(r.outstandingContext[0]).toContain("Tests are still failing");
+  });
+
+  it("brief transcript hides tool results", () => {
+    const blocks: NormalizedBlock[] = [
+      { kind: "tool_result", name: "Read", text: "lots of code here ..." },
+      { kind: "tool_result", name: "bash", text: "Command not found" },
+    ];
+    const r = buildSections({ blocks });
+    expect(r.briefTranscript).toBe("");
+  });
+
+  it("brief transcript merges adjacent assistant sections", () => {
+    const blocks: NormalizedBlock[] = [
+      { kind: "assistant", text: "Part one." },
+      { kind: "tool_call", name: "Read", args: { file_path: "a.ts" } },
+      { kind: "assistant", text: "Part two." },
+    ];
+    const r = buildSections({ blocks });
+    const matches = r.briefTranscript.match(/\[assistant\]/g);
+    expect(matches?.length).toBe(1);
+  });
+});

--- a/tests/vcc-compile.test.ts
+++ b/tests/vcc-compile.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/core/summarize.js";
+import {
+  userMsg,
+  assistantText,
+  assistantWithToolCall,
+  toolResult,
+} from "./vcc-fixtures.js";
+
+describe("compile", () => {
+  it("returns empty string for no messages", () => {
+    expect(compile({ messages: [] })).toBe("");
+  });
+
+  it("produces hybrid output with header + brief transcript", () => {
+    const r = compile({
+      messages: [
+        userMsg("Fix login bug"),
+        assistantWithToolCall("Read", { path: "auth.ts" }),
+        assistantText("Found the issue.\n1. Fix validation"),
+      ],
+    });
+    expect(r).toContain("[Session Goal]");
+    expect(r).toContain("Fix login bug");
+    expect(r).toContain("---");
+    expect(r).toContain("[user]\nFix login bug");
+    expect(r).toContain('* Read "auth.ts"');
+    expect(r).toContain("Found the issue.");
+  });
+
+  it("merges previous summary goals", () => {
+    const r = compile({
+      messages: [userMsg("New task")],
+      previousSummary: "[Session Goal]\n- Original goal\n\n---\n\n[user]\nOriginal goal",
+    });
+    expect(r).toContain("- Original goal");
+    expect(r).toContain("- New task");
+  });
+
+  it("appends brief transcript on merge", () => {
+    const previousSummary = [
+      "[Session Goal]\n- Original goal",
+      "---",
+      "[user]\nOriginal goal\n\n[assistant]\n* Read \"old.ts\"",
+    ].join("\n\n");
+    const r = compile({
+      previousSummary,
+      messages: [
+        userMsg("Next step"),
+        assistantWithToolCall("Read", { path: "new.ts" }),
+      ],
+    });
+    expect(r).toContain('* Read "old.ts"');
+    expect(r).toContain('* Read "new.ts"');
+    expect(r).toContain("Next step");
+  });
+
+  it("outstanding context is volatile (fresh only)", () => {
+    const previousSummary = "[Outstanding Context]\n- old blocker\n\n---\n\n[user]\nhi";
+    const r = compile({
+      previousSummary,
+      messages: [userMsg("continue")],
+    });
+    expect(r).not.toContain("old blocker");
+  });
+
+  it("caps long brief transcript with rolling window", () => {
+    // Build a very long previous transcript
+    const longTranscript = Array.from({ length: 200 }, (_, i) =>
+      `[user]\nmessage ${i}`
+    ).join("\n\n");
+    const previousSummary = `[Session Goal]\n- goal\n\n---\n\n${longTranscript}`;
+    const r = compile({
+      previousSummary,
+      messages: [userMsg("latest")],
+    });
+    expect(r).toContain("earlier lines omitted");
+    expect(r).toContain("latest");
+  });
+
+  it("wraps final output with reasonable line lengths", () => {
+    const r = compile({
+      messages: [userMsg("check final summary wrapping")],
+    });
+    // RECALL_NOTE is now appended by the before-compact hook render-summary,
+    // not by compile() itself, so we only check line wrapping.
+    const maxLineLength = Math.max(...r.split("\n").map((line) => line.length));
+    expect(maxLineLength).toBeLessThanOrEqual(120);
+  });
+});

--- a/tests/vcc-content.test.ts
+++ b/tests/vcc-content.test.ts
@@ -3,7 +3,7 @@
  * Changes: bun:test → vitest, added .js import extensions
  */
 import { describe, it, expect } from "vitest";
-import { textParts, textOf, clip, firstLine } from "../src/core/content.js.js";
+import { textParts, textOf, clip, firstLine } from "../src/core/content.js";
 
 describe("textParts", () => {
   it("returns [] for undefined content", () => {

--- a/tests/vcc-content.test.ts
+++ b/tests/vcc-content.test.ts
@@ -1,0 +1,35 @@
+/**
+ * Ported from upstream pi-vcc
+ * Changes: bun:test → vitest, added .js import extensions
+ */
+import { describe, it, expect } from "vitest";
+import { textParts, textOf, clip, firstLine } from "../src/core/content.js";
+
+describe("textParts", () => {
+  it("returns [] for undefined content", () => {
+    expect(textParts(undefined as any)).toEqual([]);
+  });
+
+  it("returns [] for null content", () => {
+    expect(textParts(null as any)).toEqual([]);
+  });
+
+  it("wraps string content", () => {
+    expect(textParts("hello")).toEqual(["hello"]);
+  });
+
+  it("extracts text parts from array content", () => {
+    const content = [
+      { type: "text" as const, text: "first" },
+      { type: "toolCall" as const, name: "x", id: "1", arguments: {} },
+      { type: "text" as const, text: "second" },
+    ];
+    expect(textParts(content)).toEqual(["first", "second"]);
+  });
+});
+
+describe("textOf", () => {
+  it("returns empty string for undefined content", () => {
+    expect(textOf(undefined as any)).toBe("");
+  });
+});

--- a/tests/vcc-content.test.ts
+++ b/tests/vcc-content.test.ts
@@ -3,7 +3,7 @@
  * Changes: bun:test → vitest, added .js import extensions
  */
 import { describe, it, expect } from "vitest";
-import { textParts, textOf, clip, firstLine } from "../src/core/content.js";
+import { textParts, textOf, clip, firstLine } from "../src/core/content.js.js";
 
 describe("textParts", () => {
   it("returns [] for undefined content", () => {

--- a/tests/vcc-extract-goals.test.ts
+++ b/tests/vcc-extract-goals.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from "vitest";
+import { extractGoals } from "../src/extract/goals.js";
+import type { NormalizedBlock } from "../src/types.js";
+
+describe("extractGoals", () => {
+  it("returns empty for no blocks", () => {
+    expect(extractGoals([])).toEqual([]);
+  });
+
+  it("returns empty when no user blocks", () => {
+    const blocks: NormalizedBlock[] = [
+      { kind: "assistant", text: "hello" },
+    ];
+    expect(extractGoals(blocks)).toEqual([]);
+  });
+
+  it("extracts first user message lines as goals", () => {
+    const blocks: NormalizedBlock[] = [
+      { kind: "user", text: "Fix login bug\nCheck auth flow" },
+    ];
+    const goals = extractGoals(blocks);
+    expect(goals).toEqual(["Fix login bug", "Check auth flow"]);
+  });
+
+  it("takes up to 6 lines from first user block", () => {
+    const blocks: NormalizedBlock[] = [
+      { kind: "user", text: "fix the login bug\ncheck auth flow\nupdate the tests\nrefactor utils\nclean up" },
+    ];
+    expect(extractGoals(blocks)).toHaveLength(5);
+  });
+
+  it("ignores subsequent user blocks", () => {
+    const blocks: NormalizedBlock[] = [
+      { kind: "user", text: "first goal" },
+      { kind: "assistant", text: "ok" },
+      { kind: "user", text: "second request" },
+    ];
+    expect(extractGoals(blocks)).toEqual(["first goal"]);
+  });
+
+  it("detects scope change with explicit pivot keywords", () => {
+    const blocks: NormalizedBlock[] = [
+      { kind: "user", text: "Fix login bug" },
+      { kind: "assistant", text: "ok" },
+      { kind: "user", text: "Actually, instead let's refactor the auth module" },
+    ];
+    const goals = extractGoals(blocks);
+    expect(goals).toContain("Fix login bug");
+    expect(goals).toContain("[Scope change]");
+    expect(goals.some((g) => g.includes("refactor"))).toBe(true);
+  });
+
+  it("detects scope change from new task statements", () => {
+    const blocks: NormalizedBlock[] = [
+      { kind: "user", text: "Fix login bug" },
+      { kind: "assistant", text: "done" },
+      { kind: "user", text: "Now implement the user registration flow" },
+    ];
+    const goals = extractGoals(blocks);
+    expect(goals).toContain("[Scope change]");
+  });
+
+  it("keeps latest scope change only", () => {
+    const blocks: NormalizedBlock[] = [
+      { kind: "user", text: "Fix login bug" },
+      { kind: "assistant", text: "done" },
+      { kind: "user", text: "Actually, fix the signup page instead" },
+      { kind: "assistant", text: "ok" },
+      { kind: "user", text: "Change of plan, implement password reset" },
+    ];
+    const goals = extractGoals(blocks);
+    const scopeIdx = goals.indexOf("[Scope change]");
+    expect(goals[scopeIdx + 1]).toContain("password reset");
+  });
+
+  it("skips noise short user messages as goals", () => {
+    const blocks: NormalizedBlock[] = [
+      { kind: "user", text: "ok" },
+      { kind: "assistant", text: "hello" },
+      { kind: "user", text: "Fix the authentication module" },
+    ];
+    const goals = extractGoals(blocks);
+    expect(goals[0]).toContain("Fix the authentication");
+    expect(goals.some((g) => g === "ok")).toBe(false);
+  });
+});

--- a/tests/vcc-extract-preferences.test.ts
+++ b/tests/vcc-extract-preferences.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from "vitest";
+import { extractPreferences } from "../src/extract/preferences.js";
+import type { NormalizedBlock } from "../src/types.js";
+
+describe("extractPreferences", () => {
+  it("returns empty for no blocks", () => {
+    expect(extractPreferences([])).toEqual([]);
+  });
+
+  it("captures preference patterns from user", () => {
+    const blocks: NormalizedBlock[] = [
+      { kind: "user", text: "I prefer TypeScript over JavaScript" },
+    ];
+    expect(extractPreferences(blocks).length).toBe(1);
+  });
+
+  it("ignores assistant blocks", () => {
+    const blocks: NormalizedBlock[] = [
+      { kind: "assistant", text: "I always use best practices" },
+    ];
+    expect(extractPreferences(blocks)).toEqual([]);
+  });
+
+  it("captures please use pattern", () => {
+    const blocks: NormalizedBlock[] = [
+      { kind: "user", text: "please use bun instead of node" },
+    ];
+    expect(extractPreferences(blocks).length).toBe(1);
+  });
+});

--- a/tests/vcc-filter-noise.test.ts
+++ b/tests/vcc-filter-noise.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "vitest";
+import { filterNoise } from "../src/core/filter-noise.js";
+import type { NormalizedBlock } from "../src/types.js";
+
+describe("filterNoise", () => {
+  it("removes noise tool calls and results", () => {
+    const blocks: NormalizedBlock[] = [
+      { kind: "tool_call", name: "TodoWrite", args: {} },
+      { kind: "tool_result", name: "TodoWrite", text: "ok" },
+      { kind: "tool_call", name: "Read", args: { path: "x.ts" } },
+    ];
+    const result = filterNoise(blocks);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({ kind: "tool_call", name: "Read", args: { path: "x.ts" } });
+  });
+
+  it("removes user blocks that are pure XML wrappers", () => {
+    const blocks: NormalizedBlock[] = [
+      { kind: "user", text: "<system-reminder>some noise</system-reminder>" },
+      { kind: "user", text: "Fix the bug" },
+    ];
+    const result = filterNoise(blocks);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({ kind: "user", text: "Fix the bug" });
+  });
+
+  it("cleans XML wrappers from user text but keeps real content", () => {
+    const blocks: NormalizedBlock[] = [
+      { kind: "user", text: "<system-reminder>noise</system-reminder>\nFix the login" },
+    ];
+    const result = filterNoise(blocks);
+    expect(result).toHaveLength(1);
+    expect((result[0] as any).text).toBe("Fix the login");
+  });
+
+  it("removes known noise strings", () => {
+    const blocks: NormalizedBlock[] = [
+      { kind: "user", text: "Continue from where you left off." },
+      { kind: "user", text: "real task" },
+    ];
+    const result = filterNoise(blocks);
+    expect(result).toHaveLength(1);
+    expect((result[0] as any).text).toBe("real task");
+  });
+
+  it("preserves non-noise tool calls", () => {
+    const blocks: NormalizedBlock[] = [
+      { kind: "tool_call", name: "Edit", args: { path: "a.ts" } },
+      { kind: "tool_result", name: "Edit", text: "ok" },
+    ];
+    expect(filterNoise(blocks)).toHaveLength(2);
+  });
+});

--- a/tests/vcc-fixtures.ts
+++ b/tests/vcc-fixtures.ts
@@ -1,0 +1,60 @@
+import type { Message } from "@earendil-works/pi-ai";
+
+const ts = Date.now();
+const assistBase = {
+  api: "messages" as any,
+  provider: "anthropic" as any,
+  model: "test",
+  usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+  timestamp: ts,
+};
+
+export const userMsg = (text: string): Message => ({
+  role: "user",
+  content: text,
+  timestamp: ts,
+});
+
+export const assistantText = (text: string): Message => ({
+  role: "assistant",
+  content: [{ type: "text", text }],
+  ...assistBase,
+  stopReason: "stop",
+});
+
+export const assistantWithThinking = (
+  text: string,
+  thinking: string,
+): Message => ({
+  role: "assistant",
+  content: [
+    { type: "thinking", thinking },
+    { type: "text", text },
+  ],
+  ...assistBase,
+  stopReason: "stop",
+});
+
+export const assistantWithToolCall = (
+  name: string,
+  args: Record<string, unknown>,
+): Message => ({
+  role: "assistant",
+  content: [{ type: "toolCall", id: "tc_1", name, arguments: args }],
+  ...assistBase,
+  stopReason: "toolUse",
+});
+
+export const toolResult = (
+  name: string,
+  text: string,
+): Message => ({
+  role: "toolResult",
+  toolCallId: "tc_1",
+  toolName: name,
+  content: [{ type: "text", text }],
+  isError: false,
+  timestamp: ts,
+});
+
+

--- a/tests/vcc-format-recall.test.ts
+++ b/tests/vcc-format-recall.test.ts
@@ -3,8 +3,8 @@
  * Changes: bun:test → vitest, added .js import extensions
  */
 import { describe, it, expect } from "vitest";
-import { formatRecallOutput } from "../src/core/format-recall.js.js";
-import type { RenderedEntry } from "../src/core/render-entries.js.js";
+import { formatRecallOutput } from "../src/core/format-recall.js";
+import type { RenderedEntry } from "../src/core/render-entries.js";
 
 describe("formatRecallOutput", () => {
   it("shows no-match message with query", () => {

--- a/tests/vcc-format-recall.test.ts
+++ b/tests/vcc-format-recall.test.ts
@@ -1,0 +1,34 @@
+/**
+ * Ported from upstream pi-vcc
+ * Changes: bun:test → vitest, added .js import extensions
+ */
+import { describe, it, expect } from "vitest";
+import { formatRecallOutput } from "../src/core/format-recall.js";
+import type { RenderedEntry } from "../src/core/render-entries.js";
+
+describe("formatRecallOutput", () => {
+  it("shows no-match message with query", () => {
+    const r = formatRecallOutput([], "xyz");
+    expect(r).toContain('No matches for "xyz"');
+  });
+
+  it("shows no-entries message without query", () => {
+    expect(formatRecallOutput([])).toContain("No entries");
+  });
+
+  it("formats entries with index and role", () => {
+    const entries: RenderedEntry[] = [
+      { index: 0, role: "user", summary: "hello" },
+    ];
+    const r = formatRecallOutput(entries);
+    expect(r).toContain("#0 [user] hello");
+  });
+
+  it("shows match count with query", () => {
+    const entries: RenderedEntry[] = [
+      { index: 2, role: "assistant", summary: "done" },
+    ];
+    const r = formatRecallOutput(entries, "done");
+    expect(r).toContain('Found 1 matches for "done"');
+  });
+});

--- a/tests/vcc-format-recall.test.ts
+++ b/tests/vcc-format-recall.test.ts
@@ -3,8 +3,8 @@
  * Changes: bun:test → vitest, added .js import extensions
  */
 import { describe, it, expect } from "vitest";
-import { formatRecallOutput } from "../src/core/format-recall.js";
-import type { RenderedEntry } from "../src/core/render-entries.js";
+import { formatRecallOutput } from "../src/core/format-recall.js.js";
+import type { RenderedEntry } from "../src/core/render-entries.js.js";
 
 describe("formatRecallOutput", () => {
   it("shows no-match message with query", () => {

--- a/tests/vcc-format.test.ts
+++ b/tests/vcc-format.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from "vitest";
+import { formatSummary } from "../src/core/format.js";
+import type { SectionData } from "../src/sections.js";
+
+const empty: SectionData = {
+  sessionGoal: [],
+  outstandingContext: [],
+  filesAndChanges: [],
+  commits: [],
+  userPreferences: [],
+  briefTranscript: "",
+};
+
+describe("formatSummary", () => {
+  it("returns empty string for all-empty sections", () => {
+    expect(formatSummary(empty)).toBe("");
+  });
+
+  it("formats a single header section", () => {
+    const data = {
+      ...empty,
+      sessionGoal: ["fix auth bug"],
+    };
+    const r = formatSummary(data);
+    expect(r).toContain("[Session Goal]");
+    expect(r).toContain("- fix auth bug");
+  });
+
+  it("separates header and brief transcript with ---", () => {
+    const data = {
+      ...empty,
+      sessionGoal: ["goal"],
+      briefTranscript: "[user]\ndo something",
+    };
+    const r = formatSummary(data);
+    expect(r).toContain("[Session Goal]");
+    expect(r).toContain("---");
+    expect(r).toContain("[user]\ndo something");
+  });
+
+  it("renders brief transcript alone when no header sections", () => {
+    const data = {
+      ...empty,
+      briefTranscript: "[user]\nhi\n\n[assistant]\nhello",
+    };
+    const r = formatSummary(data);
+    expect(r).toContain("[user]\nhi\n\n[assistant]\nhello");
+  });
+
+  it("joins multiple header sections with blank line", () => {
+    const data = {
+      ...empty,
+      sessionGoal: ["goal"],
+      outstandingContext: ["blocker"],
+    };
+    const r = formatSummary(data);
+    expect(r).toContain("[Session Goal]");
+    expect(r).toContain("[Outstanding Context]");
+    expect(r).toContain("\n\n");
+  });
+
+  it("wraps long lines so compaction TUI rendering stays bounded", () => {
+    const data = {
+      ...empty,
+      briefTranscript: `[assistant]\n${"word ".repeat(80)}`,
+    };
+    const r = formatSummary(data);
+    expect(Math.max(...r.split("\n").map((line) => line.length))).toBeLessThanOrEqual(120);
+  });
+});

--- a/tests/vcc-lineage.test.ts
+++ b/tests/vcc-lineage.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from "vitest";
+import { getActiveLineageEntryIds } from "../src/core/lineage.js";
+
+describe("getActiveLineageEntryIds", () => {
+  it("returns IDs from active branch", () => {
+    const ids = getActiveLineageEntryIds({
+      getBranch: () => [{ id: "a" }, { id: "b" }, { id: "c" }],
+    });
+    expect([...ids]).toEqual(["a", "b", "c"]);
+  });
+
+  it("falls back to getEntries when getBranch throws", () => {
+    const ids = getActiveLineageEntryIds({
+      getBranch: () => {
+        throw new Error("boom");
+      },
+      getEntries: () => [{ id: "x" }, { id: "y" }],
+    });
+    expect([...ids]).toEqual(["x", "y"]);
+  });
+
+  it("returns empty set when both branch and entries are unavailable", () => {
+    const ids = getActiveLineageEntryIds({
+      getBranch: () => {
+        throw new Error("boom");
+      },
+      getEntries: () => {
+        throw new Error("boom2");
+      },
+    });
+    expect(ids.size).toBe(0);
+  });
+});

--- a/tests/vcc-load-messages.test.ts
+++ b/tests/vcc-load-messages.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from "vitest";
+import { mkdtempSync, writeFileSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { loadAllMessages } from "../src/core/load-messages.js";
+
+describe("loadAllMessages", () => {
+  it("loads all message entries when no lineage filter is provided", () => {
+    const dir = mkdtempSync(join(tmpdir(), "pi-vcc-load-all-"));
+    const file = join(dir, "session.jsonl");
+    try {
+      const lines = [
+        JSON.stringify({ type: "session", id: "s1" }),
+        JSON.stringify({ type: "message", id: "m1", message: { role: "user", content: "u1" } }),
+        JSON.stringify({ type: "custom", id: "c1", customType: "x", data: {} }),
+        JSON.stringify({ type: "message", id: "m2", message: { role: "assistant", content: [{ type: "text", text: "a1" }] } }),
+        JSON.stringify({ type: "message", id: "m3", message: { role: "toolResult", toolName: "read", content: [{ type: "text", text: "ok" }] } }),
+      ];
+      writeFileSync(file, lines.join("\n") + "\n", "utf8");
+
+      const loaded = loadAllMessages(file, false);
+      expect(loaded.rendered).toHaveLength(3);
+      expect(loaded.rawMessages).toHaveLength(3);
+      expect(loaded.rendered.map((e) => e.index)).toEqual([0, 1, 2]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("filters messages by allowed lineage entry IDs and preserves original message index", () => {
+    const dir = mkdtempSync(join(tmpdir(), "pi-vcc-load-filter-"));
+    const file = join(dir, "session.jsonl");
+    try {
+      const lines = [
+        JSON.stringify({ type: "message", id: "m1", message: { role: "user", content: "u1" } }),
+        JSON.stringify({ type: "message", id: "m2", message: { role: "assistant", content: [{ type: "text", text: "a1" }] } }),
+        JSON.stringify({ type: "message", id: "m3", message: { role: "user", content: "u2" } }),
+      ];
+      writeFileSync(file, lines.join("\n") + "\n", "utf8");
+
+      const loaded = loadAllMessages(file, false, new Set(["m2"]));
+      expect(loaded.rendered).toHaveLength(1);
+      expect(loaded.rawMessages).toHaveLength(1);
+      expect(loaded.rendered[0].index).toBe(1);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/vcc-normalize.test.ts
+++ b/tests/vcc-normalize.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from "vitest";
+import { normalize } from "../src/core/normalize.js";
+import {
+  userMsg,
+  assistantText,
+  assistantWithThinking,
+  assistantWithToolCall,
+  toolResult,
+} from "./vcc-fixtures.js";
+
+describe("normalize", () => {
+  it("returns empty for empty input", () => {
+    expect(normalize([])).toEqual([]);
+  });
+
+  it("normalizes user message (string content)", () => {
+    const blocks = normalize([userMsg("fix the bug")]);
+    expect(blocks).toEqual([{ kind: "user", text: "fix the bug", sourceIndex: 0 }]);
+  });
+
+  it("normalizes assistant text message", () => {
+    const blocks = normalize([assistantText("done")]);
+    expect(blocks).toEqual([{ kind: "assistant", text: "done", sourceIndex: 0 }]);
+  });
+
+  it("normalizes assistant string content", () => {
+    const msg = { ...assistantText("done"), content: "plain text" } as any;
+    expect(normalize([msg])).toEqual([{ kind: "assistant", text: "plain text", sourceIndex: 0 }]);
+  });
+
+  it("includes thinking blocks (blackhole keeps them, unlike upstream)", () => {
+    const blocks = normalize([assistantWithThinking("result", "hmm")]);
+    // blackhole keeps thinking blocks (upstream commit a156870 deferred).
+    expect(blocks).toHaveLength(2);
+    expect(blocks[0]).toEqual({ kind: "thinking", text: "hmm", redacted: false, sourceIndex: 0 });
+    expect(blocks[1]).toEqual({ kind: "assistant", text: "result", sourceIndex: 0 });
+  });
+
+  it("normalizes tool call", () => {
+    const blocks = normalize([assistantWithToolCall("Read", { path: "a.ts" })]);
+    expect(blocks).toEqual([{
+      kind: "tool_call", name: "Read", args: { path: "a.ts" }, sourceIndex: 0,
+    }]);
+  });
+
+  it("normalizes tool result with isError flag", () => {
+    const blocks = normalize([toolResult("Read", "file contents")]);
+    // blackhole keeps isError (upstream commit a156870 deferred)
+    expect(blocks).toEqual([{
+      kind: "tool_result", name: "Read",
+      text: "file contents", isError: false, sourceIndex: 0,
+    }]);
+  });
+
+  it("handles mixed message sequence", () => {
+    const blocks = normalize([
+      userMsg("fix it"),
+      assistantWithToolCall("Read", { path: "x.ts" }),
+      toolResult("Read", "code"),
+      assistantText("done"),
+    ]);
+    expect(blocks).toHaveLength(4);
+    expect(blocks.map((b) => b.kind)).toEqual([
+      "user", "tool_call", "tool_result", "assistant",
+    ]);
+  });
+
+  it("produces image placeholder for user image content", () => {
+    const msg = {
+      role: "user" as const,
+      content: [
+        { type: "text" as const, text: "look at this" },
+        { type: "image" as const, data: "abc", mimeType: "image/png" },
+      ],
+      timestamp: Date.now(),
+    };
+    const blocks = normalize([msg]);
+    expect(blocks).toHaveLength(2);
+    expect(blocks[0]).toEqual({ kind: "user", text: "look at this", sourceIndex: 0 });
+    expect(blocks[1]).toEqual({ kind: "user", text: "[image: image/png]", sourceIndex: 0 });
+  });
+
+  it("normalizes bashExecution messages", () => {
+    const msg = { role: "bashExecution", command: "ls -la", output: "files", exitCode: 0 } as any;
+    const blocks = normalize([msg]);
+    expect(blocks).toEqual([
+      { kind: "bash", command: "ls -la", output: "files", exitCode: 0, sourceIndex: 0 },
+    ]);
+  });
+
+  it("skips truly unknown message roles gracefully", () => {
+    const custom = { role: "custom", content: "hello" } as any;
+    expect(normalize([custom])).toEqual([]);
+  });
+});
+
+

--- a/tests/vcc-recall-expand.test.ts
+++ b/tests/vcc-recall-expand.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from "vitest";
+import { invalidExpandIndices } from "../src/tools/recall.js";
+
+describe("invalidExpandIndices", () => {
+  it("returns indices that are not in available lineage index set", () => {
+    const available = new Set([0, 2, 5]);
+    expect(invalidExpandIndices([0, 2], available)).toEqual([]);
+    expect(invalidExpandIndices([1, 2, 7], available)).toEqual([1, 7]);
+  });
+
+  it("rejects non-integer indices", () => {
+    const available = new Set([0, 1, 2]);
+    expect(invalidExpandIndices([1.5, 2], available)).toEqual([1.5]);
+  });
+});

--- a/tests/vcc-recall-scope.test.ts
+++ b/tests/vcc-recall-scope.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+import { normalizeRecallScope, parseRecallScope } from "../src/core/recall-scope.js";
+
+describe("normalizeRecallScope", () => {
+  it("defaults to active lineage", () => {
+    expect(normalizeRecallScope()).toBe("lineage");
+    expect(normalizeRecallScope("lineage")).toBe("lineage");
+    expect(normalizeRecallScope("unknown")).toBe("lineage");
+    expect(normalizeRecallScope(123)).toBe("lineage");
+  });
+
+  it("accepts all scope", () => {
+    expect(normalizeRecallScope("all")).toBe("all");
+    expect(normalizeRecallScope("ALL")).toBe("all");
+  });
+});
+
+describe("parseRecallScope", () => {
+  it("removes scope token from command text", () => {
+    expect(parseRecallScope("license scope:all page:2")).toEqual({
+      scope: "all",
+      text: "license page:2",
+    });
+  });
+
+  it("defaults to lineage when no scope token is present", () => {
+    expect(parseRecallScope("license page:2")).toEqual({
+      scope: "lineage",
+      text: "license page:2",
+    });
+  });
+});

--- a/tests/vcc-recall-tool-scope.test.ts
+++ b/tests/vcc-recall-tool-scope.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from "vitest";
+import { mkdtempSync, writeFileSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { registerRecallTool } from "../src/tools/recall.js";
+
+const makeSession = () => {
+  const dir = mkdtempSync(join(tmpdir(), "pi-vcc-recall-scope-"));
+  const file = join(dir, "session.jsonl");
+  const lines = [
+    JSON.stringify({ type: "message", id: "m1", message: { role: "user", content: "active lineage token" } }),
+    JSON.stringify({ type: "message", id: "m2", message: { role: "user", content: "off lineage secret" } }),
+  ];
+  writeFileSync(file, lines.join("\n") + "\n", "utf8");
+  return { dir, file };
+};
+
+const register = () => {
+  let tool: any;
+  registerRecallTool({ registerTool: (t: any) => { tool = t; } } as any);
+  return tool;
+};
+
+const invoke = async (tool: any, file: string, params: Record<string, unknown>) => {
+  const result = await tool.execute("tool-call", params, undefined, undefined, {
+    sessionManager: {
+      getSessionFile: () => file,
+      getBranch: () => [{ id: "m1" }],
+      getEntries: () => [{ id: "m1" }, { id: "m2" }],
+    },
+  });
+  return result.content[0].text as string;
+};
+
+describe("vcc_recall scope", () => {
+  it("defaults to active lineage and opts into all-session search explicitly", async () => {
+    const { dir, file } = makeSession();
+    try {
+      const tool = register();
+
+      const lineage = await invoke(tool, file, { query: "secret" });
+      expect(lineage).toContain("No matches");
+
+      const all = await invoke(tool, file, { query: "secret", scope: "all" });
+      expect(all).toContain("scope: all");
+      expect(all).toContain("off lineage secret");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps expand strict by default but allows off-lineage expand with scope all", async () => {
+    const { dir, file } = makeSession();
+    try {
+      const tool = register();
+
+      const lineage = await invoke(tool, file, { expand: [1] });
+      expect(lineage).toContain("Cannot expand indices outside active lineage: 1");
+
+      const all = await invoke(tool, file, { expand: [1], scope: "all" });
+      expect(all).toContain("Scope: all");
+      expect(all).toContain("#1 [user] off lineage secret");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/vcc-render-entries.test.ts
+++ b/tests/vcc-render-entries.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from "vitest";
+import { renderMessage } from "../src/core/render-entries.js";
+import type { Message } from "@earendil-works/pi-ai";
+import { userMsg, assistantText, assistantWithToolCall, toolResult } from "./vcc-fixtures.js";
+
+describe("renderMessage", () => {
+  it("renders user message", () => {
+    const r = renderMessage(userMsg("hello"), 0);
+    expect(r).toEqual({ index: 0, role: "user", summary: "hello" });
+  });
+
+  it("renders assistant text", () => {
+    const r = renderMessage(assistantText("done"), 1);
+    expect(r.role).toBe("assistant");
+    expect(r.summary).toBe("done");
+  });
+
+  it("renders tool result", () => {
+    const r = renderMessage(toolResult("Read", "file contents"), 2);
+    expect(r.role).toBe("tool_result");
+    expect(r.summary).toContain("[Read]");
+  });
+
+  it("renders tool call arguments with values", () => {
+    const r = renderMessage(assistantWithToolCall("Read", { path: "a.ts" }), 2);
+    expect(r.summary).toContain("Read(path=a.ts)");
+  });
+
+  it("renders tool results without error prefix", () => {
+    const r = renderMessage(toolResult("bash", "not found"), 3);
+    expect(r.summary).toBe("[bash] not found");
+  });
+
+  it("truncates long user text", () => {
+    const long = "x".repeat(500);
+    const r = renderMessage(userMsg(long), 0);
+    expect(r.summary.length).toBeLessThanOrEqual(300);
+  });
+
+  it("renders bashExecution message", () => {
+    const msg = { role: "bashExecution", command: "ls -la", output: "total 0\n" } as any;
+    const r = renderMessage(msg, 5);
+    expect(r.role).toBe("bash");
+    expect(r.summary).toContain("$ ls -la");
+    expect(r.summary).toContain("total 0");
+  });
+
+  it("renders bashExecution with missing output", () => {
+    const msg = { role: "bashExecution", command: "exit 1" } as any;
+    const r = renderMessage(msg, 6);
+    expect(r.role).toBe("bash");
+    expect(r.summary).toContain("$ exit 1");
+  });
+
+  it("handles message with undefined content", () => {
+    const msg = { role: "assistant", content: undefined } as any;
+    const r = renderMessage(msg, 3);
+    expect(r.role).toBe("assistant");
+    expect(r.summary).toBe("");
+  });
+});
+

--- a/tests/vcc-report.test.ts
+++ b/tests/vcc-report.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest";
+import { buildCompactReport } from "../src/core/report.js";
+import {
+  userMsg,
+  assistantText,
+  assistantWithToolCall,
+  toolResult,
+} from "./vcc-fixtures.js";
+
+describe("buildCompactReport", () => {
+  it("includes before and after compact metrics", () => {
+    const report = buildCompactReport({
+      messages: [
+        userMsg("Fix login bug in auth.ts"),
+        assistantWithToolCall("Read", { path: "auth.ts" }),
+        toolResult("Read", "const x = 1;"),
+        assistantText("Found the root cause in auth.ts.\n1. Fix validation\n2. Run tests"),
+      ],
+    });
+    expect(report.before.messageCount).toBe(4);
+    expect(report.before.roleCounts.user).toBe(1);
+    expect(report.before.topFiles).toContain("auth.ts");
+    expect(report.before.preview).toContain("Fix login bug in auth.ts");
+    expect(report.after.sectionCount).toBeGreaterThan(0);
+    expect(report.after.summaryPreview).toContain("[Session Goal]");
+    expect(report.after.summaryPreview).toContain('* Read "auth.ts"');
+    expect(report.after.briefTranscriptLines).toBeGreaterThan(0);
+    expect(report.compression.ratio).toBeGreaterThan(0);
+  });
+
+  it("marks recall probe coverage for goal and file queries", () => {
+    const report = buildCompactReport({
+      messages: [
+        userMsg("Fix login bug in auth.ts"),
+        assistantWithToolCall("Read", { path: "auth.ts" }),
+        toolResult("Read", "code content"),
+        assistantText("Found the root cause"),
+      ],
+    });
+    expect(report.recall.probes.length).toBeGreaterThanOrEqual(1);
+    const goalProbe = report.recall.probes.find((p) => p.label === "goal");
+    expect(goalProbe?.summaryMentioned).toBe(true);
+  });
+
+  it("counts recall hits with the probe query", () => {
+    const report = buildCompactReport({
+      messages: [
+        userMsg("Handle unrelated setup"),
+        assistantWithToolCall("Read", { path: "unique-auth-file.ts" }),
+        toolResult("Read", "code content"),
+        assistantText("Done"),
+      ],
+    });
+    const fileProbe = report.recall.probes.find((p) => p.label === "file");
+    expect(fileProbe?.query).toBe("unique-auth-file.ts");
+    expect(fileProbe?.recallHits).toBe(1);
+  });
+});

--- a/tests/vcc-sanitize.test.ts
+++ b/tests/vcc-sanitize.test.ts
@@ -1,0 +1,28 @@
+/**
+ * Ported from upstream pi-vcc
+ * Changes: bun:test → vitest, added .js import extensions
+ */
+import { describe, it, expect } from "vitest";
+import { sanitize } from "../src/core/sanitize.js";
+
+describe("sanitize", () => {
+  it("strips ANSI escape codes", () => {
+    expect(sanitize("\x1b[31mred\x1b[0m")).toBe("red");
+  });
+
+  it("normalizes CRLF to LF", () => {
+    expect(sanitize("a\r\nb\r\n")).toBe("a\nb\n");
+  });
+
+  it("strips bare CR", () => {
+    expect(sanitize("a\rb")).toBe("a\nb");
+  });
+
+  it("strips control characters but preserves newlines and tabs", () => {
+    expect(sanitize("a\x00b\tc\nd")).toBe("ab\tc\nd");
+  });
+
+  it("passes clean text unchanged", () => {
+    expect(sanitize("hello world")).toBe("hello world");
+  });
+});

--- a/tests/vcc-sanitize.test.ts
+++ b/tests/vcc-sanitize.test.ts
@@ -3,7 +3,7 @@
  * Changes: bun:test → vitest, added .js import extensions
  */
 import { describe, it, expect } from "vitest";
-import { sanitize } from "../src/core/sanitize.js";
+import { sanitize } from "../src/core/sanitize.js.js";
 
 describe("sanitize", () => {
   it("strips ANSI escape codes", () => {

--- a/tests/vcc-sanitize.test.ts
+++ b/tests/vcc-sanitize.test.ts
@@ -3,7 +3,7 @@
  * Changes: bun:test → vitest, added .js import extensions
  */
 import { describe, it, expect } from "vitest";
-import { sanitize } from "../src/core/sanitize.js.js";
+import { sanitize } from "../src/core/sanitize.js";
 
 describe("sanitize", () => {
   it("strips ANSI escape codes", () => {

--- a/tests/vcc-search-entries.test.ts
+++ b/tests/vcc-search-entries.test.ts
@@ -4,7 +4,7 @@
  */
 import { describe, it, expect } from "vitest";
 import { searchEntries } from "../src/core/search-entries.js";
-import type { RenderedEntry } from "../src/core/render-entries.js.js";
+import type { RenderedEntry } from "../src/core/render-entries.js";
 import type { Message } from "@earendil-works/pi-ai";
 
 const entries: RenderedEntry[] = [

--- a/tests/vcc-search-entries.test.ts
+++ b/tests/vcc-search-entries.test.ts
@@ -3,8 +3,8 @@
  * Changes: bun:test → vitest, added .js import extensions
  */
 import { describe, it, expect } from "vitest";
-import { searchEntries } from "../src/core/search-entries.js";
-import type { RenderedEntry } from "../src/core/render-entries.js";
+import { searchEntries } from "../src/core/search-entries.js.js";
+import type { RenderedEntry } from "../src/core/render-entries.js.js";
 import type { Message } from "@earendil-works/pi-ai";
 
 const entries: RenderedEntry[] = [

--- a/tests/vcc-search-entries.test.ts
+++ b/tests/vcc-search-entries.test.ts
@@ -3,7 +3,7 @@
  * Changes: bun:test → vitest, added .js import extensions
  */
 import { describe, it, expect } from "vitest";
-import { searchEntries } from "../src/core/search-entries.js.js";
+import { searchEntries } from "../src/core/search-entries.js";
 import type { RenderedEntry } from "../src/core/render-entries.js.js";
 import type { Message } from "@earendil-works/pi-ai";
 

--- a/tests/vcc-search-entries.test.ts
+++ b/tests/vcc-search-entries.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Ported from upstream pi-vcc
+ * Changes: bun:test → vitest, added .js import extensions
+ */
+import { describe, it, expect } from "vitest";
+import { searchEntries } from "../src/core/search-entries.js";
+import type { RenderedEntry } from "../src/core/render-entries.js";
+import type { Message } from "@earendil-works/pi-ai";
+
+const entries: RenderedEntry[] = [
+  { index: 0, role: "user", summary: "Fix login bug" },
+  { index: 1, role: "assistant", summary: "Reading auth.ts" },
+  { index: 2, role: "tool_result", summary: "[Read] code here" },
+  { index: 3, role: "assistant", summary: "Found the root cause in auth module" },
+];
+
+const messages: Message[] = [
+  { role: "user", content: "Fix login bug" } as any,
+  { role: "assistant", content: [{ type: "text", text: "Reading auth.ts" }] } as any,
+  { role: "toolResult", content: [{ type: "text", text: "[Read] code here" }] } as any,
+  { role: "assistant", content: [{ type: "text", text: "Found the root cause in auth module" }] } as any,
+];
+
+describe("searchEntries", () => {
+  it("returns all for empty query", () => {
+    expect(searchEntries(entries, messages)).toEqual(entries);
+    expect(searchEntries(entries, messages, "")).toEqual(entries);
+  });
+
+  it("filters by single term", () => {
+    const r = searchEntries(entries, messages, "login");
+    expect(r).toHaveLength(1);
+    expect(r[0].index).toBe(0);
+  });
+
+  it("returns empty for no match", () => {
+    expect(searchEntries(entries, messages, "xyz123")).toEqual([]);
+  });
+
+  it("finds keyword beyond clip boundary in full content", () => {
+    const longText = "A".repeat(400) + " hidden_keyword here";
+    const longEntries: RenderedEntry[] = [
+      { index: 0, role: "user", summary: "A".repeat(300) },
+    ];
+    const longMsgs: Message[] = [
+      { role: "user", content: longText } as any,
+    ];
+    const r = searchEntries(longEntries, longMsgs, "hidden_keyword");
+    expect(r).toHaveLength(1);
+    expect(r[0].snippet).toContain("hidden_keyword");
+  });
+
+  it("returns snippet around matched term", () => {
+    const r = searchEntries(entries, messages, "root");
+    expect(r).toHaveLength(1);
+    expect(r[0].snippet).toBeDefined();
+    expect(r[0].snippet).toContain("root");
+  });
+
+  // ── regex support ──
+
+  it("supports regex pattern: alternation", () => {
+    const r = searchEntries(entries, messages, "login|auth");
+    expect(r).toHaveLength(3); // "login bug", "auth.ts", "auth module"
+    expect(r.map((h) => h.index).sort()).toEqual([0, 1, 3]);
+  });
+
+  it("supports regex pattern: wildcard", () => {
+    const r = searchEntries(entries, messages, "Read.*auth");
+    expect(r).toHaveLength(1);
+    expect(r[0].index).toBe(1);
+  });
+
+  it("falls back to escaped literal for invalid regex", () => {
+    const extraEntries: RenderedEntry[] = [
+      { index: 0, role: "user", summary: "test (foo" },
+      { index: 1, role: "assistant", summary: "no match here" },
+    ];
+    const extraMsgs: Message[] = [
+      { role: "user", content: "error with (foo pattern" } as any,
+      { role: "assistant", content: [{ type: "text", text: "no match here" }] } as any,
+    ];
+    const r = searchEntries(extraEntries, extraMsgs, "(foo");
+    expect(r).toHaveLength(1);
+    expect(r[0].index).toBe(0);
+  });
+
+  it("regex is case-insensitive", () => {
+    const r = searchEntries(entries, messages, "FIX|ROOT");
+    expect(r).toHaveLength(2);
+  });
+
+  // ── natural language queries (OR logic + ranking) ──
+
+  it("natural language query uses OR logic", () => {
+    // "root cause auth" -- matches entries containing ANY of these terms
+    const r = searchEntries(entries, messages, "root cause auth");
+    expect(r.length).toBeGreaterThanOrEqual(2); // #3 has all 3, #1 has auth
+    // Best match (highest BM25) should come first
+    expect(r[0].index).toBe(3); // "Found the root cause in auth module" matches all 3
+  });
+
+  it("natural language ranks by BM25 score", () => {
+    const r = searchEntries(entries, messages, "root cause auth");
+    // Top result has more terms matched = higher BM25 score
+    expect(r[0].matchCount!).toBeGreaterThanOrEqual(r[r.length - 1].matchCount!);
+  });
+
+  it("filters stopwords from queries", () => {
+    // "the root cause of it" → stopwords: the, of, it → meaningful: root, cause
+    const r = searchEntries(entries, messages, "the root cause of it");
+    expect(r).toHaveLength(1);
+    expect(r[0].index).toBe(3);
+  });
+
+  it("keeps all terms if all are stopwords", () => {
+    // When all terms are stopwords, keep them (don't drop everything)
+    // "the" appears in "Found the root cause" so it matches
+    const r = searchEntries(entries, messages, "the");
+    expect(r.length).toBeGreaterThan(0);
+  });
+
+  // ── line-based snippet ──
+
+  it("snippet shows context lines around match", () => {
+    const multiline = "line 0\nline 1\nline 2 TARGET\nline 3\nline 4\nline 5";
+    const e: RenderedEntry[] = [{ index: 0, role: "user", summary: "test" }];
+    const m: Message[] = [{ role: "user", content: multiline } as any];
+    const r = searchEntries(e, m, "TARGET");
+    expect(r).toHaveLength(1);
+    const snip = r[0].snippet!;
+    expect(snip).toContain("line 2 TARGET");
+    expect(snip).toContain("line 0");
+    expect(snip).toContain("line 4");
+    expect(snip).not.toContain("line 5");
+  });
+
+  it("snippet handles match at beginning", () => {
+    const multiline = "TARGET here\nline 1\nline 2\nline 3";
+    const e: RenderedEntry[] = [{ index: 0, role: "user", summary: "test" }];
+    const m: Message[] = [{ role: "user", content: multiline } as any];
+    const r = searchEntries(e, m, "TARGET");
+    const snip = r[0].snippet!;
+    expect(snip).toContain("TARGET here");
+    expect(snip).toContain("line 2");
+    expect(snip).not.toContain("line 3");
+  });
+});

--- a/tests/vcc-support/load-session.ts
+++ b/tests/vcc-support/load-session.ts
@@ -1,0 +1,23 @@
+import { buildSessionContext, loadEntriesFromFile } from "../../node_modules/@earendil-works/pi-coding-agent/dist/core/session-manager.js";
+import type { Message } from "@earendil-works/pi-ai";
+
+export interface LoadedSession {
+  messageCount: number;
+  skippedCount: number;
+  messages: Message[];
+}
+
+export const loadSessionMessages = (file: string): LoadedSession => {
+  const entries = loadEntriesFromFile(file);
+  const sessionEntries = entries.filter((entry) => entry.type !== "header");
+  const context = buildSessionContext(sessionEntries as any);
+  const messages = (context.messages as any[]).filter(
+    (msg): msg is Message =>
+      msg && typeof msg.role === "string" && "content" in msg,
+  );
+  return {
+    messageCount: messages.length,
+    skippedCount: context.messages.length - messages.length,
+    messages,
+  };
+};

--- a/tests/vcc-support/real-sessions.ts
+++ b/tests/vcc-support/real-sessions.ts
@@ -1,0 +1,51 @@
+import { mkdir, mkdtemp, copyFile, chmod, readdir, stat } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, basename } from "node:path";
+
+const SESSION_ROOT = join(process.env.HOME ?? "", ".pi/agent/sessions");
+
+export interface SessionSample {
+  source: string;
+  copy: string;
+  size: number;
+  mtimeMs: number;
+}
+
+const walk = async (dir: string): Promise<string[]> => {
+  const names = await readdir(dir, { withFileTypes: true });
+  const out: string[] = [];
+  for (const name of names) {
+    const path = join(dir, name.name);
+    if (name.isDirectory()) out.push(...await walk(path));
+    else if (name.isFile() && path.endsWith(".jsonl")) out.push(path);
+  }
+  return out;
+};
+
+const pickLargest = async (limit: number): Promise<string[]> => {
+  const files = await walk(SESSION_ROOT);
+  const sized = await Promise.all(
+    files.map(async (file) => ({ file, size: (await stat(file)).size })),
+  );
+  return sized.sort((a, b) => b.size - a.size).slice(0, limit).map((x) => x.file);
+};
+
+export const prepareSessionSamples = async (limit = 2): Promise<SessionSample[]> => {
+  const selected = await pickLargest(limit);
+  const dir = await mkdtemp(join(tmpdir(), "pi-vcc-sessions-"));
+  await mkdir(dir, { recursive: true });
+  const samples: SessionSample[] = [];
+  for (const source of selected) {
+    const srcStat = await stat(source);
+    const copy = join(dir, basename(source));
+    await copyFile(source, copy);
+    await chmod(copy, 0o444);
+    samples.push({ source, copy, size: srcStat.size, mtimeMs: srcStat.mtimeMs });
+  }
+  return samples;
+};
+
+export const readSourceStat = async (sample: SessionSample) => {
+  const s = await stat(sample.source);
+  return { size: s.size, mtimeMs: s.mtimeMs };
+};


### PR DESCRIPTION
## Summary

This PR ports upstream tests from pi-vcc (22 files) and pi-observational-memory (9 files), and adds native blackhole tests for custom commands and infrastructure.

### VCC tests ported (22 files, 128 tests)
Direct clone + bun:test → vitest + .js extension replacements. Minimal adaptations:
- **normalize**: adapted for thinking blocks + isError (a156870 deferred)
- **compile**: removed recall-note assertion (now appended by before-compact hook)
- **before-compact-hook**: added mock omRuntime parameter for blackhole's extended signature
- **recall-expand**: exported `invalidExpandIndices` from src/tools/recall.ts

### OM tests ported (9 files, 78 tests)
- clipboard, session-ledger-types, session-ledger-progress, session-ledger-fold: import path only
- dropper-coverage, observer, reflector: minor API adaptations
- dropper: pool-math adapted for blackhole's ratio-based algorithm
- compaction-trigger: adapted for queueMicrotask-based deferral

### Native blackhole tests (4 new files, 33 tests)
- **memory-command**: status/pipeline counters, view/full modes, passive/in-flight/error indicators
- **blackhole-command**: compaction trigger, om-off/om-on, noAutoCompact flush path
- **blackhole-recall**: search, pagination, scope:all, empty/no-session errors
- **debug-log**: write-to-file, context inheritance, enabled/disabled

### Skipped
- `real-sessions.test.ts` (needs live session files on disk)
- `consolidation-trigger.test.ts`, `dropper-pool.test.ts`, `status-command.test.ts`, `view-command.test.ts`, `compaction-hook.test.ts`, `recall-tool.test.ts` (REWRITTEN/ELIMINATED/MERGED files)

### Stats
- **329/329** tests passing across **40 test files**
- **21 production source files** tested
- **1 new export**: `invalidExpandIndices` in `src/tools/recall.ts`