### PR TITLE
fix: ignore stale ctx in compaction trigger

### DIFF
--- a/src/om/compaction-trigger.ts
+++ b/src/om/compaction-trigger.ts
@@ -4,9 +4,26 @@ import type { Runtime } from "./runtime.js";
 import { debugLog } from "./debug-log.js";
 import { RETRYABLE_ERROR_RE } from "./retryable-error.js";
 
+function getErrorMessage(error: unknown): string {
+	if (error instanceof Error) return error.message;
+	if (error && typeof error === "object" && "message" in error) {
+		return String((error as { message: unknown }).message);
+	}
+	return String(error);
+}
+
 function isStaleExtensionContextError(error: unknown): boolean {
-	const message = error instanceof Error ? error.message : String(error);
+	const message = getErrorMessage(error);
 	return message.includes("extension ctx is stale") || message.includes("ctx is stale");
+}
+
+function notifySafely(hasUI: boolean, ui: any, message: string, level: "info" | "warning" | "error"): void {
+	if (!hasUI) return;
+	try {
+		ui?.notify(message, level);
+	} catch (error) {
+		if (!isStaleExtensionContextError(error)) throw error;
+	}
 }
 
 export function registerCompactionTrigger(pi: ExtensionAPI, runtime: Runtime): void {
@@ -108,7 +125,9 @@ function handleAgentEnd(event: any, ctx: any, runtime: Runtime): void {
 
 		dbg("compaction_trigger.threshold_reached", { tokens, sessionId, hasUI });
 
-		if (hasUI) ui?.notify(
+		notifySafely(
+			hasUI,
+			ui,
 			`Observational memory: compaction threshold reached (~${tokens.toLocaleString()} tokens); triggering compaction`,
 			"info",
 		);
@@ -125,7 +144,9 @@ function handleAgentEnd(event: any, ctx: any, runtime: Runtime): void {
 				if (currentSessionId !== sessionId) {
 					runtime.compactInFlight = false;
 					dbg("compaction_trigger.microtask.bail", { reason: "session_changed" });
-					if (hasUI) ui?.notify(
+					notifySafely(
+						hasUI,
+						ui,
 						"Observational memory: compaction cancelled — session changed before compaction",
 						"info",
 					);
@@ -137,7 +158,9 @@ function handleAgentEnd(event: any, ctx: any, runtime: Runtime): void {
 				if (!isIdle) {
 					runtime.compactInFlight = false;
 					dbg("compaction_trigger.microtask.bail", { reason: "not_idle" });
-					if (hasUI) ui?.notify(
+					notifySafely(
+						hasUI,
+						ui,
 						"Observational memory: compaction deferred — agent became busy before compaction",
 						"info",
 					);
@@ -149,7 +172,9 @@ function handleAgentEnd(event: any, ctx: any, runtime: Runtime): void {
 				if (currentTokens < runtime.config.compactAfterTokens) {
 					runtime.compactInFlight = false;
 					dbg("compaction_trigger.microtask.bail", { reason: "pressure_relieved", currentTokens, threshold: runtime.config.compactAfterTokens });
-					if (hasUI) ui?.notify(
+					notifySafely(
+						hasUI,
+						ui,
 						"Observational memory: compaction skipped — another compaction already ran before deferred compaction",
 						"info",
 					);
@@ -161,7 +186,7 @@ function handleAgentEnd(event: any, ctx: any, runtime: Runtime): void {
 					onComplete: (result: any) => {
 						runtime.compactInFlight = false;
 						dbg("compaction_trigger.onComplete", { result: !!result });
-						if (hasUI) ui?.notify("Observational memory: compaction complete", "info");
+						notifySafely(hasUI, ui, "Observational memory: compaction complete", "info");
 					},
 					onError: (error: { message: string }) => {
 						runtime.compactInFlight = false;
@@ -170,18 +195,18 @@ function handleAgentEnd(event: any, ctx: any, runtime: Runtime): void {
 							// We already notified the user with the real reason before returning { cancel: true }.
 							return;
 						}
-						if (hasUI) ui?.notify(`Observational memory: ${error.message}`, "error");
+						notifySafely(hasUI, ui, `Observational memory: ${error.message}`, "error");
 					},
 				});
 			} catch (error) {
 				runtime.compactInFlight = false;
-				const msg = error instanceof Error ? error.message : String(error);
+				const msg = getErrorMessage(error);
 				if (isStaleExtensionContextError(error)) {
 					dbg("compaction_trigger.microtask.bail", { reason: "stale_ctx", message: msg });
 					return;
 				}
 				dbg("compaction_trigger.microtask.error", { message: msg });
-				if (hasUI) ui?.notify(`Observational memory: compact threw: ${msg}`, "error");
+				notifySafely(hasUI, ui, `Observational memory: compact threw: ${msg}`, "error");
 			}
 	}, 0);
 }

--- a/src/om/compaction-trigger.ts
+++ b/src/om/compaction-trigger.ts
@@ -4,9 +4,24 @@ import type { Runtime } from "./runtime.js";
 import { debugLog } from "./debug-log.js";
 import { RETRYABLE_ERROR_RE } from "./retryable-error.js";
 
+function isStaleExtensionContextError(error: unknown): boolean {
+	const message = error instanceof Error ? error.message : String(error);
+	return message.includes("extension ctx is stale") || message.includes("ctx is stale");
+}
+
 export function registerCompactionTrigger(pi: ExtensionAPI, runtime: Runtime): void {
 	pi.on("agent_end", (event: any, ctx: any) => {
-		runtime.ensureConfig(ctx.cwd);
+		try {
+			handleAgentEnd(event, ctx, runtime);
+		} catch (error) {
+			if (isStaleExtensionContextError(error)) return;
+			throw error;
+		}
+	});
+}
+
+function handleAgentEnd(event: any, ctx: any, runtime: Runtime): void {
+	runtime.ensureConfig(ctx.cwd);
 
 		// Pass the config flag explicitly — this handler runs outside ALS context
 		// (agent_end events don't flow through consolidation's withDebugLogContext),
@@ -161,9 +176,12 @@ export function registerCompactionTrigger(pi: ExtensionAPI, runtime: Runtime): v
 			} catch (error) {
 				runtime.compactInFlight = false;
 				const msg = error instanceof Error ? error.message : String(error);
+				if (isStaleExtensionContextError(error)) {
+					dbg("compaction_trigger.microtask.bail", { reason: "stale_ctx", message: msg });
+					return;
+				}
 				dbg("compaction_trigger.microtask.error", { message: msg });
 				if (hasUI) ui?.notify(`Observational memory: compact threw: ${msg}`, "error");
 			}
-		}, 0);
-	});
+	}, 0);
 }

