### PR TITLE
refactor: simplify recall tool — drop transcript mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,7 +244,6 @@ The agent gets a unified `recall` tool that handles three types of input:
 | `#N:path` | Drill-down into file content from a tool call (e.g. `#42:auth.ts` shows first 30 lines; `#42:auth.ts:30` shows next 30; `#42:auth.ts:full` shows everything) |
 | Free text | BM25-ranked OR search across transcript and/or file content. Rare terms weighted higher. |
 | `mode:file` | Search only write/edit file content |
-| `mode:transcript` | Search only conversation text |
 | `mode:touched` | Aggregate all files written/edited, grouped by path with entry indices |
 | Regex | Pattern search (e.g. `fork.*pi-vcc`, `hook|inject`) |
 | `scope:all` | Search across all session lineages, not just the active one |
@@ -453,7 +452,6 @@ The agent gets one unified tool that searches session history, expands entries, 
 | `#N:path` | Drill-down into file content from a tool call (e.g. `#42:auth.ts` shows first 30 lines; `#42:auth.ts:30` shows next 30; `#42:auth.ts:full` shows everything) |
 | Free text | BM25-ranked OR search across transcript + file indicators. Rare terms weighted higher. |
 | `mode:file` | Search only write/edit file content |
-| `mode:transcript` | Search only conversation text |
 | `mode:touched` | Aggregate all files written/edited across the session, grouped by path with entry indices |
 | Regex | Pattern search (e.g. `fork.*pi-vcc`, `hook\|inject`) |
 | `scope:all` | Search across all session lineages (default: active lineage only) |
@@ -470,7 +468,6 @@ Results are shown as a collapsible message and auto-fed to the agent as context.
 /blackhole-recall hook|inject                       # regex
 /blackhole-recall fail.*build scope:all             # regex across all lineages
 /blackhole-recall mode:file                         # search only write/edit file content
