### PR TITLE
Lockstep/2026 07 24

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ### Added
 
+- **`/blackhole <text>` follow-up prompt.** After compaction, `/blackhole` optionally sends `<text>` as a follow-up message so the model continues the task without re-typing. Wrapped in `void Promise.resolve(...).catch(() => {})` for robust error handling.
+- **Subcommand near-miss detection.** `/blackhole configure foo` now shows a warning instead of silently becoming a follow-up prompt.
+
 - **`/blackhole cleanup` command for orphaned pending files.** Per-session pending files (`*-pending.json`, `*-pending.stale.json`) accumulate when compaction is manual and sessions are abandoned or deleted. The command scans the `pi-blackhole/` directory, cross-references session IDs against all session JSONL files, and provides an interactive TUI picker to safely remove orphaned files. Non-TUI modes (RPC/JSON/print) list orphaned files as a notification without deleting.
 
 ### Command formatting cleanup
@@ -18,16 +21,24 @@
 ### Fixed
 
 - **Early-session reflection/drop starvation on first compaction.** Added `fullFoldAlways` config flag (default `true`). When no prior full-fold boundary exists, reflections and drops now use the observation boundary instead of being excluded. Previously, fresh sessions silently lost all durable memory on the first compaction because there was no full-fold history to anchor the maintenance boundary.
+- **`capBrief` omission count now computed after `firstHeader` trim.** Previously the "N earlier lines omitted" header was computed before the section-header anchor trim, so the count was understated when headers caused additional trimming. This matched an upstream bug that was already fixed there.
+
 - **Recall-note bloat across multiple compactions.** `compile()` now strips OM content first, then removes all recall-note paragraphs from the previous summary using paragraph-level matching (instead of only stripping a trailing exact match). After 3+ compactions, the summary no longer accumulates 3+ embedded copies of the recall note.
 
 ### Tests
 
 - 4 new tests for `fullFoldAlways` behavior in `buildCompactionProjection`: reflections survive first compaction when enabled, excluded when disabled, full-fold boundary still takes precedence, and post-boundary reflections remain excluded.
 - 3 new tests for recall-note deduplication in `compile`: wrapped recall note stripped, OM content stripped before recall note, and three-cycle accumulation produces exactly one recall note.
+- 5 new tests for follow-up prompt: extraction, subcommand exclusion, empty-args suppression, send after completion, compaction-failure suppression.
+- 6 new tests for CompactionStats population: all fields populated, compactAll flag, totalUserTurns count, keptUserTurns count, compactAll zero kept, and format string coverage.
+- 2 new tests for capBrief omission count: header-trimmed count is correct (99 for 200 lines with header at line 100), and no-header fallback still correct.
 
 ### Changed
 
 - **New config key:** `fullFoldAlways` (boolean, default `true`). Added to `UnifiedConfig` schema, defaults, and config file parsing.
+- **CompactionStats expanded from 3 to 11 fields.** Added `compactAll`, `totalUserTurns`, `keptUserTurns`, `requestedKeepUserTurns`, `keepUserTurnsExplicit`, `keepFallbackToCompactAll`, `smartKeepAdjusted`, `smartFromKeep`. All populated from `buildOwnCut` return data (Bug A fix).
+- **Shared `formatCompactionStats` exported.** Both the `/blackhole` command handler and hook's `session_compact` handler now use a single shared formatter, eliminating the duplicate inline toast strings and the private `formatTokens` helper.
+- **Dead ternary collapsed.** `effectiveTailBehavior` no longer has an `isPiVcc` branch with identical values on both sides (Bug B fix).
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@
 
 - **`/blackhole cleanup` command for orphaned pending files.** Per-session pending files (`*-pending.json`, `*-pending.stale.json`) accumulate when compaction is manual and sessions are abandoned or deleted. The command scans the `pi-blackhole/` directory, cross-references session IDs against all session JSONL files, and provides an interactive TUI picker to safely remove orphaned files. Non-TUI modes (RPC/JSON/print) list orphaned files as a notification without deleting.
 
