### PR TITLE
feat: cooldownHours: 0 disables cooldown without disk writes

### DIFF
--- a/src/core/unified-config.ts
+++ b/src/core/unified-config.ts
@@ -187,6 +187,11 @@ function positiveInt(v: unknown): number | undefined {
 	return Number.isInteger(v) && typeof v === "number" && v > 0 ? v : undefined;
 }
 
+/** Like positiveInt but allows 0. Used for cooldownHours where 0 means "disabled". */
+function nonNegativeInt(v: unknown): number | undefined {
+	return Number.isInteger(v) && typeof v === "number" && v >= 0 ? v : undefined;
+}
+
 function parseModel(v: unknown): OmModelConfig | undefined {
 	if (!isRecord(v)) return undefined;
 	const provider = nonEmptyString(v.provider);
@@ -194,7 +199,7 @@ function parseModel(v: unknown): OmModelConfig | undefined {
 	if (!provider || !id) return undefined;
 	const model: OmModelConfig = { provider, id };
 	if (isThinkingLevel(v.thinking)) model.thinking = v.thinking;
-	const cooldown = positiveInt(v.cooldownHours);
+	const cooldown = nonNegativeInt(v.cooldownHours);
 	if (cooldown !== undefined) model.cooldownHours = cooldown;
 	const ctxWindow = positiveInt(v.contextWindow);
 	if (ctxWindow !== undefined) model.contextWindow = ctxWindow;

--- a/src/om/consolidation.ts
+++ b/src/om/consolidation.ts
@@ -184,13 +184,14 @@ function stageThinkingLevel(runtime: Runtime, stage: "observer" | "reflector" | 
 
 function makeModelResolver(runtime: Runtime, ctx: ConsolidationCtx): (stage: "observer" | "reflector" | "dropper") => Promise<ResolvedModel | undefined> {
 	return async (stage) => {
+		const stageFallbacks = stageFallbackModels(runtime, stage);
 		const resolved = await runtime.resolveModel({
 			model: ctx.model,
 			modelRegistry: ctx.modelRegistry,
 			hasUI: ctx.hasUI,
 			ui: ctx.ui,
 			stageModel: stageModelConfig(runtime, stage),
-			stageFallbacks: stageFallbackModels(runtime, stage),
+			stageFallbacks,
 		});
 		if (resolved.ok) {
 			runtime.resolveFailureNotified = false;
@@ -198,7 +199,17 @@ function makeModelResolver(runtime: Runtime, ctx: ConsolidationCtx): (stage: "ob
 		}
 		debugLog(`${stage}.model_unavailable`, { reason: resolved.reason });
 		if (!runtime.resolveFailureNotified && ctx.hasUI && ctx.ui) {
-			ctx.ui.notify(`Observational memory: ${stage} skipped — ${resolved.reason}`, "warning");
+			if (runtime.failedInCycle.size > 0) {
+				const fallbackMsg = stageFallbacks.length === 0
+					? "no fallbacks configured"
+					: "no available fallbacks";
+				ctx.ui.notify(
+					`Observational memory: ${stage} skipped — model unavailable (cooldown set to 0, ${fallbackMsg}, will retry next run)`,
+					"info",
+				);
+			} else {
+				ctx.ui.notify(`Observational memory: ${stage} skipped — ${resolved.reason}`, "warning");
+			}
 			runtime.resolveFailureNotified = true;
 		}
 		return undefined;
@@ -254,6 +265,7 @@ export async function runConsolidationPipeline(
 	const resolveModel = makeModelResolver(runtime, ctx);
 
 	runtime.consolidationPhase = "observer";
+	runtime.failedInCycle.clear();
 	try {
 		const observerOutcome = await runObserverStage(pi, runtime, ctx, resolveModel);
 		if (observerOutcome === "abort") return;
@@ -263,6 +275,7 @@ export async function runConsolidationPipeline(
 	}
 
 	runtime.consolidationPhase = "reflector";
+	runtime.failedInCycle.clear();
 	let reflectorResult: ReflectorStageResult;
 	try {
 		reflectorResult = await runReflectorStage(pi, runtime, ctx, resolveModel);
@@ -273,6 +286,7 @@ export async function runConsolidationPipeline(
 	}
 
 	runtime.consolidationPhase = "dropper";
+	runtime.failedInCycle.clear();
 	try {
 		await runDropperStage(pi, runtime, ctx, resolveModel, reflectorResult.sameRunReflections, reflectorResult.effectiveReflectionCoverageId);
 	} catch (error) {

--- a/src/om/consolidation.ts
+++ b/src/om/consolidation.ts
@@ -199,7 +199,7 @@ function makeModelResolver(runtime: Runtime, ctx: ConsolidationCtx): (stage: "ob
 		}
 		debugLog(`${stage}.model_unavailable`, { reason: resolved.reason });
 		if (!runtime.resolveFailureNotified && ctx.hasUI && ctx.ui) {
-			if (runtime.failedInCycle.size > 0) {
+			if (runtime.failedInCycle.size > 0 && resolved.reason.includes("all candidates exhausted")) {
 				const fallbackMsg = stageFallbacks.length === 0
 					? "no fallbacks configured"
 					: "no available fallbacks";

--- a/src/om/cooldown.ts
+++ b/src/om/cooldown.ts
@@ -75,8 +75,13 @@ function writeCooldownMap(map: CooldownMap): void {
 /**
  * Check whether a model is currently cooled down.
  * Expired entries are cleaned up lazily.
+ *
+ * When cooldownHours is explicitly 0, cooldown is disabled — always returns false.
  */
 export function isCooldownActive(model: OmModelConfig, now: Date = new Date()): boolean {
+	// cooldownHours === 0 means cooldown disabled
+	if (model.cooldownHours === 0) return false;
+
 	const map = readCooldownMap();
 	const key = modelKey(model);
 	const entry = map[key];
@@ -97,11 +102,16 @@ export function isCooldownActive(model: OmModelConfig, now: Date = new Date()): 
 /**
  * Record a cooldown for a model after a retryable error.
  *
+ * When cooldownHours is explicitly 0, cooldown is disabled — no-op.
+ *
  * @param model   The model that failed.
  * @param reason  Human-readable error reason (e.g. "429 Too Many Requests").
  * @param stage   Which pipeline stage failed ("observer" | "reflector" | "dropper").
  */
 export function recordCooldown(model: OmModelConfig, reason: string, stage: string): void {
+	// cooldownHours === 0 means cooldown disabled
+	if (model.cooldownHours === 0) return;
+
 	const hours = model.cooldownHours ?? 1;
 	const until = new Date(Date.now() + hours * 3_600_000).toISOString();
 	const map = readCooldownMap();

--- a/src/om/runtime.ts
+++ b/src/om/runtime.ts
@@ -45,6 +45,13 @@ export class Runtime {
 	consolidationInFlight = false;
 	consolidationPromise: Promise<void> | null = null;
 	consolidationPhase: ConsolidationPhase | undefined;
+	/**
+	 * Models that failed in the current consolidation stage (in-memory only).
+	 * Used when cooldownHours is 0 — avoids disk writes while still letting
+	 * the retry loop advance past the failed model within this stage.
+	 * Cleared between stages at the pipeline level.
+	 */
+	failedInCycle: Set<string> = new Set();
 	compactInFlight = false;
 	compactHookInFlight = false;
 	resolveFailureNotified = false;
@@ -101,10 +108,23 @@ export class Runtime {
 
 		// Try configured candidates
 		for (const candidate of candidates) {
+			const key = modelKey(candidate);
+
+			// In-memory skip: model failed earlier in this stage with cooldownHours 0
+			if (this.failedInCycle.has(key)) {
+				if (ctx.hasUI && ctx.ui) {
+					ctx.ui.notify(
+						`Observational memory: ${stageName} skipping ${key} (failed this cycle, cooldown disabled)`,
+						"info",
+					);
+				}
+				continue;
+			}
+
 			if (isCooldownActive(candidate)) {
 				if (ctx.hasUI && ctx.ui) {
 					ctx.ui.notify(
-						`Observational memory: ${stageName} skipping ${modelKey(candidate)} (cooldown active)`,
+						`Observational memory: ${stageName} skipping ${key} (cooldown active)`,
 						"info",
 					);
 				}
@@ -179,9 +199,19 @@ export class Runtime {
 	/**
 	 * Record a retryable error for a model.  The model must be one of the candidates
 	 * (not the session model).  If it's the session model we don't cool it down.
+	 *
+	 * When cooldownHours is explicitly 0, the model is tracked in-memory for the
+	 * current consolidation stage (no disk writes). Otherwise a persisted cooldown
+	 * is recorded.
 	 */
 	recordRetryableError(modelConfig: ConfiguredModel | undefined, error: unknown, stage: ConsolidationPhase): void {
 		if (!modelConfig) return;
+		if (modelConfig.cooldownHours === 0) {
+			// In-memory only: skip this model for the rest of this stage.
+			// No disk writes, no persistent cooldown.
+			this.failedInCycle.add(modelKey(modelConfig));
+			return;
+		}
 		const reason = error instanceof Error ? error.message : String(error || "unknown error");
 		recordCooldown(modelConfig, reason, stage);
 	}

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -163,6 +163,19 @@ describe("Config with model IDs containing slashes and colons", () => {
 		expect(config.observerModel!.cooldownHours).toBe(12);
 	});
 
+	it("parses cooldownHours: 0 as valid (cooldown disabled)", async () => {
+		const { loadUnifiedConfig } = await import("../src/core/unified-config.js");
+		writeConfig({
+			observerModel: {
+				provider: "openrouter",
+				id: "some-model:free",
+				cooldownHours: 0,
+			},
+		});
+		const config = loadUnifiedConfig(testDir);
+		expect(config.observerModel!.cooldownHours).toBe(0);
+	});
+
 	it("parses fallback model arrays", async () => {
 		const { loadUnifiedConfig } = await import("../src/core/unified-config.js");
 		writeConfig({

--- a/tests/runtime.test.ts
+++ b/tests/runtime.test.ts
@@ -188,6 +188,84 @@ describe("Runtime.resolveModel — fallback chain", () => {
 			expect(result.model.id).toBe("session-model");
 		}
 	});
+
+	it("skips model in failedInCycle (cooldown 0, failed this cycle), uses fallback", async () => {
+		writeConfig({
+			observerModel: { provider: "openrouter", id: "primary:free", cooldownHours: 0 },
+			observerFallbackModels: [{ provider: "openrouter", id: "fallback:free", cooldownHours: 6 }],
+		});
+
+		const { Runtime } = await import("../src/om/runtime.js");
+		const runtime = new Runtime();
+		runtime.ensureConfig(testDir);
+
+		// Simulate: primary model failed this cycle → tracked in-memory
+		runtime.recordRetryableError(
+			{ provider: "openrouter", id: "primary:free", cooldownHours: 0 },
+			new Error("connection error"),
+			"observer",
+		);
+
+		const registry = makeRegistry([
+			makeModel("primary:free", "openrouter"),
+			makeModel("fallback:free", "openrouter"),
+		]);
+
+		const result = await runtime.resolveModel({
+			model: undefined,
+			modelRegistry: registry,
+			hasUI: false,
+			stageModel: { provider: "openrouter", id: "primary:free" },
+			stageFallbacks: [{ provider: "openrouter", id: "fallback:free", cooldownHours: 6 }],
+		});
+
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			// Should skip primary (in failedInCycle) and use fallback
+			expect(result.model.id).toBe("fallback:free");
+		}
+		// No cooldown was written to disk for the primary model
+		const data = readCooldownFile();
+		expect(data["openrouter/primary:free"]).toBeUndefined();
+	});
+
+	it("clears failedInCycle between stages so model retried fresh", async () => {
+		writeConfig({
+			observerModel: { provider: "openrouter", id: "primary:free", cooldownHours: 0 },
+		});
+
+		const { Runtime } = await import("../src/om/runtime.js");
+		const runtime = new Runtime();
+		runtime.ensureConfig(testDir);
+
+		// Simulate failure in observer stage
+		runtime.recordRetryableError(
+			{ provider: "openrouter", id: "primary:free", cooldownHours: 0 },
+			new Error("observer error"),
+			"observer",
+		);
+		expect(runtime.failedInCycle.has("openrouter/primary:free")).toBe(true);
+
+		// Clear as pipeline does between stages
+		runtime.failedInCycle.clear();
+
+		const registry = makeRegistry([
+			makeModel("primary:free", "openrouter"),
+		]);
+
+		// After clear, primary should be available again
+		const result = await runtime.resolveModel({
+			model: undefined,
+			modelRegistry: registry,
+			hasUI: false,
+			stageModel: { provider: "openrouter", id: "primary:free" },
+		});
+
+		expect(result.ok).toBe(true);
+		if (result.ok) {
+			expect(result.model.id).toBe("primary:free");
+		}
+	});
 });
 
 // ── Phase 9: Consolidation trigger guards ─────────────────────────────────
@@ -318,6 +396,24 @@ describe("Runtime — cooldown persistence", () => {
 		// Should be expired now
 		expect(isCooldownActive({ provider: "openrouter", id: "expiring:free" })).toBe(false);
 	});
+
+	it("recordCooldown with cooldownHours: 0 writes nothing to disk", async () => {
+		const { recordCooldown } = await import("../src/om/cooldown.js");
+		recordCooldown({ provider: "openrouter", id: "noop-model:free", cooldownHours: 0 }, "any error", "observer");
+		const data = readCooldownFile();
+		expect(data["openrouter/noop-model:free"]).toBeUndefined();
+		expect(Object.keys(data)).toHaveLength(0);
+	});
+
+	it("isCooldownActive with cooldownHours: 0 returns false without disk read", async () => {
+		const { isCooldownActive } = await import("../src/om/cooldown.js");
+		// No cooldown file exists yet
+		expect(isCooldownActive({ provider: "openrouter", id: "disabled:free", cooldownHours: 0 })).toBe(false);
+		// Even with a stale cooldown file, cooldownHours: 0 short-circuits
+		const { recordCooldown } = await import("../src/om/cooldown.js");
+		recordCooldown({ provider: "openrouter", id: "other:free", cooldownHours: 5 }, "error", "observer");
+		expect(isCooldownActive({ provider: "openrouter", id: "disabled:free", cooldownHours: 0 })).toBe(false);
+	});
 });
 
 describe("Runtime — retry gating", () => {
@@ -413,6 +509,44 @@ describe("Runtime — recordRetryableError", () => {
 		// Should not throw or write
 		runtime.recordRetryableError(undefined, new Error("429"), "observer");
 		expect(readCooldownFile()).toEqual({});
+	});
+
+	it("cooldownHours: 0 tracks in failedInCycle, does not write to disk", async () => {
+		const { Runtime } = await import("../src/om/runtime.js");
+		const runtime = new Runtime();
+		runtime.ensureConfig(testDir);
+
+		runtime.recordRetryableError(
+			{ provider: "openrouter", id: "no-persist:free", cooldownHours: 0 },
+			new Error("connection refused"),
+			"observer",
+		);
+
+		// No disk write
+		const data = readCooldownFile();
+		expect(data["openrouter/no-persist:free"]).toBeUndefined();
+
+		// But tracked in-memory
+		expect(runtime.failedInCycle.has("openrouter/no-persist:free")).toBe(true);
+	});
+
+	it("cooldownHours > 0 persists to disk and does NOT add to failedInCycle", async () => {
+		const { Runtime } = await import("../src/om/runtime.js");
+		const runtime = new Runtime();
+		runtime.ensureConfig(testDir);
+
+		runtime.recordRetryableError(
+			{ provider: "openrouter", id: "persist:free", cooldownHours: 6 },
+			new Error("rate limited"),
+			"observer",
+		);
+
+		// Disk write happened
+		const data = readCooldownFile();
+		expect(data["openrouter/persist:free"]).toBeDefined();
+
+		// NOT in in-memory set
+		expect(runtime.failedInCycle.has("openrouter/persist:free")).toBe(false);
 	});
 });
 


### PR DESCRIPTION
## Problem

`cooldownHours: 0` was silently dropped by the config parser (`positiveInt()` rejects 0), acting as the default 1-hour cooldown. This caused models with `cooldownHours: 0` to get persisted cooldown entries on disk after errors, forcing fallback to the session model instead of respecting the "no cooldown" intent.

Reported in #16: local dual-GPU setups where a sidecar OM model fails (GPU unavailable) would fall through to the main 27B model, slowing the coding experience.

## Solution

- **Config parser**: Added `nonNegativeInt()` validator that accepts 0 alongside existing `positiveInt` (`> 0`). `parseModel` uses it for `cooldownHours`.
- **Cooldown module**: `isCooldownActive` returns false immediately when `cooldownHours === 0`. `recordCooldown` is a no-op — no disk I/O at all.
- **In-memory stage tracking**: `Runtime.failedInCycle` (Set<string>) tracks models with `cooldownHours: 0` that failed within the current consolidation stage. `resolveModel` checks it before `isCooldownActive`, so the retry loop advances past the failed model to configured fallbacks.
- **Cleared between stages**: `failedInCycle` is cleared before each stage (observer → reflector → dropper), so the same model gets a fresh try in each stage.
- **Info notification**: When `failedInCycle.size > 0` and `resolveModel` fails (no fallbacks available), shows grey info-level message instead of yellow warning: "... model unavailable (cooldown set to 0, no fallbacks configured, will retry next run)".

## Non-breaking

The `failedInCycle` path is only entered when `modelConfig.cooldownHours === 0`. For `undefined` (default), `5`, `1`, or any other value, the original persisted-cooldown path runs byte-identical to before. `failedInCycle` is always empty when no model has `cooldownHours: 0` — the `has()` checks and `clear()` calls are no-ops.

## Edge cases verified

- Existing users (no cooldownHours set): unchanged
- cooldownHours: 0 + configured fallbacks: primary fails (in-memory skip), fallback tried normally
- cooldownHours: 0 + no fallbacks: stage aborts, info notification shown
- Context window too small also uses recordRetryableError — same cooldown: 0 skip path
- Multiple cooldownHours: 0 models: all tracked in Set, all skipped
- Notification NOT shown for empty observations (tool not called) — that's a successful return, not a resolveModel failure

## Tests

7 new tests (580 total, 0 failures):
- Config accepts cooldownHours: 0
- recordCooldown with 0 writes nothing to disk
- isCooldownActive with 0 returns false
- recordRetryableError with 0 tracks in failedInCycle, no disk write
- recordRetryableError with >0 writes to disk, NOT in failedInCycle
- resolveModel skips failedInCycle model, uses fallback
- failedInCycle cleared between stages (model retried fresh)