-/blackhole-recall mode:transcript                   # search only conversation
 /blackhole-recall mode:touched                      # aggregate view of all files touched
 /blackhole-recall                                   # recent 25 entries
 ```

--- a/src/commands/vcc-recall.ts
+++ b/src/commands/vcc-recall.ts
@@ -41,7 +41,7 @@ async function augmentWithObservations(
 export const registerVccRecallCommand = (pi: ExtensionAPI) => {
 	pi.registerCommand("blackhole-recall", {
 		description:
-			"Search session history. Defaults to active lineage. Usage: /blackhole-recall <query> [page:N] [scope:all] [mode:file|transcript]",
+			"Search session history. Defaults to active lineage. Usage: /blackhole-recall <query> [page:N] [scope:all] [mode:file]",
 		handler: async (args: string, ctx) => {
 			const sessionFile = ctx.sessionManager.getSessionFile();
 			if (!sessionFile) {

--- a/src/commands/vcc-recall.ts
+++ b/src/commands/vcc-recall.ts
@@ -6,8 +6,8 @@
  */
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { loadAllMessages } from "../core/load-messages.js";
-import { searchEntries } from "../core/search-entries.js";
-import { formatRecallOutput } from "../core/format-recall.js";
+import { searchEntries, getTouchedFiles } from "../core/search-entries.js";
+import { formatRecallOutput, formatTouchedOutput } from "../core/format-recall.js";
 import { getActiveLineageEntryIds } from "../core/lineage.js";
 import { parseRecallScope } from "../core/recall-scope.js";
 import {
@@ -41,7 +41,7 @@ async function augmentWithObservations(
 export const registerVccRecallCommand = (pi: ExtensionAPI) => {
 	pi.registerCommand("blackhole-recall", {
 		description:
-			"Search session history. Defaults to active lineage. Usage: /blackhole-recall <query> [page:N] [scope:all] [mode:file]",
+			"Search session history. Defaults to active lineage. Usage: /blackhole-recall <query> [page:N] [scope:all] [mode:file|touched]",
 		handler: async (args: string, ctx) => {
 			const sessionFile = ctx.sessionManager.getSessionFile();
 			if (!sessionFile) {
@@ -56,6 +56,19 @@ export const registerVccRecallCommand = (pi: ExtensionAPI) => {
 					? getActiveLineageEntryIds(ctx.sessionManager)
 					: undefined;
 			const mode = parsed.mode;
+
+			if (mode === "touched") {
+				const pageMatch = raw.match(/\bpage:(\d+)\b/i);
+				const page = pageMatch ? Math.max(1, parseInt(pageMatch[1], 10)) : 1;
+				const { rendered, rawMessages } = loadAllMessages(sessionFile, false, lineageEntryIds);
+				const touched = getTouchedFiles(rawMessages, rendered);
+				const text = formatTouchedOutput(touched, page);
+				pi.sendMessage(
+					{ customType: "blackhole-recall", content: text, display: true },
+					{ triggerTurn: true },
+				);
+				return;
+			}
 
 			if (!parsed.text) {
 				// No query: show recent entries

--- a/src/core/recall-scope.ts
+++ b/src/core/recall-scope.ts
@@ -1,10 +1,10 @@
 export type RecallScope = "lineage" | "all";
-export type RecallMode = "hybrid" | "file" | "transcript" | "touched";
+export type RecallMode = "hybrid" | "file" | "touched";
 
 const SCOPE_RE = /\bscope:(lineage|all)\b/i;
-const MODE_RE = /\bmode:(hybrid|file|transcript|touched)\b/i;
+const MODE_RE = /\bmode:(hybrid|file|touched)\b/i;
 
-const VALID_MODES = new Set(["hybrid", "file", "transcript", "touched"]);
+const VALID_MODES = new Set(["hybrid", "file", "touched"]);
 
 export const normalizeRecallScope = (scope?: unknown): RecallScope =>
   typeof scope === "string" && scope.toLowerCase() === "all" ? "all" : "lineage";

--- a/src/core/search-entries.ts
+++ b/src/core/search-entries.ts
@@ -196,10 +196,7 @@ const fullText = (msg: Message, mode?: RecallMode): string => {
   if (mode === "file") {
     return toolCallArgsText(msg.content);
   }
-  if (mode === "transcript") {
-    return textOf(msg.content);
-  }
-  // hybrid (default): both
+  // hybrid (default): both transcript text + tool call args
   const text = textOf(msg.content);
   const toolArgs = toolCallArgsText(msg.content);
   return toolArgs ? `${text}\n${toolArgs}` : text;
@@ -330,7 +327,7 @@ export const searchEntries = (
       const hay = `${e.role} ${text} ${filePart}`;
       if (regex.test(hay)) {
         const snip = lineSnippet(text, regex);
-        const fileMatches = mode === "transcript" ? [] : computeFileMatches(msg, rawQuery);
+        const fileMatches = computeFileMatches(msg, rawQuery);
         const extra = fileMatches.length > 0 ? { fileMatches } : {};
         hits.push({ ...e, snippet: snip, matchCount: 1, ...extra });
       }
@@ -366,7 +363,7 @@ export const searchEntries = (
     const score = bm25Score(hay, terms, ctx);
     const text = fullTextCache[i];
     const snip = lineSnippet(text, snipRe);
-    const fileMatches = mode === "transcript" ? [] : computeFileMatches(messages[i], rawQuery);
+    const fileMatches = computeFileMatches(messages[i], rawQuery);
     const extra = fileMatches.length > 0 ? { fileMatches } : {};
     scored.push({
       hit: { ...e, snippet: snip, matchCount: mc, ...extra },

--- a/src/tools/recall.ts
+++ b/src/tools/recall.ts
@@ -240,7 +240,7 @@ export function registerRecallTool(pi: ExtensionAPI): void {
 		promptSnippet:
 			"recall: Search session history + file write/edit content by text/regex. #N expand, #N:path drill-down with optional :offset:limit or :full, mode:file/touched.",
 		promptGuidelines: [
-			"Use recall — literal text/regex search across session history and file write/edit content. #N expands an entry; #N:path with optional :offset:limit or :full drills file content; 12-char hex ids recover observation/reflection sources. mode:file for file-content-only, mode:touched for aggregated files-by-path. scope:'all' to search the full session. If no results, try fewer terms or a regex pattern.",
+			"Use recall — literal text/regex search across session history and file write/edit content. #N expands an entry; #N:path with optional :offset:limit or :full drills down into file content; 12-char hex ids recover observation/reflection sources. mode:file for file-content-only, mode:touched for aggregated files-by-path. scope:'all' to search the full session. If no results, try fewer terms or a regex pattern.",
 			"Use recall — when a drill-down path matches multiple files, options are listed. Narrow with a more specific path substring. Only full-file writes are indexed for text search (edit diffs are not).",
 		],
 		parameters: Type.Object({

--- a/src/tools/recall.ts
+++ b/src/tools/recall.ts
@@ -238,13 +238,10 @@ export function registerRecallTool(pi: ExtensionAPI): void {
 			"Search session history and earlier lines omitted, file write/edit content by text/regex. " +
 			"Expand entries (#N), drill-down file content (#N:path) with paging, or aggregate touched files (mode:touched).",
 		promptSnippet:
-			"recall: Search session history + file write/edit content by text/regex. #N expand, #N:path drill-down with offset/limit paging, mode:file/transcript/touched.",
+			"recall: Search session history + file write/edit content by text/regex. #N expand, #N:path drill-down with optional :offset:limit or :full, mode:file/touched.",
 		promptGuidelines: [
-			"Use recall — search is literal text/regex matching, NOT semantic. If no results, try different terms or a regex pattern. Set scope:'all' to search the full session.",
-			"Use recall — mode:file to search only write/edit file content, mode:transcript for conversation-only, mode:touched for aggregate view of all files written/edited across the session.",
-			"Use recall — drill-down supports paging: #42:auth.ts shows first 30 lines, #42:auth.ts:30 shows next 30, #42:auth.ts:full shows everything. Note: edit diffs are not indexed for text search — drill-down reads them from raw JSONL.",
-			"Use recall — when a drill-down path matches multiple files, options are listed. Narrow with a more specific path substring.",
-			"Use recall — hex observation/reflection ids (12-char hex) link memory evidence to session entries with cross-references for navigation.",
+			"Use recall — literal text/regex search across session history and file write/edit content. #N expands an entry; #N:path with optional :offset:limit or :full drills file content; 12-char hex ids recover observation/reflection sources. mode:file for file-content-only, mode:touched for aggregated files-by-path. scope:'all' to search the full session. If no results, try fewer terms or a regex pattern.",
+			"Use recall — when a drill-down path matches multiple files, options are listed. Narrow with a more specific path substring. Only full-file writes are indexed for text search (edit diffs are not).",
 		],
 		parameters: Type.Object({
 			query: Type.Optional(
@@ -260,7 +257,7 @@ export function registerRecallTool(pi: ExtensionAPI): void {
 				StringEnum(["lineage", "all"] as const, { description: "Search scope. lineage = active lineage (default), all = entire session." }),
 			),
 			mode: Type.Optional(
-				StringEnum(["hybrid", "file", "transcript", "touched"] as const, { description: "What content to search. hybrid (default) = transcript + file indicators. file = write/edit file content only. transcript = conversation only. touched = aggregate files grouped by path (not per-entry search)." }),
+				StringEnum(["hybrid", "file", "touched"] as const, { description: "What content to search. hybrid (default) = all session content. file = file content only. touched = files-by-path summary with entry indices." }),
 			),
 		}),
 		async execute(_toolCallId, params, _signal, _onUpdate, ctx) {


### PR DESCRIPTION
## Summary

Drop `transcript` mode from the recall tool — it was a strict subset of `hybrid` with no unique capability.

## Changes

- **`src/core/recall-scope.ts`** — remove `transcript` from type, regex, and valid-modes set
- **`src/core/search-entries.ts`** — remove `transcript`-only branches in `fullText()` and two `computeFileMatches` calls
- **`src/tools/recall.ts`** — drop `transcript` from `StringEnum`, consolidate 5 scattered `promptGuidelines` into 2, remove "NOT semantic" redundancy and JSONL implementation leak
- **`src/commands/vcc-recall.ts`** — update usage string
- **`README.md`** — remove `mode:transcript` from tables and examples

## Prompt text improvements

- 5 scattered bullet points → 2 consolidated entries
- Drill-down collapsed: `#42:auth.ts`, `#42:auth.ts:30`, `#42:auth.ts:full` → `#N:path with optional :offset:limit or :full`
- Mode description: "transcript + file indicators" (internal taxonomy) → "all session content"
- Behavioral boundary kept (what is indexed) but rephrased without implementation details

## Checklist

- [x] `pnpm check` passes (`tsc --noEmit`)
- [x] `pnpm run lint` passes