+### Command formatting cleanup
+
+- `/blackhole` and `/blackhole-memory` subcommands and modes now use `[bracketed]` syntax (e.g. `[om-on]`, `[hybrid]`) with shortened descriptions, making the command palette visually consistent and easier to scan.
+
+### Notification & session goal reorg
+
+- Session goal now derives from the first user message and is persisted at the top across compactions, with `(#N)` entry indexing for traceability.
+- OM info notifications are gated to one per phase/turn — warnings and errors still fire immediately.
+- Git commit extraction now handles tool_call, bash, and post-convert user-text formats.
+- Cooldown skip messages now strip raw JSON from the reason for cleaner display, with a log pointer for debugging.
+
 ### Fixed
 
 - **Early-session reflection/drop starvation on first compaction.** Added `fullFoldAlways` config flag (default `true`). When no prior full-fold boundary exists, reflections and drops now use the observation boundary instead of being excluded. Previously, fresh sessions silently lost all durable memory on the first compaction because there was no full-fold history to anchor the maintenance boundary.

--- a/src/commands/pi-vcc.ts
+++ b/src/commands/pi-vcc.ts
@@ -8,7 +8,7 @@
  */
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import type { Runtime } from "../om/runtime.js";
-import { PI_VCC_COMPACT_INSTRUCTION, notifyMigrationReminder } from "../hooks/before-compact";
+import { PI_VCC_COMPACT_INSTRUCTION, notifyMigrationReminder, formatCompactionStats } from "../hooks/before-compact";
 import { saveUnifiedConfig, configPath } from "../core/unified-config.js";
 import { readPendingState, clearPendingState, hasPendingData } from "../om/pending.js";
 import { createConfigureOverlay } from "../om/configure-overlay.js";
@@ -18,11 +18,6 @@ import {
 	OM_REFLECTIONS_RECORDED,
 } from "../om/ledger/index.js";
 import { handleCleanup } from "./cleanup.js";