--- a/tests/compaction-trigger.test.ts
+++ b/tests/compaction-trigger.test.ts
@@ -190,6 +190,36 @@ describe("V3 compaction trigger (blackhole)", () => {
 		expect(ctx.compact).not.toHaveBeenCalled();
 	});
 
+	it("ignores stale extension ctx during agent_end", async () => {
+		const { handler, runtime } = captureHandler();
+		const staleCtx = {
+			get cwd() {
+				throw new Error("This extension ctx is stale after session replacement or reload.");
+			},
+		};
+
+		expect(() => handler(agentEnd(), staleCtx)).not.toThrow();
+		await flushAll();
+
+		expect(runtime.ensureConfig).not.toHaveBeenCalled();
+		expect(runtime.compactInFlight).toBe(false);
+	});
+
+	it("cancels deferred compaction if ctx becomes stale before the timer fires", async () => {
+		const { handler, runtime } = captureHandler({ compactAfterTokens: 3 });
+		const ctx = fakeCtx([dueBranch]);
+
+		handler(agentEnd(), ctx);
+		expect(runtime.compactInFlight).toBe(true);
+		ctx.sessionManager.getSessionId.mockImplementation(() => {
+			throw new Error("This extension ctx is stale after session replacement or reload.");
+		});
+		await flushAll();
+
+		expect(runtime.compactInFlight).toBe(false);
+		expect(ctx.compact).not.toHaveBeenCalled();
+	});
+
 	it("defers compaction if context is no longer idle", async () => {
 		const { handler, runtime } = captureHandler({ compactAfterTokens: 3 });
 		const ctx = fakeCtx([dueBranch], { isIdle: vi.fn(() => false) });

--- a/tests/compaction-trigger.test.ts
+++ b/tests/compaction-trigger.test.ts
@@ -194,7 +194,7 @@ describe("V3 compaction trigger (blackhole)", () => {
 		const { handler, runtime } = captureHandler();
 		const staleCtx = {
 			get cwd() {
-				throw new Error("This extension ctx is stale after session replacement or reload.");
+				throw { message: "This extension ctx is stale after session replacement or reload." };
 			},
 		};
 
@@ -218,6 +218,28 @@ describe("V3 compaction trigger (blackhole)", () => {
 
 		expect(runtime.compactInFlight).toBe(false);
 		expect(ctx.compact).not.toHaveBeenCalled();
+	});
+
+	it("ignores stale notification errors in async compaction callbacks", async () => {
+		const { handler, runtime } = captureHandler({ compactAfterTokens: 3 });
+		const ctx = fakeCtx([dueBranch]);
+
+		handler(agentEnd(), ctx);
+		await flushAll();
+
+		expect(ctx.compact).toHaveBeenCalledTimes(1);
+		const compactOptions = ctx.compact.mock.calls[0][0];
+		ctx.ui.notify.mockImplementation(() => {
+			throw new Error("This extension ctx is stale after session replacement or reload.");
+		});
+
+		runtime.compactInFlight = true;
+		expect(() => compactOptions.onComplete({})).not.toThrow();
+		expect(runtime.compactInFlight).toBe(false);
+
+		runtime.compactInFlight = true;
+		expect(() => compactOptions.onError({ message: "test failure" })).not.toThrow();
+		expect(runtime.compactInFlight).toBe(false);
 	});
 
 	it("defers compaction if context is no longer idle", async () => {


### PR DESCRIPTION
## Summary
- ignore stale extension contexts when `agent_end` is delivered after session replacement/reload
- cancel deferred auto-compaction quietly if the captured ctx becomes stale before the timer fires
- add regression coverage for both stale-ctx paths

## Why
Pi invalidates extension contexts during session replacement/reload. The compaction trigger reads `ctx.cwd` at the start of `agent_end`, and later reuses the captured ctx in the deferred compaction callback. If either path runs after invalidation, the extension can surface an uncaught stale-context error instead of simply abandoning the obsolete compaction attempt.

## Tests
- `pnpm exec vitest run tests/compaction-trigger.test.ts`
- `pnpm run check`
- `pnpm run lint`