### PR TITLE
fix: crash protection — jiti bridge, EACCES guards, config safety

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -18,6 +18,47 @@ import { registerRecallTool } from "./src/tools/recall";
 import { Runtime } from "./src/om/runtime.js";
 
 export default (pi: ExtensionAPI) => {
+	// ── Bridge: capture custom provider stream functions for jiti-loaded agents ──
+	// pi-blackhole's consolidation agents are loaded via jiti with moduleCache: false,
+	// which creates a separate pi-ai instance whose apiProviderRegistry lacks custom
+	// providers (e.g., claude-bridge registered by other extensions). This bridge stores
+	// streamSimple functions in a Symbol.for() global so agents can access them without
+	// going through pi-ai's registry.
+	//
+	// There are two mechanisms:
+	// 1. Wrap pi.registerProvider to capture streamSimple at registration time.
+	//    This handles providers registered AFTER our factory runs.
+	// 2. On agent_start, scan modelRegistry.registeredProviders for any providers
+	//    that registered BEFORE our factory ran (different extension load order).
+	const PROVIDER_STREAMS_KEY = Symbol.for("pi-blackhole:provider-streams");
+	const providerStreams: Map<string, Function> = (globalThis as any)[PROVIDER_STREAMS_KEY] ??= new Map();
+
+	const origRegisterProvider = pi.registerProvider.bind(pi);
+	pi.registerProvider = (name: string, config: any) => {
+		if (config && config.streamSimple && config.api) {
+			providerStreams.set(config.api, config.streamSimple);
+		}
+		origRegisterProvider(name, config);
+	};
+
+	// Fallback: on agent_start, capture providers that registered before our wrapper
+	// (handles the case where pi-blackhole loads after another provider extension).
+	pi.on("agent_start", (_event: unknown, ctx: any) => {
+		if (providerStreams.size > 0) return; // Already have captures
+		// modelRegistry.registeredProviders is declared private in TypeScript but is a
+		// regular JS class field at runtime. We access it via bracket notation for
+		// future-proofing against potential #private migration.
+		const registry = (ctx as any)?.modelRegistry;
+		const registered: Map<string, any> | undefined = registry?.["registeredProviders"];
+		if (registered && typeof registered.forEach === "function") {
+			registered.forEach((config: any, _name: string) => {
+				if (config && config.streamSimple && config.api && !providerStreams.has(config.api)) {
+					providerStreams.set(config.api, config.streamSimple);
+				}
+			});
+		}
+	});
+
 	scaffoldSettings();
 
 	const omRuntime = new Runtime();

--- a/index.ts
+++ b/index.ts
@@ -43,8 +43,12 @@ export default (pi: ExtensionAPI) => {
 
 	// Fallback: on agent_start, capture providers that registered before our wrapper
 	// (handles the case where pi-blackhole loads after another provider extension).
+	// Uses a dedicated flag instead of checking providerStreams.size so the scan
+	// always runs once even if the wrapper already captured some providers.
+	let hasScannedFallback = false;
 	pi.on("agent_start", (_event: unknown, ctx: any) => {
-		if (providerStreams.size > 0) return; // Already have captures
+		if (hasScannedFallback) return;
+		hasScannedFallback = true
 		// modelRegistry.registeredProviders is declared private in TypeScript but is a
 		// regular JS class field at runtime. We access it via bracket notation for
 		// future-proofing against potential #private migration.

--- a/src/commands/pi-vcc.ts
+++ b/src/commands/pi-vcc.ts
@@ -35,19 +35,29 @@ export const registerPiVccCommand = (pi: ExtensionAPI, runtime: Runtime) => {
 			if (trimmed === "om-off") {
 				const saved = saveUnifiedConfig({ memory: false });
 				runtime.config.memory = false;
-				ctx.ui.notify(
-					saved ? "Observational memory disabled. Use /blackhole om-on to re-enable." : "Failed to save config.",
-					"info",
-				);
+				if (saved) {
+					ctx.ui.notify("Observational memory disabled. Use /blackhole om-on to re-enable.", "info");
+				} else {
+					ctx.ui.notify(
+						"Failed to save config — the config file may be read-only (e.g., managed by Nix). " +
+						"Runtime state updated for this session only.",
+						"warning",
+					);
+				}
 				return;
 			}
 			if (trimmed === "om-on") {
 				const saved = saveUnifiedConfig({ memory: true });
 				runtime.config.memory = true;
-				ctx.ui.notify(
-					saved ? "Observational memory enabled." : "Failed to save config.",
-					"info",
-				);
+				if (saved) {
+					ctx.ui.notify("Observational memory enabled.", "info");
+				} else {
+					ctx.ui.notify(
+						"Failed to save config — the config file may be read-only (e.g., managed by Nix). " +
+						"Runtime state updated for this session only.",
+						"warning",
+					);
+				}
 				return;
 			}
 

--- a/src/core/unified-config.ts
+++ b/src/core/unified-config.ts
@@ -252,8 +252,30 @@ export function loadUnifiedConfig(cwd: string): UnifiedConfig {
 	// Merge defaults then override
 	const merged = { ...DEFAULTS, ...parsed };
 
-	// Derive observationsPoolTargetTokens if unset or invalid (must be < max)
-	if (merged.observationsPoolTargetTokens >= merged.observationsPoolMaxTokens) {
+	// ── Validate all numeric fields ──
+	// Prevents NaN/undefined from leaking into runtime math.
+	const NUMERIC_KEYS: ReadonlyArray<keyof UnifiedConfig> = [
+		"observeAfterTokens", "reflectAfterTokens", "compactAfterTokens",
+		"observationsPoolMaxTokens", "observationsPoolTargetTokens",
+		"reflectorInputMaxTokens", "dropperInputMaxTokens",
+		"observerChunkMaxTokens", "observerPreambleMaxTokens",
+		"agentMaxTurns",
+	];
+	for (const k of NUMERIC_KEYS) {
+		const v = (merged as Record<string, unknown>)[k];
+		// observerPreambleMaxTokens=0 means "auto-compute from observerChunkMaxTokens (30%)"
+		// so 0 is valid for that field. All other numeric fields must be strictly positive.
+		const minVal = k === "observerPreambleMaxTokens" ? 0 : 1;
+		if (typeof v !== "number" || !Number.isFinite(v) || v < minVal) {
+			(merged as Record<string, unknown>)[k] = DEFAULTS[k];
+		}
+	}
+
+	// Derive observationsPoolTargetTokens if still unset or invalid (must be < max)
+	if (
+		merged.observationsPoolTargetTokens === undefined ||
+		merged.observationsPoolTargetTokens >= merged.observationsPoolMaxTokens
+	) {
 		merged.observationsPoolTargetTokens = Math.floor(merged.observationsPoolMaxTokens / 2);
 	}
 
@@ -279,7 +301,11 @@ export function saveUnifiedConfig(settings: Partial<UnifiedConfig>): boolean {
 
 /**
  * Ensure ~/.pi/agent/pi-blackhole/pi-blackhole-config.json exists with defaults.
- * If the file exists but is missing keys, fill them in.
+ *
+ * Only creates the file if it doesn't exist. Missing keys are filled at read
+ * time by loadUnifiedConfig() via { ...DEFAULTS, ...parsed } merge, so there
+ * is no need to keep the on-disk file "complete". This avoids a crash on
+ * read-only filesystems where the config is managed externally (e.g., Nix).
  */
 export function scaffoldConfig(): void {
 	try {
@@ -289,21 +315,7 @@ export function scaffoldConfig(): void {
 
 		if (!existsSync(path)) {
 			writeFileSync(path, `${JSON.stringify(DEFAULTS, null, 2)}\n`);
-			return;
 		}
-
-		const parsed = readJson(path);
-		if (!parsed || typeof parsed !== "object") return;
-
-		let changed = false;
-		const next: Record<string, unknown> = { ...parsed };
-		for (const [key, value] of Object.entries(DEFAULTS)) {
-			if (!(key in next)) {
-				next[key] = value;
-				changed = true;
-			}
-		}
-		if (changed) writeFileSync(path, `${JSON.stringify(next, null, 2)}\n`);
 	} catch (e) {
 		console.error("blackhole: config scaffold failed", e);
 	}

--- a/src/om/agents/dropper/agent.ts
+++ b/src/om/agents/dropper/agent.ts
@@ -7,7 +7,8 @@
  */
 import { agentLoop, type AgentContext, type AgentLoopConfig, type AgentTool } from "@earendil-works/pi-agent-core";
 import type { Message, Model, ModelThinkingLevel } from "@earendil-works/pi-ai";
-import { Type } from "@earendil-works/pi-ai";
+import { streamSimple } from "@earendil-works/pi-ai";
+import { Type } from "typebox";
 import type { Static } from "typebox";
 import { debugLog } from "../../debug-log.js";
 import { AGENT_LOOP_MAX_TOKENS, boundedMaxTokens } from "../../model-budget.js";
@@ -33,6 +34,10 @@ interface RunDropperArgs {
 	budgetTokens: number;
 	signal?: AbortSignal;
 	agentLoop?: typeof agentLoop;
+	/** Optional custom stream function bypassing agentLoop's default streamSimple.
+	 *  Used by the Symbol.for bridge to access native pi-ai provider registrations
+	 *  from jiti-loaded consolidation agents. */
+	streamFn?: (model: any, context: any, options: any) => any;
 	maxTurns?: number;
 	thinkingLevel?: ModelThinkingLevel;
 }
@@ -281,7 +286,18 @@ export async function runDropper(args: RunDropperArgs): Promise<string[] | undef
 	};
 
 	const loop = args.agentLoop ?? agentLoop;
-	const stream = loop(prompts, context, config, signal);
+	// ── Bridge stream function ──
+	const PROVIDER_STREAMS_KEY = Symbol.for("pi-blackhole:provider-streams");
+	const bridgeStreamFn = (() => {
+		const providerStreams: Map<string, Function> | undefined = (globalThis as any)[PROVIDER_STREAMS_KEY];
+		if (!providerStreams || providerStreams.size === 0) return undefined;
+		return (model: any, ctx: any, opts: any) => {
+			const customFn = providerStreams.get(model.api);
+			return customFn ? customFn(model, ctx, opts) : streamSimple(model, ctx, opts);
+		};
+	})();
+	const streamFn = args.streamFn ?? bridgeStreamFn;
+	const stream = loop(prompts, context, config, signal, streamFn);
 	let agentError: string | undefined;
 	for await (const event of stream) {
 		// Tool execution collects candidate ids.

--- a/src/om/agents/dropper/agent.ts
+++ b/src/om/agents/dropper/agent.ts
@@ -291,7 +291,7 @@ export async function runDropper(args: RunDropperArgs): Promise<string[] | undef
 	const bridgeStreamFn = (model: any, ctx: any, opts: any) => {
 		const providerStreams: Map<string, Function> | undefined = (globalThis as any)[PROVIDER_STREAMS_KEY];
 		if (!providerStreams) return streamSimple(model, ctx, opts);
-		const customFn = providerStreams.get(model.api);
+		const customFn = model?.api ? providerStreams.get(model.api) : undefined;
 		return customFn ? customFn(model, ctx, opts) : streamSimple(model, ctx, opts);
 	};
 	const streamFn = args.streamFn ?? bridgeStreamFn;

--- a/src/om/agents/dropper/agent.ts
+++ b/src/om/agents/dropper/agent.ts
@@ -288,14 +288,12 @@ export async function runDropper(args: RunDropperArgs): Promise<string[] | undef
 	const loop = args.agentLoop ?? agentLoop;
 	// ── Bridge stream function ──
 	const PROVIDER_STREAMS_KEY = Symbol.for("pi-blackhole:provider-streams");
-	const bridgeStreamFn = (() => {
+	const bridgeStreamFn = (model: any, ctx: any, opts: any) => {
 		const providerStreams: Map<string, Function> | undefined = (globalThis as any)[PROVIDER_STREAMS_KEY];
-		if (!providerStreams || providerStreams.size === 0) return undefined;
-		return (model: any, ctx: any, opts: any) => {
-			const customFn = providerStreams.get(model.api);
-			return customFn ? customFn(model, ctx, opts) : streamSimple(model, ctx, opts);
-		};
-	})();
+		if (!providerStreams) return streamSimple(model, ctx, opts);
+		const customFn = providerStreams.get(model.api);
+		return customFn ? customFn(model, ctx, opts) : streamSimple(model, ctx, opts);
+	};
 	const streamFn = args.streamFn ?? bridgeStreamFn;
 	const stream = loop(prompts, context, config, signal, streamFn);
 	let agentError: string | undefined;

--- a/src/om/agents/observer/agent.ts
+++ b/src/om/agents/observer/agent.ts
@@ -233,7 +233,7 @@ ${conversation}`;
 	const bridgeStreamFn = (model: any, ctx: any, opts: any) => {
 		const providerStreams: Map<string, Function> | undefined = (globalThis as any)[PROVIDER_STREAMS_KEY];
 		if (!providerStreams) return streamSimple(model, ctx, opts);
-		const customFn = providerStreams.get(model.api);
+		const customFn = model?.api ? providerStreams.get(model.api) : undefined;
 		return customFn ? customFn(model, ctx, opts) : streamSimple(model, ctx, opts);
 	};
 	const streamFn = args.streamFn ?? bridgeStreamFn;

--- a/src/om/agents/observer/agent.ts
+++ b/src/om/agents/observer/agent.ts
@@ -8,7 +8,8 @@
  */
 import { agentLoop, type AgentContext, type AgentLoopConfig, type AgentTool } from "@earendil-works/pi-agent-core";
 import type { Message, Model, ModelThinkingLevel } from "@earendil-works/pi-ai";
-import { Type } from "@earendil-works/pi-ai";
+import { streamSimple } from "@earendil-works/pi-ai";
+import { Type } from "typebox";
 import type { Static } from "typebox";
 import { hashId } from "../../ids.js";
 import { AGENT_LOOP_MAX_TOKENS, boundedMaxTokens } from "../../model-budget.js";
@@ -27,6 +28,10 @@ interface RunObserverArgs {
 	allowedSourceEntryIds: string[];
 	signal?: AbortSignal;
 	agentLoop?: typeof agentLoop;
+	/** Optional custom stream function bypassing agentLoop's default streamSimple.
+	 *  Used by the Symbol.for bridge to access native pi-ai provider registrations
+	 *  from jiti-loaded consolidation agents. */
+	streamFn?: (model: any, context: any, options: any) => any;
 	maxTurns?: number;
 	thinkingLevel?: ModelThinkingLevel;
 }
@@ -217,7 +222,24 @@ ${conversation}`;
 	};
 
 	const loop = args.agentLoop ?? agentLoop;
-	const stream = loop(prompts, context, config, signal);
+	// ── Bridge stream function ──
+	// Consolidation agents run via jiti (moduleCache: false) which creates a separate
+	// pi-ai instance whose apiProviderRegistry lacks custom providers registered by
+	// other extensions (e.g., claude-bridge). The bridge looks up streamSimple functions
+	// from a Symbol.for() global that index.ts populates during provider registration.
+	// If no custom provider is found, it falls back to the jiti-loaded streamSimple
+	// which handles all built-in providers correctly.
+	const PROVIDER_STREAMS_KEY = Symbol.for("pi-blackhole:provider-streams");
+	const bridgeStreamFn = (() => {
+		const providerStreams: Map<string, Function> | undefined = (globalThis as any)[PROVIDER_STREAMS_KEY];
+		if (!providerStreams || providerStreams.size === 0) return undefined;
+		return (model: any, ctx: any, opts: any) => {
+			const customFn = providerStreams.get(model.api);
+			return customFn ? customFn(model, ctx, opts) : streamSimple(model, ctx, opts);
+		};
+	})();
+	const streamFn = args.streamFn ?? bridgeStreamFn;
+	const stream = loop(prompts, context, config, signal, streamFn);
 	let agentError: string | undefined;
 	for await (const event of stream) {
 		// Drain events; the tool's execute already collects records.

--- a/src/om/agents/observer/agent.ts
+++ b/src/om/agents/observer/agent.ts
@@ -230,14 +230,12 @@ ${conversation}`;
 	// If no custom provider is found, it falls back to the jiti-loaded streamSimple
 	// which handles all built-in providers correctly.
 	const PROVIDER_STREAMS_KEY = Symbol.for("pi-blackhole:provider-streams");
-	const bridgeStreamFn = (() => {
+	const bridgeStreamFn = (model: any, ctx: any, opts: any) => {
 		const providerStreams: Map<string, Function> | undefined = (globalThis as any)[PROVIDER_STREAMS_KEY];
-		if (!providerStreams || providerStreams.size === 0) return undefined;
-		return (model: any, ctx: any, opts: any) => {
-			const customFn = providerStreams.get(model.api);
-			return customFn ? customFn(model, ctx, opts) : streamSimple(model, ctx, opts);
-		};
-	})();
+		if (!providerStreams) return streamSimple(model, ctx, opts);
+		const customFn = providerStreams.get(model.api);
+		return customFn ? customFn(model, ctx, opts) : streamSimple(model, ctx, opts);
+	};
 	const streamFn = args.streamFn ?? bridgeStreamFn;
 	const stream = loop(prompts, context, config, signal, streamFn);
 	let agentError: string | undefined;

--- a/src/om/agents/reflector/agent.ts
+++ b/src/om/agents/reflector/agent.ts
@@ -7,7 +7,8 @@
  */
 import { agentLoop, type AgentContext, type AgentLoopConfig, type AgentTool } from "@earendil-works/pi-agent-core";
 import type { Message, Model, ModelThinkingLevel } from "@earendil-works/pi-ai";
-import { Type } from "@earendil-works/pi-ai";
+import { streamSimple } from "@earendil-works/pi-ai";
+import { Type } from "typebox";
 import type { Static } from "typebox";
 import { hashId } from "../../ids.js";
 import { AGENT_LOOP_MAX_TOKENS, boundedMaxTokens } from "../../model-budget.js";
@@ -29,6 +30,10 @@ interface RunReflectorArgs {
 	existingObservationsSummary?: string;
 	signal?: AbortSignal;
 	agentLoop?: typeof agentLoop;
+	/** Optional custom stream function bypassing agentLoop's default streamSimple.
+	 *  Used by the Symbol.for bridge to access native pi-ai provider registrations
+	 *  from jiti-loaded consolidation agents. */
+	streamFn?: (model: any, context: any, options: any) => any;
 	maxTurns?: number;
 	thinkingLevel?: ModelThinkingLevel;
 }
@@ -144,7 +149,18 @@ export async function runReflector(args: RunReflectorArgs): Promise<Reflection[]
 	};
 
 	const loop = args.agentLoop ?? agentLoop;
-	const stream = loop(prompts, context, config, signal);
+	// ── Bridge stream function ──
+	const PROVIDER_STREAMS_KEY = Symbol.for("pi-blackhole:provider-streams");
+	const bridgeStreamFn = (() => {
+		const providerStreams: Map<string, Function> | undefined = (globalThis as any)[PROVIDER_STREAMS_KEY];
+		if (!providerStreams || providerStreams.size === 0) return undefined;
+		return (model: any, ctx: any, opts: any) => {
+			const customFn = providerStreams.get(model.api);
+			return customFn ? customFn(model, ctx, opts) : streamSimple(model, ctx, opts);
+		};
+	})();
+	const streamFn = args.streamFn ?? bridgeStreamFn;
+	const stream = loop(prompts, context, config, signal, streamFn);
 	let agentError: string | undefined;
 	for await (const event of stream) {
 		// Tool execution collects records.

--- a/src/om/agents/reflector/agent.ts
+++ b/src/om/agents/reflector/agent.ts
@@ -151,14 +151,12 @@ export async function runReflector(args: RunReflectorArgs): Promise<Reflection[]
 	const loop = args.agentLoop ?? agentLoop;
 	// ── Bridge stream function ──
 	const PROVIDER_STREAMS_KEY = Symbol.for("pi-blackhole:provider-streams");
-	const bridgeStreamFn = (() => {
+	const bridgeStreamFn = (model: any, ctx: any, opts: any) => {
 		const providerStreams: Map<string, Function> | undefined = (globalThis as any)[PROVIDER_STREAMS_KEY];
-		if (!providerStreams || providerStreams.size === 0) return undefined;
-		return (model: any, ctx: any, opts: any) => {
-			const customFn = providerStreams.get(model.api);
-			return customFn ? customFn(model, ctx, opts) : streamSimple(model, ctx, opts);
-		};
-	})();
+		if (!providerStreams) return streamSimple(model, ctx, opts);
+		const customFn = providerStreams.get(model.api);
+		return customFn ? customFn(model, ctx, opts) : streamSimple(model, ctx, opts);
+	};
 	const streamFn = args.streamFn ?? bridgeStreamFn;
 	const stream = loop(prompts, context, config, signal, streamFn);
 	let agentError: string | undefined;

--- a/src/om/agents/reflector/agent.ts
+++ b/src/om/agents/reflector/agent.ts
@@ -154,7 +154,7 @@ export async function runReflector(args: RunReflectorArgs): Promise<Reflection[]
 	const bridgeStreamFn = (model: any, ctx: any, opts: any) => {
 		const providerStreams: Map<string, Function> | undefined = (globalThis as any)[PROVIDER_STREAMS_KEY];
 		if (!providerStreams) return streamSimple(model, ctx, opts);
-		const customFn = providerStreams.get(model.api);
+		const customFn = model?.api ? providerStreams.get(model.api) : undefined;
 		return customFn ? customFn(model, ctx, opts) : streamSimple(model, ctx, opts);
 	};
 	const streamFn = args.streamFn ?? bridgeStreamFn;

--- a/src/om/cooldown.ts
+++ b/src/om/cooldown.ts
@@ -57,10 +57,17 @@ function readCooldownMap(): CooldownMap {
 }
 
 function writeCooldownMap(map: CooldownMap): void {
-	const path = cooldownPath();
-	const dir = dirname(path);
-	if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
-	writeFileSync(path, `${JSON.stringify(map, null, 2)}\n`);
+	try {
+		const path = cooldownPath();
+		const dir = dirname(path);
+		if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+		writeFileSync(path, `${JSON.stringify(map, null, 2)}\n`);
+	} catch {
+		// Best-effort: cooldowns are advisory. Losing them means a rate-limited
+		// model might be retried before its cooldown window expires — slightly
+		// more API traffic, no data loss. This also prevents a process crash
+		// on read-only filesystems.
+	}
 }
 
 // ── API ─────────────────────────────────────────────────────────────────────

--- a/src/om/pending.ts
+++ b/src/om/pending.ts
@@ -143,7 +143,13 @@ function writeSessionState(sessionId: string, state: PendingOMState): void {
 		}
 	} catch { /* best-effort — stale backup is optional */ }
 
-	writeFileSync(path, `${JSON.stringify(state, null, 2)}\n`);
+	try {
+		writeFileSync(path, `${JSON.stringify(state, null, 2)}\n`);
+	} catch {
+		// Best-effort: pending state loss means consolidation may re-process
+		// the same data on the next run — safe (idempotent by design).
+		// Prevents process crash on read-only filesystems.
+	}
 }
 
 /**

--- a/src/tools/recall.ts
+++ b/src/tools/recall.ts
@@ -4,7 +4,7 @@
  *
  * Created by pi-vcc-om. Replaces pi-vcc's vcc_recall and OM's standalone recall-observation.
  */
-import { Type } from "@earendil-works/pi-ai";
+import { Type } from "typebox";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { loadAllMessages } from "../core/load-messages";
 import { searchEntries } from "../core/search-entries";


### PR DESCRIPTION
## Summary

Fixes two independent crash vectors reported by a NixOS user running pi-blackhole alongside pi-claude-bridge on a read-only filesystem.

### [A] jiti `moduleCache:false` instance isolation (P0)

**Root cause**: pi-core's extension loader uses jiti with `moduleCache: false`, creating separate pi-ai instances for each import. Custom providers registered by other extensions (e.g., claude-bridge) are stored in the native pi-ai's `apiProviderRegistry`, but consolidation agents read from the jiti-loaded instance which lacks them — causing `No API provider registered` crashes on session startup.

**Fix**: Three-part Symbol.for() bridge:
1. Wrap `pi.registerProvider` in `index.ts` to capture `streamSimple` at registration time (handles providers registered after our factory)
2. Scan `modelRegistry.registeredProviders` on `agent_start` as fallback (handles providers registered before our factory)
3. Agent files pass bridge `streamFn` as 5th arg to `agentLoop`, checking bridge first then falling back to jiti `streamSimple` for built-in providers

### [B] Unguarded filesystem writes (P1)

**Root cause**: `writeCooldownMap()` and `writeSessionState()` final `writeFileSync` crashed on read-only filesystems.

**Fix**: try/catch wrappers with best-effort semantics. `scaffoldConfig` no longer modifies existing config files.

### Additional safety (P2-P3)

- Defensive numeric field validation in `loadUnifiedConfig`
- Replace `import { Type } from pi-ai` with `typebox` (removes 4 unnecessary jiti pi-ai triggers)
- Improved `saveUnifiedConfig` failure message for read-only FS

## Verification

- TypeScript: 0 new errors (54 pre-existing test-file errors unchanged)
- All 329 existing tests pass
- No breaking changes, no new dependencies, no pi-core modifications
- Load-order agnostic (works regardless of which extension loads first)