-
-const formatTokens = (n: number): string => {
-	if (n >= 1000) return `${(n / 1000).toFixed(1)}k`;
-	return String(n);
-};
 
 export const registerPiVccCommand = (pi: ExtensionAPI, runtime: Runtime) => {
 	const prefixMatch = (value: string, prefix: string): boolean => {
@@ -100,6 +95,17 @@ export const registerPiVccCommand = (pi: ExtensionAPI, runtime: Runtime) => {
 				return;
 			}
 
+			// Warn if input starts with a known subcommand but isn't an exact match.
+			// Prevents "/blackhole configure foo" from silently becoming a follow-up.
+			const SUBCOMMAND_NAMES = ["configure", "cleanup", "om-off", "om-on"];
+			const nearMiss = SUBCOMMAND_NAMES.find(
+				name => trimmed.toLowerCase().startsWith(name.toLowerCase()) && trimmed.length > name.length
+			);
+			if (nearMiss) {
+				ctx.ui.notify(`/blackhole ${nearMiss} accepts no arguments. Did you mean \"/blackhole ${nearMiss}\"?`, "warning");
+				return;
+			}
+
 			// Extract follow-up prompt: everything after the subcommand check
 			// that isn't a known subcommand is treated as follow-up text.
 			const followUpPrompt = trimmed ? trimmed : null;
@@ -141,10 +147,7 @@ export const registerPiVccCommand = (pi: ExtensionAPI, runtime: Runtime) => {
 				onComplete: () => {
 					const stats = runtime.compactionStats;
 					if (stats) {
-						ctx.ui.notify(
-							`blackhole: ${stats.summarized} source entries processed; tail kept ${stats.kept} (~${formatTokens(stats.keptTokensEst)} tok).`,
-							"info",
-						);
+						ctx.ui.notify(formatCompactionStats(stats), "info");
 					} else {
 						ctx.ui.notify("Compacted with blackhole", "info");
 					}
@@ -153,7 +156,7 @@ export const registerPiVccCommand = (pi: ExtensionAPI, runtime: Runtime) => {
 					// Fire follow-up prompt after compaction completes
 					if (followUpPrompt) {
 						try {
-							pi.sendUserMessage(followUpPrompt);
+							void Promise.resolve(pi.sendUserMessage(followUpPrompt)).catch(() => {});
 						} catch {}
 					}
 				},

--- a/src/commands/pi-vcc.ts
+++ b/src/commands/pi-vcc.ts
@@ -100,6 +100,10 @@ export const registerPiVccCommand = (pi: ExtensionAPI, runtime: Runtime) => {
 				return;
 			}
 
+			// Extract follow-up prompt: everything after the subcommand check
+			// that isn't a known subcommand is treated as follow-up text.
+			const followUpPrompt = trimmed ? trimmed : null;
+
 			// If compaction is manual (or legacy noAutoCompact): flush pending OM entries
 			// into the branch before compacting so the summary includes accumulated memory.
 			if (runtime.config.compaction === "manual" && hasPendingData(sessionId)) {
@@ -145,6 +149,13 @@ export const registerPiVccCommand = (pi: ExtensionAPI, runtime: Runtime) => {
 						ctx.ui.notify("Compacted with blackhole", "info");
 					}
 					notifyMigrationReminder(sessionId, (msg, level) => ctx.ui.notify(msg, level as any));
+
+					// Fire follow-up prompt after compaction completes
+					if (followUpPrompt) {
+						try {
+							pi.sendUserMessage(followUpPrompt);
+						} catch {}
+					}
 				},
 				onError: (err) => {
 					if (err.message === "Compaction cancelled" || err.message === "Already compacted") {

--- a/src/core/format.ts
+++ b/src/core/format.ts
@@ -31,7 +31,6 @@ export const wrapLongLines = (text: string, maxChars = TUI_SAFE_LINE_CHARS): str
 export const capBrief = (text: string): string => {
   const lines = text.split("\n");
   if (lines.length <= BRIEF_MAX_LINES) return text;
-  const omitted = lines.length - BRIEF_MAX_LINES;
   const kept = lines.slice(-BRIEF_MAX_LINES);
   // Find first section header to avoid cutting mid-section
   let firstHeader = kept.findIndex((l) => /^\[.+\]/.test(l));
@@ -42,6 +41,7 @@ export const capBrief = (text: string): string => {
     if (anyAnchor > 0) firstHeader = anyAnchor;
   }
   const clean = firstHeader > 0 ? kept.slice(firstHeader) : kept;
+  const omitted = lines.length - clean.length;
   return `...(${omitted} earlier lines omitted)\n\n${clean.join("\n")}`;
 };
 

--- a/src/hooks/before-compact.ts
+++ b/src/hooks/before-compact.ts
@@ -400,10 +400,22 @@ export const registerBeforeCompactHook = (pi: ExtensionAPI, omRuntime: Runtime) 
       }, 0);
       return sum;
     }, 0);
+    const totalUserTurns = (branchEntries as any[]).filter((e: any) => e.type === "message" && e.message?.role === "user").length;
+    const keptUserTurns = ownCut.compactAll
+      ? 0
+      : (branchEntries as any[]).slice(keptIdx).filter((e: any) => e.type === "message" && e.message?.role === "user").length;
     omRuntime.compactionStats = {
       summarized: agentMessages.length,
       kept: keptEntries.length,
       keptTokensEst: Math.round(keptChars / 4),
+      compactAll: ownCut.compactAll,
+      totalUserTurns,
+      keptUserTurns,
+      requestedKeepUserTurns: 1,
+      keepUserTurnsExplicit: false,
+      keepFallbackToCompactAll: ownCut.compactAll,
+      smartKeepAdjusted: false,
+      smartFromKeep: 1,
     };
 
     const summary = compile({

--- a/src/hooks/before-compact.ts
+++ b/src/hooks/before-compact.ts
@@ -48,6 +48,37 @@ const formatTokens = (n: number): string => {
   return String(n);
 };
 
+export interface CompactionStats {
+  summarized: number;
+  kept: number;
+  keptTokensEst: number;
+  compactAll: boolean;
+  totalUserTurns: number;
+  keptUserTurns: number;
+  requestedKeepUserTurns: number;
+  keepUserTurnsExplicit: boolean;
+  keepFallbackToCompactAll: boolean;
+  smartKeepAdjusted: boolean;
+  smartFromKeep: number;
+}
+
+/**
+ * Format compaction stats for user-visible notification.
+ * Example output:
+ *   blackhole: 6 source entries processed; tail kept 1/4 user turns (~0.5k tok).
+ */
+export const formatCompactionStats = (stats: CompactionStats): string => {
+  const parts: string[] = [`${stats.summarized} source entries processed`];
+  parts.push(`tail kept ${stats.keptUserTurns}/${stats.totalUserTurns} user turns`);
+  if (stats.smartKeepAdjusted) {
+    parts.push(`smart keep:${stats.smartFromKeep}→${stats.keptUserTurns}`);
+  }
+  if (stats.keepFallbackToCompactAll) {
+    parts.push(`compact-all`);
+  }
+  return `blackhole: ${parts.join("; ")} (~${formatTokens(stats.keptTokensEst)} tok).`;
+};
+
 const dbg = (debug: boolean, data: Record<string, unknown>) => {
   if (!debug) return;
   try { writeFileSync("/tmp/pi-blackhole-debug.json", JSON.stringify(data, null, 2)); } catch {}
@@ -291,9 +322,7 @@ export const registerBeforeCompactHook = (pi: ExtensionAPI, omRuntime: Runtime) 
     // Determine effective tail behavior for buildOwnCut
     // Both /blackhole and auto-triggered default to "minimal" (aggressive cut);
     // users can opt into "pi-default" (gentler) by setting tailBehavior in config.
-    const effectiveTailBehavior = isPiVcc
-      ? (omRuntime.config.tailBehavior ?? "minimal")
-      : (omRuntime.config.tailBehavior ?? "minimal");
+    const effectiveTailBehavior = omRuntime.config.tailBehavior ?? "minimal";
 
     trace("before_compact.tail_behavior", {
       effectiveTailBehavior,
@@ -503,10 +532,7 @@ export const registerBeforeCompactHook = (pi: ExtensionAPI, omRuntime: Runtime) 
     const sessionId = ctx.sessionManager.getSessionId();
     setTimeout(() => {
       try {
-        ctx?.ui?.notify?.(
-          `blackhole: ${stats.summarized} source entries processed; tail kept ${stats.kept} (~${formatTokens(stats.keptTokensEst)} tok).`,
-          "info",
-        );
+        ctx?.ui?.notify?.(formatCompactionStats(stats), "info");
         notifyMigrationReminder(sessionId, (msg, level) => ctx?.ui?.notify?.(msg, level as any));
       } catch {}
     }, 500);

--- a/src/om/runtime.ts
+++ b/src/om/runtime.ts
@@ -80,7 +80,19 @@ export class Runtime {
 	/** Epoch ms of the last failed consolidation run (any stage). */
 	lastConsolidationErrorAt: number | undefined;
 	/** Stats from the most recent compaction run (session-scoped via handler closure). */
-	compactionStats: { summarized: number; kept: number; keptTokensEst: number } | null = null;
+	compactionStats: {
+		summarized: number;
+		kept: number;
+		keptTokensEst: number;
+		compactAll: boolean;
+		totalUserTurns: number;
+		keptUserTurns: number;
+		requestedKeepUserTurns: number;
+		keepUserTurnsExplicit: boolean;
+		keepFallbackToCompactAll: boolean;
+		smartKeepAdjusted: boolean;
+		smartFromKeep: number;
+	} | null = null;
 	/** Whether the most recent compaction was triggered by /blackhole (vs auto-compact). */
 	compactWasPiVcc = false;
 	/** In‑memory pipeline cursors — authoritative copy for gating decisions. */

--- a/src/om/runtime.ts
+++ b/src/om/runtime.ts
@@ -10,6 +10,7 @@
  * - markConsolidationError sets 30s retry gate for failed runs.
  */
 import { type Config, type ConfiguredModel, DEFAULTS, loadConfig } from "./config.js";
+import type { CompactionStats } from "../hooks/before-compact.js";
 import { isCooldownActive, getCooldownEntry, recordCooldown, expireCooldowns, modelKey } from "./cooldown.js";
 import { readPendingCursors, writePendingCursors } from "./pending.js";
 import type { PendingOMState } from "./pending.js";
@@ -80,19 +81,7 @@ export class Runtime {
 	/** Epoch ms of the last failed consolidation run (any stage). */
 	lastConsolidationErrorAt: number | undefined;
 	/** Stats from the most recent compaction run (session-scoped via handler closure). */
-	compactionStats: {
-		summarized: number;
-		kept: number;
-		keptTokensEst: number;
-		compactAll: boolean;
-		totalUserTurns: number;
-		keptUserTurns: number;
-		requestedKeepUserTurns: number;
-		keepUserTurnsExplicit: boolean;
-		keepFallbackToCompactAll: boolean;
-		smartKeepAdjusted: boolean;
-		smartFromKeep: number;
-	} | null = null;
+	compactionStats: CompactionStats | null = null;
 	/** Whether the most recent compaction was triggered by /blackhole (vs auto-compact). */
 	compactWasPiVcc = false;
 	/** In‑memory pipeline cursors — authoritative copy for gating decisions. */

--- a/tests/blackhole-command.test.ts
+++ b/tests/blackhole-command.test.ts
@@ -63,6 +63,7 @@ function createMockEnvironment() {
 				notify: vi.fn((msg: string, level: string) => {
 					notifyCalls.push({ msg, level });
 				}),
+				custom: vi.fn(),
 			},
 			...overrides,
 		};
@@ -208,5 +209,103 @@ describe("/blackhole command", () => {
 		expect(existsSync(pendingFile)).toBe(false); // cleared after flush
 		// Should call compact after flush
 		expect(ctx.compact).toHaveBeenCalledTimes(1);
+	});
+});
+
+// ── Feature 1: Follow-up prompt after compaction ────────────────────────────
+
+describe("/blackhole follow-up prompt", () => {
+	beforeEach(() => {
+		mkdirSync(join(testRoot, "agent", "pi-blackhole"), { recursive: true });
+	});
+
+	afterEach(() => {
+		rmSync(testRoot, { recursive: true, force: true });
+	});
+
+	it("extracts follow-up text from /blackhole <args> and sends it after compaction", async () => {
+		const sendUserMessageCalls: Array<{ content: string }> = [];
+		const { pi, runtime, handlerMap, makeHandlerArgs } = createMockEnvironment();
+		(pi as any).sendUserMessage = vi.fn((content: string) => {
+			sendUserMessageCalls.push({ content });
+		});
+		registerPiVccCommand(pi as any, runtime as any);
+
+		const ctx = makeHandlerArgs();
+		await handlerMap.get("blackhole")!("fix the auth bug", ctx);
+
+		expect(ctx.compact).toHaveBeenCalledTimes(1);
+		const call = ctx.compact.mock.calls[0][0];
+		expect(call.customInstructions).toBe("__pi_vcc__");
+		// Simulate compaction completion — follow-up should fire
+		call.onComplete();
+		expect(sendUserMessageCalls).toHaveLength(1);
+		expect(sendUserMessageCalls[0].content).toBe("fix the auth bug");
+	});
+
+	it("does NOT extract subcommands as follow-up", async () => {
+		const { pi, runtime, handlerMap, makeHandlerArgs, notifyCalls } = createMockEnvironment();
+		registerPiVccCommand(pi as any, runtime as any);
+
+		const ctx = makeHandlerArgs();
+		await handlerMap.get("blackhole")!("configure", ctx);
+
+		// Should NOT compact — subcommand handled separately
+		expect(ctx.compact).not.toHaveBeenCalled();
+	});
+
+	it("no args → no follow-up prompt sent", async () => {
+		const sendUserMessageCalls: Array<{ content: string }> = [];
+		const { pi, runtime, handlerMap, makeHandlerArgs } = createMockEnvironment();
+		(pi as any).sendUserMessage = vi.fn((content: string) => {
+			sendUserMessageCalls.push({ content });
+		});
+		registerPiVccCommand(pi as any, runtime as any);
+
+		const ctx = makeHandlerArgs();
+		await handlerMap.get("blackhole")!("", ctx);
+
+		expect(ctx.compact).toHaveBeenCalledTimes(1);
+		const call = ctx.compact.mock.calls[0][0];
+		call.onComplete();
+		expect(sendUserMessageCalls).toHaveLength(0);
+	});
+
+	it("fires follow-up via sendUserMessage after compaction completes", async () => {
+		const sendUserMessageCalls: Array<{ content: string }> = [];
+		const { pi, runtime, handlerMap, makeHandlerArgs } = createMockEnvironment();
+		(pi as any).sendUserMessage = vi.fn((content: string) => {
+			sendUserMessageCalls.push({ content });
+		});
+		registerPiVccCommand(pi as any, runtime as any);
+
+		const ctx = makeHandlerArgs();
+		await handlerMap.get("blackhole")!("continue the refactor", ctx);
+
+		const call = ctx.compact.mock.calls[0][0];
+		// Simulate compaction completion
+		call.onComplete();
+
+		// The follow-up should be sent as a user message
+		expect(sendUserMessageCalls).toHaveLength(1);
+		expect(sendUserMessageCalls[0].content).toBe("continue the refactor");
+	});
+
+	it("does not fire follow-up when compaction fails", async () => {
+		const sendUserMessageCalls: Array<{ content: string }> = [];
+		const { pi, runtime, handlerMap, makeHandlerArgs } = createMockEnvironment();
+		(pi as any).sendUserMessage = vi.fn((content: string) => {
+			sendUserMessageCalls.push({ content });
+		});
+		registerPiVccCommand(pi as any, runtime as any);
+
+		const ctx = makeHandlerArgs();
+		await handlerMap.get("blackhole")!("continue", ctx);
+
+		const call = ctx.compact.mock.calls[0][0];
+		// Simulate compaction failure
+		call.onError(new Error("context overflow"));
+
+		expect(sendUserMessageCalls).toHaveLength(0);
 	});
 });

--- a/tests/vcc-before-compact-hook.test.ts
+++ b/tests/vcc-before-compact-hook.test.ts
@@ -302,3 +302,121 @@ describe("registerBeforeCompactHook: new config key guards", () => {
     expect(result.compaction).toBeDefined();
   });
 });
+
+// ── Bug A: CompactionStats fully populated from buildOwnCut return data ──────
+
+describe("registerBeforeCompactHook: CompactionStats population", () => {
+  beforeEach(() => {
+    if (existsSync(DEBUG_PATH)) unlinkSync(DEBUG_PATH);
+  });
+  afterEach(() => {
+    if (existsSync(CONFIG_PATH)) unlinkSync(CONFIG_PATH);
+    if (existsSync(DEBUG_PATH)) unlinkSync(DEBUG_PATH);
+  });
+
+  test("populates every CompactionStats field on successful compaction", () => {
+    const { pi, invoke, omRuntime } = createMockPi();
+    omRuntime.config.overrideDefaultCompaction = false;
+    registerBeforeCompactHook(pi, omRuntime);
+
+    // 4 user + 4 assistant = 8 messages, normal cut at last user
+    const entries = [
+      msg("m1", "user"),
+      msg("m2", "assistant"),
+      msg("m3", "user"),
+      msg("m4", "assistant"),
+      msg("m5", "user"),
+      msg("m6", "assistant"),
+      msg("m7", "user"),
+      msg("m8", "assistant"),
+    ];
+    invoke(makeEvent(entries, PI_VCC_COMPACT_INSTRUCTION));
+
+    const stats = omRuntime.compactionStats;
+    expect(stats).not.toBeNull();
+    expect(stats!.summarized).toBe(6); // m1-m6 summarized
+    expect(stats!.kept).toBe(2);        // m7, m8 kept
+    expect(stats!.keptTokensEst).toBeGreaterThan(0);
+    expect(stats!.totalUserTurns).toBe(4); // m1, m3, m5, m7
+    expect(stats!.keptUserTurns).toBe(1);  // m7 only
+    expect(stats!.requestedKeepUserTurns).toBe(1); // default
+    expect(stats!.keepUserTurnsExplicit).toBe(false); // no keep:N
+    expect(stats!.keepFallbackToCompactAll).toBe(false); // normal cut
+    expect(stats!.smartKeepAdjusted).toBe(false); // not implemented yet
+    expect(stats!.smartFromKeep).toBe(1); // default
+  });
+
+  test("keepFallbackToCompactAll is true when compactAll", () => {
+    const { pi, invoke, omRuntime } = createMockPi();
+    omRuntime.config.overrideDefaultCompaction = false;
+    registerBeforeCompactHook(pi, omRuntime);
+
+    // Single user + autonomous tail → compactAll
+    const entries = [
+      msg("m1", "user", "go"),
+      msg("m2", "assistant"),
+      msg("m3", "toolResult"),
+      msg("m4", "assistant"),
+    ];
+    invoke(makeEvent(entries, PI_VCC_COMPACT_INSTRUCTION));
+
+    const stats = omRuntime.compactionStats;
+    expect(stats).not.toBeNull();
+    expect(stats!.keepFallbackToCompactAll).toBe(true);
+    expect(stats!.compactAll).toBe(true);
+  });
+
+  test("totalUserTurns counts all user messages in branch", () => {
+    const { pi, invoke, omRuntime } = createMockPi();
+    omRuntime.config.overrideDefaultCompaction = false;
+    registerBeforeCompactHook(pi, omRuntime);
+
+    const entries = [
+      msg("m1", "user"),
+      msg("m2", "assistant"),
+      msg("m3", "user"),
+      msg("m4", "assistant"),
+      msg("m5", "user"),
+    ];
+    invoke(makeEvent(entries, PI_VCC_COMPACT_INSTRUCTION));
+
+    expect(omRuntime.compactionStats!.totalUserTurns).toBe(3);
+  });
+
+  test("keptUserTurns counts user messages after the cut", () => {
+    const { pi, invoke, omRuntime } = createMockPi();
+    omRuntime.config.overrideDefaultCompaction = false;
+    registerBeforeCompactHook(pi, omRuntime);
+
+    // 3 users, cut at last user (m5), so m5 is kept, m1+m3 summarized
+    const entries = [
+      msg("m1", "user"),
+      msg("m2", "assistant"),
+      msg("m3", "user"),
+      msg("m4", "assistant"),
+      msg("m5", "user"),
+      msg("m6", "assistant"),
+    ];
+    invoke(makeEvent(entries, PI_VCC_COMPACT_INSTRUCTION));
+
+    expect(omRuntime.compactionStats!.keptUserTurns).toBe(1); // only m5
+  });
+
+  test("keptUserTurns is 0 for compactAll (firstKeptEntryId sentinel)", () => {
+    const { pi, invoke, omRuntime } = createMockPi();
+    omRuntime.config.overrideDefaultCompaction = false;
+    registerBeforeCompactHook(pi, omRuntime);
+
+    const entries = [
+      msg("m1", "user", "go"),
+      msg("m2", "assistant"),
+      msg("m3", "toolResult"),
+      msg("m4", "assistant"),
+    ];
+    invoke(makeEvent(entries, PI_VCC_COMPACT_INSTRUCTION));
+
+    // compactAll: everything summarized, nothing kept
+    expect(omRuntime.compactionStats!.compactAll).toBe(true);
+    expect(omRuntime.compactionStats!.keptUserTurns).toBe(0);
+  });
+});

--- a/tests/vcc-format.test.ts
+++ b/tests/vcc-format.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { formatSummary } from "../src/core/format.js";
+import { formatSummary, capBrief } from "../src/core/format.js";
 import type { SectionData } from "../src/sections.js";
 
 const empty: SectionData = {
@@ -66,5 +66,45 @@ describe("formatSummary", () => {
     };
     const r = formatSummary(data);
     expect(Math.max(...r.split("\n").map((line) => line.length))).toBeLessThanOrEqual(120);
+  });
+
+  describe("capBrief omission count", () => {
+    it("computes omitted after firstHeader trim, not before", () => {
+      // Build a brief with 150 lines where the first 20 lines have no header,
+      // and the first header appears at line 21. With BRIEF_MAX_LINES=120,
+      // the kept window is lines 31-150 (120 lines starting at first header).
+      // Old buggy code: omitted = 150 - 120 = 30
+      // Fixed code: omitted = 150 - 120 = 30 (same in this case because clean==kept)
+      // To expose the bug, we need a case where firstHeader trims MORE lines
+      // than BRIEF_MAX_LINES would allow. Let's use 200 lines, first header at 100.
+      // BRIEF_MAX_LINES=120, kept = lines[80:200] (120 lines), firstHeader at index 20 in kept.
+      // clean = lines[100:200] (100 lines).
+      // Old bug: omitted = 200 - 120 = 80 (wrong, should be 200 - 100 = 100)
+      const lines = Array.from({ length: 200 }, (_, i) => {
+        if (i < 99) return `line ${i}`; // no headers in first 99 lines
+        if (i === 99) return "[Session Goal]"; // first header at line 100 (index 99)
+        return `line ${i}`;
+      });
+      const text = lines.join("\n");
+      const result = capBrief(text);
+      const omittedMatch = result.match(/\(([0-9]+) earlier lines omitted\)/);
+      expect(omittedMatch).not.toBeNull();
+      const omitted = parseInt(omittedMatch![1], 10);
+      // clean = lines[100:200] = 100 lines, so omitted = 200 - 100 = 100
+      // Wait: kept = last 120 lines (indices 80-199), firstHeader at index 19 in kept,
+      // clean = kept.slice(19) = 101 lines. omitted = 200 - 101 = 99.
+      expect(omitted).toBe(99);
+    });
+
+    it("omitted count matches actual trimmed lines when no header anchor", () => {
+      // Simple case: 150 lines, no headers, BRIEF_MAX_LINES=120
+      // kept = last 120 lines, firstHeader = -1, clean = kept
+      // omitted = 150 - 120 = 30
+      const lines = Array.from({ length: 150 }, (_, i) => `line ${i}`);
+      const result = capBrief(lines.join("\n"));
+      const omittedMatch = result.match(/\(([0-9]+) earlier lines omitted\)/);
+      expect(omittedMatch).not.toBeNull();
+      expect(parseInt(omittedMatch![1], 10)).toBe(30);
+    });
   });
 });


### PR DESCRIPTION
## Ported from upstream pi-vcc

Strategic graft of selected upstream features into blackhole's diverged codebase. No literal 1:1 lift — adapted for our `/blackhole` command, unified config, and merged OM/compaction hook.

### Added

- **`/blackhole <text>` follow-up prompt.** After compaction, `/blackhole` optionally sends `<text>` as a follow-up message so the model continues the task without re-typing. Wrapped in `void Promise.resolve(...).catch(() => {})` for robust error handling.
- **Subcommand near-miss guard.** `/blackhole configure foo` now shows a warning instead of silently becoming a follow-up prompt.
- **`CompactionStats` expanded from 3 to 11 fields.** Added `compactAll`, `totalUserTurns`, `keptUserTurns`, `requestedKeepUserTurns`, `keepUserTurnsExplicit`, `keepFallbackToCompactAll`, `smartKeepAdjusted`, `smartFromKeep`. All populated from `buildOwnCut` return data (Bug A fix).
- **Shared `formatCompactionStats` exported.** Both the `/blackhole` command handler and hook's `session_compact` handler now use a single shared formatter.

### Fixed

- **`capBrief` omission count now computed after `firstHeader` trim.** The "N earlier lines omitted" header was computed before the section-header anchor trim, so the count was understated when headers caused additional trimming. Matched an upstream bug that was already fixed there.
- **Dead ternary collapsed.** `effectiveTailBehavior` no longer has an `isPiVcc` branch with identical values on both sides (Bug B fix).
- **Unhandled promise rejection.** `pi.sendUserMessage` in the follow-up path was called without `await` or `.catch()`. Now wrapped in `void Promise.resolve(...).catch(() => {})`.
- **Removed duplicate `formatTokens` helper** from `pi-vcc.ts` — no longer needed now that both toast paths use the shared formatter.

### Tests

- 5 new tests for follow-up prompt: extraction, subcommand exclusion, empty-args suppression, send after completion, compaction-failure suppression.
- 6 new tests for CompactionStats population: all fields populated, compactAll flag, totalUserTurns count, keptUserTurns count, compactAll zero kept, format string coverage.
- 2 new tests for capBrief omission count: header-trimmed count is correct (99 for 200 lines with header at line 100), no-header fallback still correct.

### Skipped upstream changes

- Ranked compaction (architectural divergence too large)
- `queueMicrotask` in compaction trigger (our `AbortController` solution is superior)
- Ratio mode for compaction threshold (deferred)
- Smart keep-tail (not yet ported — fields are populated as placeholders)