### PR TITLE
fix: resolve non-message piFirstKeptEntryId to next message in pi-default tail

### DIFF
--- a/src/hooks/before-compact.ts
+++ b/src/hooks/before-compact.ts
@@ -162,8 +162,8 @@ export function buildOwnCut(
       // (e.g., refers to a non-message entry like type:"custom" OM metadata or
       // type:"compaction"). Resolve to the next message entry after pi's cut point.
       if (liveCutIdx < 0) {
-        const nextMsgEntry = branchEntries.slice(cutInBranch + 1).find(
-          (e: any) => e.type === "message" && e.message,
+        const nextMsgEntry = branchEntries.find(
+          (e: any, i: number) => i > cutInBranch && e.type === "message" && e.message,
         );
         if (nextMsgEntry) {
           const resolvedId: string = nextMsgEntry.id;

--- a/src/hooks/before-compact.ts
+++ b/src/hooks/before-compact.ts
@@ -159,7 +159,41 @@ export function buildOwnCut(
         // Single user message — fall through to minimal path (will compact-all)
       }
       // liveCutIdx === -1: piFirstKeptEntryId not found in liveMessages
-      // (e.g., refers to a compaction entry) — fall through to minimal/orphan recovery
+      // (e.g., refers to a non-message entry like type:"custom" OM metadata or
+      // type:"compaction"). Resolve to the next message entry after pi's cut point.
+      if (liveCutIdx < 0) {
+        const nextMsgEntry = branchEntries.slice(cutInBranch + 1).find(
+          (e: any) => e.type === "message" && e.message,
+        );
+        if (nextMsgEntry) {
+          const resolvedId: string = nextMsgEntry.id;
+          const resolvedLiveIdx = liveMessages.findIndex(
+            (lm) => lm.entry.id === resolvedId,
+          );
+          if (resolvedLiveIdx > 0) {
+            return {
+              ok: true,
+              messages: liveMessages.slice(0, resolvedLiveIdx).map((e) => e.message),
+              firstKeptEntryId: resolvedId,
+              compactAll: false,
+            };
+          }
+          if (resolvedLiveIdx === 0) {
+            let lastUserIdx = liveMessages.length - 1;
+            while (lastUserIdx > 0 && liveMessages[lastUserIdx].message.role !== "user") {
+              lastUserIdx--;
+            }
+            if (lastUserIdx > 0) {
+              return { ok: false, reason: "too_few_live_messages" };
+            }
+            // Single user message — fall through to minimal (will compact-all)
+          }
+          // resolvedLiveIdx === -1: resolved message not in liveMessages
+          // (shouldn't happen since liveMessages starts from prior firstKeptEntryId
+          // which should be before or at pi's cut), but fall through if it does.
+        }
+        // No message found after pi's cut point in branch — fall through
+      }
     }
     // piFirstKeptEntryId not found in branch → fall through to minimal / orphan recovery
   }

--- a/tests/vcc-before-compact.test.ts
+++ b/tests/vcc-before-compact.test.ts
@@ -76,6 +76,30 @@ describe("buildOwnCut", () => {
     expect(r.messages).toHaveLength(2);   // m1,m2 compiled
   });
 
+  test("T21b: tailBehavior pi-default with non-message Pi cut — resolves to next message", () => {
+    // Pi's cut points to a non-message entry (e.g. type: "custom" OM reflection).
+    // Should resolve to the next message entry and use Pi's cut position.
+    const r = buildOwnCut(
+      [
+        msg("m1", "user", "a"),
+        msg("m2", "assistant", "b"),
+        { id: "om1", type: "custom", customType: "om.reflections.recorded", data: {} },
+        msg("m3", "user", "c"),
+        msg("m4", "assistant", "d"),
+        msg("m5", "user", "e"),
+        msg("m6", "assistant", "f"),
+      ],
+      "om1",        // Pi cut at non-message entry
+      "pi-default",
+    );
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    // Should resolve to m3 (next message after om1) and compile only [m1,m2]
+    expect(r.firstKeptEntryId).toBe("m3");
+    expect(r.messages).toHaveLength(2);
+    expect(r.compactAll).toBe(false);
+  });
+
   test("T22: tailBehavior pi-default with no piFirstKeptEntryId — fall through to minimal", () => {
     // No Pi cut provided → fall through to minimal, cut at m3 (last user)
     const r = buildOwnCut(


### PR DESCRIPTION
## Problem

When `tailBehavior` is set to `pi-default` and pi's `firstKeptEntryId` points to a non-message entry (e.g., `type: custom` OM reflection entry), `buildOwnCut` cannot find it in `liveMessages` (which only contains `type: message` entries). This causes `liveCutIdx === -1`, silently falling through to the minimal fallback path — defeating the user's explicit pi-default choice.

## Fix

In the pi-default path, when `liveCutIdx === -1`, scan `branchEntries` forward from `cutInBranch + 1` to find the next `type: message` entry. Use that resolved entry's ID as the cut point. The same edge cases are handled:

- `resolvedLiveIdx === 0`: multi-user message guard applies, falls through to minimal
- No message found after pi's cut: falls through to minimal

## Test

**T21b**: simulates a branch with a `type: custom` entry at pi's boundary position and a `piFirstKeptEntryId` pointing to it. Expects resolution to the next message (`m3`) with only `[m1, m2]` compiled.