### PR TITLE
feat: add sessionFallback config option to skip main model fallback

### DIFF
--- a/src/core/unified-config.ts
+++ b/src/core/unified-config.ts
@@ -117,6 +117,10 @@ export interface UnifiedConfig {
 	/** Fallback models for dropper, tried in order after primary model fails. */
 	dropperFallbackModels?: OmModelConfig[];
 
+	/** When false, skip session model fallback when all OM model candidates are exhausted.
+	 *  Default true for backward compatibility. */
+	sessionFallback?: boolean;
+
 	/** @deprecated Use compaction instead. */
 	noAutoCompact?: boolean;
 	/** @deprecated Use compaction + memory instead. */
@@ -131,6 +135,7 @@ export interface UnifiedConfig {
 
 export const DEFAULTS: UnifiedConfig = {
 	debug: false,
+	sessionFallback: true,
 
 	// New config surface
 	compaction: "auto",
@@ -225,6 +230,7 @@ function parseConfig(raw: Record<string, unknown>): Partial<UnifiedConfig> {
 	if (typeof raw.debug === "boolean") c.debug = raw.debug;
 
 	// Booleans — om
+	if (typeof raw.sessionFallback === "boolean") c.sessionFallback = raw.sessionFallback;
 	if (typeof raw.noAutoCompact === "boolean") c.noAutoCompact = raw.noAutoCompact;
 	if (typeof raw.passive === "boolean") c.passive = raw.passive;
 	if (typeof raw.memory === "boolean") c.memory = raw.memory;

--- a/src/om/configure-overlay.ts
+++ b/src/om/configure-overlay.ts
@@ -8,6 +8,7 @@
 
 import { visibleWidth } from "./key-matcher.js";
 import { matchesKey, decodeKittyPrintable } from "@earendil-works/pi-tui";
+import { DEFAULTS } from "../core/unified-config.js";
 import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
 import { dirname } from "node:path";
 
@@ -141,9 +142,10 @@ export function createConfigureOverlay(
 		raw = {};
 	}
 
+	const defaults = DEFAULTS as unknown as Record<string, unknown>;
 	const fields: FieldState[] = FIELDS.map((def) => ({
 		def,
-		value: formatValue(def, raw[def.key]),
+		value: formatValue(def, def.key in raw ? raw[def.key] : defaults[def.key]),
 		editing: false,
 		cursor: 0,
 	}));

--- a/src/om/configure-overlay.ts
+++ b/src/om/configure-overlay.ts
@@ -49,6 +49,8 @@ const FIELDS: FieldDef[] = [
 	// ── Observational Memory ──
 	{ key: "memory", label: "Observational memory", type: "boolean", section: "Observational Memory",
 		helpText: "Enable OM workers (observer, reflector, dropper) and content injection" },
+	{ key: "sessionFallback", label: "Session model fallback", type: "boolean", section: "Observational Memory",
+		helpText: "off=skip stage when all OM models fail, instead of falling back to the main coding model" },
 	{ key: "observeAfterTokens", label: "Observer threshold", type: "number", section: "Observational Memory",
 		helpText: "Tokens accumulated since last observer run before triggering next observe" },
 	{ key: "reflectAfterTokens", label: "Reflect + dropper threshold", type: "number", section: "Observational Memory",

--- a/src/om/runtime.ts
+++ b/src/om/runtime.ts
@@ -94,13 +94,17 @@ export class Runtime {
 	 * Tries the candidate list in order:
 	 * 1. Primary stage model → 2. Stage fallbacks → 3. Base config.model → 4. Session model.
 	 *
+	 * Session model fallback can be disabled via config.sessionFallback: false.
+	 * When disabled, returns { ok: false } instead of using the session model,
+	 * allowing the stage to be skipped entirely when all configured OM models fail.
+	 *
 	 * Skips models that are currently in a cooldown window.
 	 * On retryable error (after the agent runs), the model that failed is cooled down
 	 * and the next candidate is tried.  The caller must call `recordRetryableError`
 	 * after the API attempt to mark the failed model.
 	 *
 	 * Returns `ok: true` with the resolved model, or `ok: false` with a reason
-	 * if all candidates (including session model) are exhausted or unavailable.
+	 * if all candidates (including session model, if enabled) are exhausted or unavailable.
 	 */
 	async resolveModel(ctx: ResolveCtx): Promise<ResolveResult> {
 		const candidates = this.buildCandidateList(ctx.stageModel, ctx.stageFallbacks);
@@ -162,25 +166,40 @@ export class Runtime {
 			};
 		}
 
-		// Fall back to session model
-		const sessionModel = ctx.model;
-		if (!sessionModel) {
-			return { ok: false, reason: `no model available for ${stageName} (all candidates exhausted, no session model)` };
+		// Fall back to session model (if enabled)
+		if (this.config.sessionFallback !== false) {
+			const sessionModel = ctx.model;
+			if (!sessionModel) {
+				return { ok: false, reason: `no model available for ${stageName} (all candidates exhausted, no session model)` };
+			}
+
+			const auth = await ctx.modelRegistry.getApiKeyAndHeaders(sessionModel);
+			if (!auth.ok || !auth.apiKey) {
+				const provider = (sessionModel as { provider?: string }).provider ?? "unknown";
+				return { ok: false, reason: `no API key for session model provider "${provider}"` };
+			}
+
+			return {
+				ok: true,
+				model: sessionModel,
+				apiKey: auth.apiKey as string,
+				headers: auth.headers as Record<string, string> | undefined,
+				cooldownApplied: false,
+			};
 		}
 
-		const auth = await ctx.modelRegistry.getApiKeyAndHeaders(sessionModel);
-		if (!auth.ok || !auth.apiKey) {
-			const provider = (sessionModel as { provider?: string }).provider ?? "unknown";
-			return { ok: false, reason: `no API key for session model provider "${provider}"` };
+		// All configured candidates exhausted and session fallback disabled —
+		// skip the stage entirely.  Info-level to match cooldown-disabled pattern.
+		// Set resolveFailureNotified so the consolidation layer doesn't duplicate.
+		if (ctx.hasUI && ctx.ui) {
+			ctx.ui.notify(
+				`Observational memory: ${stageName} skipped — all candidates failed (sessionFallback disabled, won't use main model)`,
+				"info",
+			);
 		}
+		this.resolveFailureNotified = true;
 
-		return {
-			ok: true,
-			model: sessionModel,
-			apiKey: auth.apiKey as string,
-			headers: auth.headers as Record<string, string> | undefined,
-			cooldownApplied: false,
-		};
+		return { ok: false, reason: `no model available for ${stageName} (all candidates exhausted, sessionFallback disabled)` };
 	}
 
 	/**

--- a/tests/runtime.test.ts
+++ b/tests/runtime.test.ts
@@ -189,6 +189,37 @@ describe("Runtime.resolveModel — fallback chain", () => {
 		}
 	});
 
+	it("skips session model fallback when sessionFallback is false", async () => {
+		writeConfig({
+			observerModel: { provider: "openrouter", id: "primary:free" },
+			sessionFallback: false,
+		});
+
+		const { recordCooldown } = await import("../src/om/cooldown.js");
+		recordCooldown({ provider: "openrouter", id: "primary:free" }, "429", "observer");
+
+		const { Runtime } = await import("../src/om/runtime.js");
+		const runtime = new Runtime();
+		runtime.ensureConfig(testDir);
+
+		const registry = makeRegistry([
+			makeModel("primary:free", "openrouter"),
+		]);
+
+		const result = await runtime.resolveModel({
+			model: makeModel("session-model", "openrouter"),
+			modelRegistry: registry,
+			hasUI: false,
+			stageModel: { provider: "openrouter", id: "primary:free" },
+		});
+
+		// Should NOT fall through to session model — returns ok: false
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.reason).toContain("sessionFallback disabled");
+		}
+	});
+
 	it("skips model in failedInCycle (cooldown 0, failed this cycle), uses fallback", async () => {
 		writeConfig({
 			observerModel: { provider: "openrouter", id: "primary:free", cooldownHours: 0 },
@@ -547,6 +578,45 @@ describe("Runtime — recordRetryableError", () => {
 
 		// NOT in in-memory set
 		expect(runtime.failedInCycle.has("openrouter/persist:free")).toBe(false);
+	});
+});
+
+describe("Runtime — sessionFallback notification", () => {
+	it("fires info notification when sessionFallback disabled and cooldown-disabled models exhausted chain", async () => {
+		writeConfig({
+			observerModel: { provider: "openrouter", id: "primary:free", cooldownHours: 0 },
+			sessionFallback: false,
+		});
+
+		const { Runtime } = await import("../src/om/runtime.js");
+		const runtime = new Runtime();
+		runtime.ensureConfig(testDir);
+
+		// Simulate: primary model failed → added to failedInCycle
+		runtime.recordRetryableError(
+			{ provider: "openrouter", id: "primary:free", cooldownHours: 0 },
+			new Error("connection error"),
+			"observer",
+		);
+
+		const notify = vi.fn();
+		const registry = makeRegistry([]);
+
+		const result = await runtime.resolveModel({
+			model: makeModel("session-model", "openrouter"),
+			modelRegistry: registry,
+			hasUI: true,
+			ui: { notify },
+			stageModel: { provider: "openrouter", id: "primary:free" },
+		});
+
+		expect(result.ok).toBe(false);
+		expect(result.reason).toContain("sessionFallback disabled");
+		expect(notify).toHaveBeenCalledTimes(2);
+		expect(notify.mock.calls[1]).toEqual([
+			expect.stringContaining("sessionFallback disabled"),
+			"info",
+		]);
 	});
 });
 


### PR DESCRIPTION
## Summary

Adds `sessionFallback: false` config option to prevent OM from falling back to the main coding model when all configured OM model candidates fail. When disabled, the stage is skipped entirely with an info notification instead.

## Background

Follow-up to PR #18 (cooldownHours: 0). Users with a dual-GPU setup where sidecar models (cooldownHours: 0) can fail when a secondary GPU is unavailable want OM to skip the stage rather than bleed into the expensive main model.

## Changes

- `src/core/unified-config.ts` — New `sessionFallback?: boolean` key (default `true` for backward compat)
- `src/om/runtime.ts` — Guard session model fallback; info notification explaining the skip
- `src/om/configure-overlay.ts` — Toggle visible in `/blackhole configure` overlay (OM section)
- `tests/runtime.test.ts` — Test verifying `ok: false` + info notification fires

## Usage

```json
{
  "sessionFallback": false
}
```

Only takes effect when `cooldownHours: 0` models have failed (info-level notification). Other failures still produce warnings.