### PR TITLE
feat: mid-run auto-compaction — evaluate compactAfterTokens at turn_end (threshold never fires during tool loops)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## [Unreleased]
+
+### Added
+
+- **Mid-run auto-compaction (`midRunCompaction`).** The threshold trigger previously only ran on `agent_end`, which never fires while the agent is looping through tool calls — during long runs `compactAfterTokens` could be exceeded many times over without a single evaluation, and the post-run wait was aborted by any new `agent_start`, deferring compaction indefinitely under continuous use. The threshold is now also evaluated at every `turn_end` (after each assistant message + tool executions). New config enum `midRunCompaction: "resume" | "pause" | "off"` (default `"resume"`): `resume` compacts at the threshold and injects a `blackhole-resume` message (`triggerTurn`) so the agent continues the task with the compacted context; `pause` compacts and hands control back; `off` restores the old end-of-run-only behavior. Available in `/blackhole configure`.
+
+### Fixed
+
+- **Mid-run compaction failure resilience.** If the before-compact hook cancels (or compaction errors) after `ctx.compact()` has already aborted the run, resume mode still re-triggers the agent so the task doesn't stall, and further mid-run attempts are suspended until a compaction lowers pressure below the threshold (prevents abort/cancel thrash loops).
+
 ## [0.4.0] - 2026-07-24
 
 ### Added

--- a/CONFIG.md
+++ b/CONFIG.md
@@ -22,6 +22,7 @@ The config file must contain **valid JSON**. A trailing comma, partial write, or
   "compaction": "auto",           // "auto" | "manual" | "off"
   "compactionEngine": "blackhole", // "blackhole" | "pi-default"
   "tailBehavior": "minimal",   // "pi-default" | "minimal"
+  "midRunCompaction": "resume",   // "resume" | "pause" | "off"
   "compactAfterTokens": 81000,    // Token threshold for auto-compaction
 
   // ── Observational Memory ──
@@ -124,9 +125,36 @@ minimal (last user at m5):
 { "tailBehavior": "minimal" }
 ```
 
+### `midRunCompaction`
+
+Controls the **mid-run** auto-compaction trigger. Pi's `agent_end` event only fires when a run exits — during long tool loops (agent calling tools turn after turn) the threshold would otherwise never be evaluated, and accumulated tokens could blow far past `compactAfterTokens` before compaction had any chance to run. This trigger evaluates the threshold at every `turn_end` (after each assistant message + tool executions) while the agent is still working.
+
+Only applies when `compaction: "auto"` and `compactionEngine: "blackhole"`.
+
+| Value | Behavior |
+|-------|----------|
+| `"resume"` | Compact at threshold mid-run, then inject a resume message (`triggerTurn`) so the agent continues the task with the compacted context (default) |
+| `"pause"` | Compact at threshold mid-run, but stop — the user continues manually |
+| `"off"` | No mid-run evaluation; threshold is only checked when the agent finishes a run (pre-0.5 behavior) |
+
+**Why compaction interrupts the run:** Pi's `compact()` aborts the in-flight agent operation by design. `turn_end` is a clean boundary — all tool results of the turn are already persisted, so at most one just-started LLM call is wasted. With `"resume"`, the agent picks the task back up immediately; the compaction summary plus the kept tail (see `tailBehavior`) carry the task state across.
+
+**Re-trigger safety:** after a compaction, accumulated tokens are counted from the fresh compaction entry, so the threshold naturally resets — no compact/resume loops.
+
+```jsonc
+// Compact mid-run and keep working (default)
+{ "midRunCompaction": "resume" }
+
+// Compact mid-run but hand control back to the user
+{ "midRunCompaction": "pause" }
+
+// Old behavior: only evaluate when the run ends
+{ "midRunCompaction": "off" }
+```
+
 ### `compactAfterTokens`
 
-Token threshold for auto-compaction. When `compaction: "auto"` and accumulated tokens since the last compaction exceed this threshold, compaction triggers automatically.
+Token threshold for auto-compaction. When `compaction: "auto"` and accumulated tokens since the last compaction exceed this threshold, compaction triggers automatically — both mid-run (see `midRunCompaction`) and when the agent finishes a run.
 
 | Type | Default |
 |------|---------|

--- a/example-config.json
+++ b/example-config.json
@@ -7,6 +7,7 @@
   "compaction": "auto",
   "compactionEngine": "blackhole",
   "tailBehavior": "minimal",
+  "midRunCompaction": "resume",
 
   "model": {
     "_comment": "Base model (last fallback before session model).",
@@ -110,6 +111,7 @@
     "  compaction (auto|manual|off) — how compaction triggers",
     "  compactionEngine (blackhole|pi-default) — who handles it",
     "  tailBehavior (pi-default|minimal) — how much stays visible",
+    "  midRunCompaction (resume|pause|off) — threshold check during tool loops",
     "  sessionFallback (true|false) — if false, skip session model as last-resort fallback",
     "  dropperPressureThreshold (0-1, default 0.70) — pressure relief valve: fraction of reflectorInputMaxTokens where dropper fires even without new data",
     "",

--- a/src/core/unified-config.ts
+++ b/src/core/unified-config.ts
@@ -62,6 +62,14 @@ export interface UnifiedConfig {
 	 *  "pi-default" — Pi's built-in summarization */
 	compactionEngine: "blackhole" | "pi-default";
 
+	/** Mid-run auto-compaction (turn_end trigger, fires while the agent is still
+	 *  executing tool loops — agent_end alone never fires during long runs).
+	 *  "resume" — compact at threshold and inject a resume message so the agent
+	 *             continues the task (default)
+	 *  "pause"  — compact at threshold but stop; user continues manually
+	 *  "off"    — only evaluate the threshold when the agent finishes a run */
+	midRunCompaction: "resume" | "pause" | "off";
+
 	/** How much recent transcript to keep visible after compaction.
 	 *  "pi-default" — use Pi's firstKeptEntryId (respects Pi's keepRecentTokens)
 	 *  "minimal"    — keep only last user message (current agressive pi-vcc behavior)
@@ -149,6 +157,7 @@ export const DEFAULTS: UnifiedConfig = {
 	compaction: "auto",
 	compactionEngine: "blackhole",
 	tailBehavior: "minimal",
+	midRunCompaction: "resume",
 
 	observeAfterTokens: 15_000,
 	reflectAfterTokens: 25_000,
@@ -175,6 +184,7 @@ const THINKING_LEVELS: readonly string[] = ["off", "minimal", "low", "medium", "
 const COMPACTION_VALUES = ["auto", "manual", "off"] as const;
 const COMPACTION_ENGINE_VALUES = ["blackhole", "pi-default"] as const;
 const TAIL_BEHAVIOR_VALUES = ["pi-default", "minimal"] as const;
+const MID_RUN_COMPACTION_VALUES = ["resume", "pause", "off"] as const;
 
 function isCompaction(v: unknown): v is "auto" | "manual" | "off" {
 	return typeof v === "string" && (COMPACTION_VALUES as readonly string[]).includes(v);
@@ -184,6 +194,9 @@ function isCompactionEngine(v: unknown): v is "blackhole" | "pi-default" {
 }
 function isTailBehavior(v: unknown): v is "pi-default" | "minimal" {
 	return typeof v === "string" && (TAIL_BEHAVIOR_VALUES as readonly string[]).includes(v);
+}
+function isMidRunCompaction(v: unknown): v is "resume" | "pause" | "off" {
+	return typeof v === "string" && (MID_RUN_COMPACTION_VALUES as readonly string[]).includes(v);
 }
 
 function isRecord(v: unknown): v is Record<string, unknown> {
@@ -234,6 +247,7 @@ function parseConfig(raw: Record<string, unknown>): Partial<UnifiedConfig> {
 	if (isCompaction(raw.compaction)) c.compaction = raw.compaction;
 	if (isCompactionEngine(raw.compactionEngine)) c.compactionEngine = raw.compactionEngine;
 	if (isTailBehavior(raw.tailBehavior)) c.tailBehavior = raw.tailBehavior;
+	if (isMidRunCompaction(raw.midRunCompaction)) c.midRunCompaction = raw.midRunCompaction;
 
 	// Booleans — pi-vcc
 	if (typeof raw.overrideDefaultCompaction === "boolean") c.overrideDefaultCompaction = raw.overrideDefaultCompaction;

--- a/src/om/compaction-trigger.ts
+++ b/src/om/compaction-trigger.ts
@@ -26,6 +26,36 @@ function notifySafely(hasUI: boolean, ui: any, message: string, level: "info" | 
 	}
 }
 
+/**
+ * Message injected after a mid-run compaction so the agent resumes the task
+ * instead of stopping (ctx.compact() aborts the in-flight run and Pi does not
+ * auto-continue).
+ */
+export const MID_RUN_RESUME_CUSTOM_TYPE = "blackhole-resume";
+export const MID_RUN_RESUME_MESSAGE =
+	"Context was auto-compacted mid-task to stay under the token threshold. "
+	+ "The summary above preserves prior progress. Continue the task from where you left off.";
+
+/**
+ * Shared config gating for auto-compaction (agent_end and turn_end paths).
+ * Returns null when compaction may proceed, or a skip reason string.
+ */
+function autoCompactionSkipReason(runtime: Runtime): string | null {
+	if (runtime.config.compaction === "off") return "compaction_off";
+	if (runtime.config.compaction === "manual") return "compaction_manual";
+	if (runtime.config.compactionEngine === "pi-default") return "compactionEngine_pi_default";
+	// NOTE: memory does not gate compaction — memory:false + compaction:auto = compact without OM
+
+	// LEGACY: old config key guards — only apply when new keys are absent (unmigrated config)
+	if (runtime.config.compaction === undefined && runtime.config.compactionEngine === undefined) {
+		if (runtime.config.passive === true) return "passive";
+		if (runtime.config.noAutoCompact === true) return "noAutoCompact";
+		// Don't force Pi to compact unless the user explicitly opted into blackhole's pipeline.
+		if (runtime.config.overrideDefaultCompaction === false) return "overrideDefaultCompaction_false";
+	}
+	return null;
+}
+
 export function registerCompactionTrigger(pi: ExtensionAPI, runtime: Runtime): void {
 	pi.on("agent_start", () => {
 		// Reset the info gate — allow one info notification during the new turn.
@@ -49,6 +79,106 @@ export function registerCompactionTrigger(pi: ExtensionAPI, runtime: Runtime): v
 			throw error;
 		}
 	});
+
+	// Mid-run trigger: turn_end fires after every assistant-message + tool-execution
+	// cycle while the agent is still working. agent_end only fires when the run
+	// exits, so during long tool loops the threshold would otherwise never be
+	// evaluated (the configured compactAfterTokens could be exceeded many times
+	// over before compaction had a chance to run).
+	pi.on("turn_end", (_event: any, ctx: any) => {
+		try {
+			handleTurnEnd(ctx, runtime, pi);
+		} catch (error) {
+			if (isStaleExtensionContextError(error)) return;
+			throw error;
+		}
+	});
+}
+
+function handleTurnEnd(ctx: any, runtime: Runtime, pi: ExtensionAPI): void {
+	runtime.ensureConfig(ctx.cwd, (msg) => ctx.ui?.notify?.(msg, "warning"));
+	const dbg = (ev: string, d?: Record<string, unknown>) => debugLog(ev, d, runtime.config.debugLog === true);
+
+	const mode = runtime.config.midRunCompaction ?? "resume";
+	if (mode === "off") {
+		dbg("compaction_trigger.turn_end.skip", { reason: "midRunCompaction_off" });
+		return;
+	}
+	const skipReason = autoCompactionSkipReason(runtime);
+	if (skipReason) {
+		dbg("compaction_trigger.turn_end.skip", { reason: skipReason });
+		return;
+	}
+	if (runtime.compactInFlight) {
+		dbg("compaction_trigger.turn_end.skip", { reason: "compactInFlight" });
+		return;
+	}
+
+	const entries = ctx.sessionManager.getBranch() as Entry[];
+	const tokens = rawTokensSinceLastCompaction(entries);
+	if (tokens < runtime.config.compactAfterTokens) {
+		// Pressure relieved (a compaction ran) — lift any failure suspension.
+		runtime.midRunCompactionSuspended = false;
+		return;
+	}
+	if (runtime.midRunCompactionSuspended) {
+		// A previous mid-run attempt failed/cancelled at this pressure level.
+		// Re-triggering every turn would thrash (each attempt aborts the run).
+		// Stay suspended until a compaction lowers pressure below the threshold.
+		dbg("compaction_trigger.turn_end.skip", { reason: "suspended_after_failure", tokens });
+		return;
+	}
+
+	const hasUI = ctx.hasUI;
+	const ui = ctx.ui;
+	dbg("compaction_trigger.turn_end.threshold_reached", { tokens, threshold: runtime.config.compactAfterTokens, mode });
+	runtime.tryEmitInfo(hasUI, ui,
+		`Observational memory: compaction threshold reached mid-run (~${tokens.toLocaleString()} tokens); compacting${mode === "resume" ? " and resuming" : ""}`);
+
+	// ctx.compact() aborts the in-flight agent run before compacting — that is
+	// the intended trade: turn_end is a clean boundary (tool results are already
+	// persisted; at most one just-started LLM call is wasted).
+	runtime.compactInFlight = true;
+	ctx.compact({
+		onComplete: (_result: any) => {
+			runtime.compactInFlight = false;
+			dbg("compaction_trigger.turn_end.onComplete", { mode });
+			if (mode === "resume") {
+				try {
+					pi.sendMessage(
+						{ customType: MID_RUN_RESUME_CUSTOM_TYPE, content: MID_RUN_RESUME_MESSAGE, display: true },
+						{ triggerTurn: true },
+					);
+				} catch (error) {
+					if (!isStaleExtensionContextError(error)) throw error;
+				}
+			}
+			runtime.tryEmitInfo(hasUI, ui, "Observational memory: mid-run compaction complete");
+		},
+		onError: (error: { message: string }) => {
+			runtime.compactInFlight = false;
+			// Don't retry at this pressure level — the next attempt would abort the
+			// run again just to fail the same way. Cleared when pressure drops.
+			runtime.midRunCompactionSuspended = true;
+			dbg("compaction_trigger.turn_end.onError", { message: error?.message ?? String(error) });
+			if (error.message !== "Compaction cancelled") {
+				notifySafely(hasUI, ui, `Observational memory: mid-run compaction failed: ${error.message}`, "error");
+			}
+			// ctx.compact() already aborted the run. In resume mode the agent must
+			// continue regardless of the failed compaction — otherwise it stalls
+			// mid-task with no one at the wheel.
+			if (mode === "resume") {
+				try {
+					pi.sendMessage(
+						{ customType: MID_RUN_RESUME_CUSTOM_TYPE, content: MID_RUN_RESUME_MESSAGE, display: true },
+						{ triggerTurn: true },
+					);
+				} catch (sendError) {
+					if (!isStaleExtensionContextError(sendError)) throw sendError;
+				}
+			}
+		},
+	});
 }
 
 function handleAgentEnd(event: any, ctx: any, runtime: Runtime): void {
@@ -70,38 +200,11 @@ function handleAgentEnd(event: any, ctx: any, runtime: Runtime): void {
 			compactAfterTokens: runtime.config.compactAfterTokens,
 		});
 
-		// NEW: Unified compaction guards
-		if (runtime.config.compaction === "off") {
-			dbg("compaction_trigger.skip", { reason: "compaction_off" });
+		// Unified + legacy compaction guards (shared with the turn_end path)
+		const skipReason = autoCompactionSkipReason(runtime);
+		if (skipReason) {
+			dbg("compaction_trigger.skip", { reason: skipReason });
 			return;
-		}
-		if (runtime.config.compaction === "manual") {
-			dbg("compaction_trigger.skip", { reason: "compaction_manual" });
-			return;
-		}
-		if (runtime.config.compactionEngine === "pi-default") {
-			dbg("compaction_trigger.skip", { reason: "compactionEngine_pi_default" });
-			return;
-		}
-		// NOTE: memory no longer gates compaction — memory:false + compaction:auto = compact without OM
-
-		// LEGACY: old config key guards — only apply when new keys are absent (unmigrated config)
-		if (runtime.config.compaction === undefined && runtime.config.compactionEngine === undefined) {
-			if (runtime.config.passive === true) {
-				dbg("compaction_trigger.skip", { reason: "passive" });
-				return;
-			}
-			if (runtime.config.noAutoCompact === true) {
-				dbg("compaction_trigger.skip", { reason: "noAutoCompact" });
-				return;
-			}
-			// Don't force Pi to compact unless the user explicitly opted into blackhole's pipeline.
-			// When overrideDefaultCompaction is false (default), blackhole stays out of the way
-			// and lets Pi handle its own compaction naturally.
-			if (runtime.config.overrideDefaultCompaction === false) {
-				dbg("compaction_trigger.skip", { reason: "overrideDefaultCompaction_false" });
-				return;
-			}
 		}
 		if (runtime.compactInFlight) {
 			dbg("compaction_trigger.skip", { reason: "compactInFlight" });

--- a/src/om/configure-overlay.ts
+++ b/src/om/configure-overlay.ts
@@ -44,6 +44,8 @@ const FIELDS: FieldDef[] = [
 		helpText: "blackhole=structured summary+OM, pi-default=built-in Pi summarization" },
 	{ key: "tailBehavior", label: "Visible tail", type: "enum", section: "Compaction", enumValues: ["minimal", "pi-default"],
 		helpText: "minimal=keep last user message only (default), pi-default=keep Pi's preserved visible context" },
+	{ key: "midRunCompaction", label: "Mid-run compaction", type: "enum", section: "Compaction", enumValues: ["resume", "pause", "off"],
+		helpText: "resume=compact at threshold during tool loops and continue (default), pause=compact and stop, off=only check when run ends" },
 	{ key: "compactAfterTokens", label: "Auto-compact threshold", type: "number", section: "Compaction",
 		helpText: "Token count that triggers auto-compaction when reached" },
 

--- a/src/om/runtime.ts
+++ b/src/om/runtime.ts
@@ -73,6 +73,10 @@ export class Runtime {
 	 * Set when handleAgentEnd schedules a wait; cleared on abort, success, or terminal bail.
 	 * agent_start handlers read this to abort the pending wait when a new turn starts. */
 	autoCompactionController: AbortController | null = null;
+	/** Mid-run (turn_end) compaction is suspended after a failed/cancelled attempt
+	 * at the current pressure level. Cleared when accumulated tokens drop below
+	 * the threshold again (i.e. a compaction ran). Prevents abort/cancel thrash. */
+	midRunCompactionSuspended = false;
 	resolveFailureNotified = false;
 	lastObserverError: string | undefined;
 	lastReflectorError: string | undefined;

--- a/tests/compaction-trigger.test.ts
+++ b/tests/compaction-trigger.test.ts
@@ -46,14 +46,19 @@ function captureHandler(args: {
 	compaction?: "auto" | "manual" | "off";
 	/** NEW: Which engine handles compaction */
 	compactionEngine?: "blackhole" | "pi-default";
+	/** NEW: Mid-run (turn_end) compaction behavior */
+	midRunCompaction?: "resume" | "pause" | "off";
 } = {}) {
 	let agentEndHandler: ((event: unknown, ctx: unknown) => void) | undefined;
 	let agentStartHandler: (() => void) | undefined;
+	let turnEndHandler: ((event: unknown, ctx: unknown) => void) | undefined;
 	const pi = {
 		on: vi.fn((name: string, cb: any) => {
 			if (name === "agent_end") agentEndHandler = cb;
 			if (name === "agent_start") agentStartHandler = cb;
+			if (name === "turn_end") turnEndHandler = cb;
 		}),
+		sendMessage: vi.fn(),
 	};
 	const runtime = {
 		ensureConfig: vi.fn(),
@@ -73,6 +78,8 @@ function captureHandler(args: {
 			compaction: args.compaction,
 			/** NEW: Which engine handles compaction */
 			compactionEngine: args.compactionEngine,
+			/** NEW: Mid-run (turn_end) compaction behavior */
+			midRunCompaction: args.midRunCompaction,
 		},
 		compactInFlight: args.compactInFlight ?? false,
 		autoCompactionController: null as AbortController | null,
@@ -80,7 +87,16 @@ function captureHandler(args: {
 	registerCompactionTrigger(pi as any, runtime as any);
 	if (!agentEndHandler) throw new Error("agent_end handler was not registered");
 	if (!agentStartHandler) throw new Error("agent_start handler was not registered");
-	return { handler: agentEndHandler, startHandler: agentStartHandler, runtime };
+	if (!turnEndHandler) throw new Error("turn_end handler was not registered");
+	return { handler: agentEndHandler, startHandler: agentStartHandler, turnHandler: turnEndHandler, runtime, pi };
+}
+
+function turnEnd() {
+	return {
+		type: "turn_end",
+		message: { role: "assistant", content: "working...", stopReason: "toolUse" },
+		toolResults: [],
+	};
 }
 
 function agentEnd(errorMessage?: string) {
@@ -448,5 +464,229 @@ describe("V3 compaction trigger (blackhole)", () => {
 		expect(runtime.compactInFlight).toBe(false);
 		expect(ctx.sessionManager.getBranch).not.toHaveBeenCalled();
 		expect(ctx.compact).not.toHaveBeenCalled();
+	});
+});
+
+describe("mid-run compaction trigger (turn_end)", () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("M1: does nothing below compactAfterTokens", () => {
+		const { turnHandler, runtime } = captureHandler({ compactAfterTokens: 3 });
+		const ctx = fakeCtx([belowBranch]);
+
+		turnHandler(turnEnd(), ctx);
+
+		expect(runtime.compactInFlight).toBe(false);
+		expect(ctx.compact).not.toHaveBeenCalled();
+	});
+
+	it("M2: compacts immediately at threshold — no idle wait, agent is mid-run by definition", () => {
+		const { turnHandler, runtime } = captureHandler({ compactAfterTokens: 3 });
+		const ctx = fakeCtx([dueBranch]);
+
+		turnHandler(turnEnd(), ctx);
+
+		// Synchronous: no flushAll/timer advance — ctx.compact must already be called.
+		expect(runtime.compactInFlight).toBe(true);
+		expect(ctx.compact).toHaveBeenCalledTimes(1);
+		expect(ctx.isIdle).not.toHaveBeenCalled();
+	});
+
+	it("M3: default mode is resume — onComplete injects a resume message with triggerTurn", () => {
+		const { turnHandler, runtime, pi } = captureHandler({ compactAfterTokens: 3 });
+		const ctx = fakeCtx([dueBranch]);
+
+		turnHandler(turnEnd(), ctx);
+		const options = ctx.compact.mock.calls[0][0];
+		options.onComplete({});
+
+		expect(runtime.compactInFlight).toBe(false);
+		expect(pi.sendMessage).toHaveBeenCalledTimes(1);
+		const [message, sendOptions] = pi.sendMessage.mock.calls[0];
+		expect(message.customType).toBe("blackhole-resume");
+		expect(typeof message.content).toBe("string");
+		expect(message.content.length).toBeGreaterThan(0);
+		expect(sendOptions).toMatchObject({ triggerTurn: true });
+	});
+
+	it("M4: pause mode compacts but does not inject a resume message", () => {
+		const { turnHandler, runtime, pi } = captureHandler({ compactAfterTokens: 3, midRunCompaction: "pause" });
+		const ctx = fakeCtx([dueBranch]);
+
+		turnHandler(turnEnd(), ctx);
+		expect(ctx.compact).toHaveBeenCalledTimes(1);
+		const options = ctx.compact.mock.calls[0][0];
+		options.onComplete({});
+
+		expect(runtime.compactInFlight).toBe(false);
+		expect(pi.sendMessage).not.toHaveBeenCalled();
+	});
+
+	it("M5: off mode never compacts mid-run (agent_end path still works)", async () => {
+		const { turnHandler, handler, runtime } = captureHandler({ compactAfterTokens: 3, midRunCompaction: "off" });
+		const ctx = fakeCtx([dueBranch]);
+
+		turnHandler(turnEnd(), ctx);
+		expect(ctx.compact).not.toHaveBeenCalled();
+		expect(runtime.compactInFlight).toBe(false);
+
+		handler(agentEnd(), ctx);
+		await flushAll();
+		expect(ctx.compact).toHaveBeenCalledTimes(1);
+	});
+
+	it("M6: onError clears compactInFlight, suspends further attempts, and still resumes (resume mode)", () => {
+		const { turnHandler, runtime, pi } = captureHandler({ compactAfterTokens: 3 });
+		const ctx = fakeCtx([dueBranch]);
+
+		turnHandler(turnEnd(), ctx);
+		const options = ctx.compact.mock.calls[0][0];
+		options.onError({ message: "boom" });
+
+		expect(runtime.compactInFlight).toBe(false);
+		expect(runtime.midRunCompactionSuspended).toBe(true);
+		// The run was already aborted by ctx.compact() — resume mode must still
+		// send the resume message or the agent stalls mid-task.
+		expect(pi.sendMessage).toHaveBeenCalledTimes(1);
+	});
+
+	it("M7: skips when compaction is already in flight", () => {
+		const { turnHandler } = captureHandler({ compactAfterTokens: 3, compactInFlight: true });
+		const ctx = fakeCtx([dueBranch]);
+
+		turnHandler(turnEnd(), ctx);
+
+		expect(ctx.sessionManager.getBranch).not.toHaveBeenCalled();
+		expect(ctx.compact).not.toHaveBeenCalled();
+	});
+
+	it("M8: respects compaction:off guard", () => {
+		const { turnHandler, runtime } = captureHandler({ compaction: "off", compactAfterTokens: 3 });
+		const ctx = fakeCtx([dueBranch]);
+
+		turnHandler(turnEnd(), ctx);
+
+		expect(runtime.compactInFlight).toBe(false);
+		expect(ctx.compact).not.toHaveBeenCalled();
+	});
+
+	it("M9: respects compaction:manual guard", () => {
+		const { turnHandler, runtime } = captureHandler({ compaction: "manual", compactAfterTokens: 3 });
+		const ctx = fakeCtx([dueBranch]);
+
+		turnHandler(turnEnd(), ctx);
+
+		expect(runtime.compactInFlight).toBe(false);
+		expect(ctx.compact).not.toHaveBeenCalled();
+	});
+
+	it("M10: respects compactionEngine:pi-default guard", () => {
+		const { turnHandler, runtime } = captureHandler({ compaction: "auto", compactionEngine: "pi-default", compactAfterTokens: 3 });
+		const ctx = fakeCtx([dueBranch]);
+
+		turnHandler(turnEnd(), ctx);
+
+		expect(runtime.compactInFlight).toBe(false);
+		expect(ctx.compact).not.toHaveBeenCalled();
+	});
+
+	it("M11: LEGACY-BACKWARD: overrideDefaultCompaction:false with no new keys — no mid-run trigger", () => {
+		const { turnHandler, runtime } = captureHandler({ overrideDefaultCompaction: false, compaction: undefined, compactionEngine: undefined, compactAfterTokens: 3 });
+		const ctx = fakeCtx([dueBranch]);
+
+		turnHandler(turnEnd(), ctx);
+
+		expect(runtime.compactInFlight).toBe(false);
+		expect(ctx.compact).not.toHaveBeenCalled();
+	});
+
+	it("M12: LEGACY-BACKWARD: noAutoCompact:true with no new keys — no mid-run trigger", () => {
+		const { turnHandler, runtime } = captureHandler({ noAutoCompact: true, compaction: undefined, compactionEngine: undefined, compactAfterTokens: 3 });
+		const ctx = fakeCtx([dueBranch]);
+
+		turnHandler(turnEnd(), ctx);
+
+		expect(runtime.compactInFlight).toBe(false);
+		expect(ctx.compact).not.toHaveBeenCalled();
+	});
+
+	it("M13: ignores stale extension ctx at turn_end", () => {
+		const { turnHandler, runtime } = captureHandler({ compactAfterTokens: 3 });
+		const staleCtx = {
+			get cwd() {
+				throw { message: "This extension ctx is stale after session replacement or reload." };
+			},
+		};
+
+		expect(() => turnHandler(turnEnd(), staleCtx)).not.toThrow();
+		expect(runtime.compactInFlight).toBe(false);
+	});
+
+	it("M14: threshold reset — a fresh compaction entry zeroes accumulated tokens, no re-trigger loop", () => {
+		const { turnHandler, runtime } = captureHandler({ compactAfterTokens: 3 });
+		// Branch after a mid-run compaction: compaction entry + small tail.
+		const postCompactionBranch = [
+			compactionEntry("comp-1", { summary: "summary", firstKeptEntryId: "raw-9" }),
+			textCustomMessage("raw-10", "aaaa"), // 1 token
+		];
+		const ctx = fakeCtx([postCompactionBranch]);
+
+		turnHandler(turnEnd(), ctx);
+
+		expect(runtime.compactInFlight).toBe(false);
+		expect(ctx.compact).not.toHaveBeenCalled();
+	});
+});
+
+describe("mid-run compaction cancellation resilience", () => {
+	it("M15: cancelled compaction still resumes the agent and suspends further mid-run attempts", () => {
+		const { turnHandler, runtime, pi } = captureHandler({ compactAfterTokens: 3 });
+		const ctx = fakeCtx([dueBranch, dueBranch]);
+
+		turnHandler(turnEnd(), ctx);
+		const options = ctx.compact.mock.calls[0][0];
+		// The before-compact hook cancelled (e.g. too few live messages).
+		// The run was already aborted by ctx.compact() — without a resume
+		// message the agent would stall mid-task.
+		options.onError({ message: "Compaction cancelled" });
+
+		expect(runtime.compactInFlight).toBe(false);
+		expect(pi.sendMessage).toHaveBeenCalledTimes(1);
+
+		// Next turn_end must NOT re-trigger (tokens unchanged, compaction would
+		// cancel again — abort/cancel thrash loop).
+		turnHandler(turnEnd(), ctx);
+		expect(ctx.compact).toHaveBeenCalledTimes(1);
+	});
+
+	it("M16: suspension clears once pressure drops below threshold (successful compaction elsewhere)", () => {
+		const { turnHandler, runtime, pi } = captureHandler({ compactAfterTokens: 3 });
+		// Sequence: due (trigger+cancel) → due (suspended) → below (clears) → due (triggers again)
+		const ctx = fakeCtx([dueBranch, dueBranch, belowBranch, dueBranch]);
+
+		turnHandler(turnEnd(), ctx);
+		ctx.compact.mock.calls[0][0].onError({ message: "Compaction cancelled" });
+		turnHandler(turnEnd(), ctx); // suspended — no new compact
+		expect(ctx.compact).toHaveBeenCalledTimes(1);
+
+		turnHandler(turnEnd(), ctx); // below threshold — clears suspension
+		turnHandler(turnEnd(), ctx); // due again — triggers
+		expect(ctx.compact).toHaveBeenCalledTimes(2);
+	});
+
+	it("M17: pause mode does not resume on cancellation", () => {
+		const { turnHandler, pi } = captureHandler({ compactAfterTokens: 3, midRunCompaction: "pause" });
+		const ctx = fakeCtx([dueBranch]);
+
+		turnHandler(turnEnd(), ctx);
+		ctx.compact.mock.calls[0][0].onError({ message: "Compaction cancelled" });
+
+		expect(pi.sendMessage).not.toHaveBeenCalled();
 	});
 });

--- a/tests/configure-overlay.test.ts
+++ b/tests/configure-overlay.test.ts
@@ -86,10 +86,10 @@ describe("createConfigureOverlay", () => {
   });
 
   test("enter toggles boolean field", () => {
-    // First navigate to memory field (index 4 in FIELDS, type boolean)
+    // First navigate to memory field (index 5 in FIELDS, type boolean)
     const overlay = createConfigureOverlay(configPath, mockTheme, makeTui(), () => {});
-    // Navigate down to memory field (4th field, 0-indexed)
-    for (let i = 0; i < 4; i++) overlay.handleInput("\x1b[B");
+    // Navigate down to memory field (5th field, 0-indexed)
+    for (let i = 0; i < 5; i++) overlay.handleInput("\x1b[B");
     // Toggle
     overlay.handleInput("\r");
     const lines = overlay.render(80).join("\n");
@@ -183,8 +183,8 @@ describe("createConfigureOverlay", () => {
 
     test("enter via CSI-u toggles boolean field", () => {
       const overlay = createConfigureOverlay(configPath, mockTheme, makeTui(), () => {});
-      // Navigate down to memory field (index 4, boolean, initially on)
-      for (let i = 0; i < 4; i++) overlay.handleInput("\x1b[1;1B");
+      // Navigate down to memory field (index 5, boolean, initially on)
+      for (let i = 0; i < 5; i++) overlay.handleInput("\x1b[1;1B");
       // Verify it's showing "on" before toggle
       const before = overlay.render(80).join("\n");
       expect(before).toContain("Observational memory");
@@ -198,8 +198,8 @@ describe("createConfigureOverlay", () => {
       let stage = 0;
       const done = () => {};
       const overlay = createConfigureOverlay(configPath, mockTheme, makeTui(), done);
-      // Navigate to compactAfterTokens (index 3, number field)
-      for (let i = 0; i < 3; i++) overlay.handleInput("\x1b[1;1B");
+      // Navigate to compactAfterTokens (index 4, number field)
+      for (let i = 0; i < 4; i++) overlay.handleInput("\x1b[1;1B");
       overlay.handleInput("\x1b[13u"); // Kitty enter → start editing
       const origLength = overlay.render(80).join("\n");
       overlay.handleInput("\x1b[127u"); // Kitty backspace
@@ -211,8 +211,8 @@ describe("createConfigureOverlay", () => {
 
     test("digit via CSI-u works in number editing", () => {
       const overlay = createConfigureOverlay(configPath, mockTheme, makeTui(), () => {});
-      // Navigate to compactAfterTokens (index 3, number field)
-      for (let i = 0; i < 3; i++) overlay.handleInput("\x1b[1;1B");
+      // Navigate to compactAfterTokens (index 4, number field)
+      for (let i = 0; i < 4; i++) overlay.handleInput("\x1b[1;1B");
       overlay.handleInput("\x1b[13u"); // Kitty enter → start editing
       overlay.handleInput("\x1b[127u"); // backspace to clear
       overlay.handleInput("\x1b[48u"); // Kitty '0'
@@ -224,8 +224,8 @@ describe("createConfigureOverlay", () => {
 
     test("tab via CSI-u exits edit mode", () => {
       const overlay = createConfigureOverlay(configPath, mockTheme, makeTui(), () => {});
-      // Navigate to compactAfterTokens (index 3, number field)
-      for (let i = 0; i < 3; i++) overlay.handleInput("\x1b[1;1B");
+      // Navigate to compactAfterTokens (index 4, number field)
+      for (let i = 0; i < 4; i++) overlay.handleInput("\x1b[1;1B");
       overlay.handleInput("\x1b[13u"); // Kitty enter → start editing
       const editingOutput = overlay.render(80).join("\n");
       overlay.handleInput("\x1b[9u"); // Kitty tab → exit edit
@@ -236,8 +236,8 @@ describe("createConfigureOverlay", () => {
 
     test("space via CSI-u toggles boolean", () => {
       const overlay = createConfigureOverlay(configPath, mockTheme, makeTui(), () => {});
-      // Navigate to memory field (index 4, boolean, initially on)
-      for (let i = 0; i < 4; i++) overlay.handleInput("\x1b[1;1B");
+      // Navigate to memory field (index 5, boolean, initially on)
+      for (let i = 0; i < 5; i++) overlay.handleInput("\x1b[1;1B");
       const before = overlay.render(80).join("\n");
       overlay.handleInput("\x1b[32u"); // Kitty space
       const after = overlay.render(80).join("\n");


### PR DESCRIPTION
## Problem

`compactAfterTokens` is effectively decorative for tool-heavy sessions. Two compounding causes:

1. **The threshold is only evaluated on `agent_end`** ([`src/om/compaction-trigger.ts`](../blob/main/src/om/compaction-trigger.ts)). In Pi's agent loop, `agent_end` only fires when a run *exits* — while the agent is looping through tool calls (`while (hasMoreToolCalls || pendingMessages)` in pi-agent-core's `agent-loop.js`), only `turn_start`/`turn_end` fire. A long autonomous run can blow through the threshold many times over without a single evaluation.
2. **Even post-run, compaction is routinely deferred.** The `agent_end` path waits for `ctx.isIdle()` and any new `agent_start` aborts the pending wait. Under continuous interactive use (long runs, user types the next prompt while reading), the wait is cancelled again and again. #31 was the symptom-level report of this area; the retry loop fixed the one-shot bail but the mid-run window remained.

The only mid-run safety net today is Pi core's overflow-triggered compact-and-retry — i.e. the threshold does nothing until the model actually overflows.

## Fix

Evaluate the threshold at every **`turn_end`** as well — the same pattern as Pi's own reference extension (`examples/extensions/trigger-compact.ts` in pi-coding-agent). `turn_end` is a clean boundary: the turn's tool results are already persisted, and Pi never cuts at tool results anyway.

One constraint drives the design: **`ctx.compact()` aborts the in-flight run and Pi does not auto-continue** (`AgentSession.compact()` does `_disconnectFromAgent(); await this.abort();`, and post-compaction it only continues when steering/follow-up messages are queued). So the new trigger:

- compacts at the threshold mid-run, then
- injects a `blackhole-resume` custom message with `triggerTurn: true` so the agent immediately resumes the task with the compacted context (the kept tail per `tailBehavior` + summary carry the task state across).

### New config

```jsonc
"midRunCompaction": "resume"   // "resume" | "pause" | "off" (default "resume")
```

- `"resume"` — compact and keep working (default)
- `"pause"` — compact but hand control back to the user
- `"off"` — previous behavior (end-of-run evaluation only)

Editable in `/blackhole configure`; documented in CONFIG.md; validated in `unified-config.ts` following the existing enum pattern.

### Resilience details

- **Cancellation/failure after abort:** if the before-compact hook cancels (e.g. `too_few_live_messages` — plausible mid-run when a couple of messages carry huge tool results) or compaction errors, the run has *already* been aborted. Resume mode still re-triggers the agent so the task doesn't stall, and further mid-run attempts are **suspended until a compaction drops pressure below the threshold** — preventing an abort→cancel→abort thrash loop (`runtime.midRunCompactionSuspended`).
- **No re-trigger loops on success:** `rawTokensSinceLastCompaction` counts from the fresh compaction entry, so the threshold naturally resets.
- **Guard parity:** the unified + legacy config guards are extracted into a shared `autoCompactionSkipReason()` used by both trigger paths (pure refactor of the `agent_end` path — same skip reasons, same debug events).
- Stale-extension-ctx tolerance mirrors the existing handlers.

## Testing

- 17 new tests in `tests/compaction-trigger.test.ts` (threshold gating below/at threshold, immediate-compact-no-idle-wait, resume/pause/off modes, all unified + legacy config guards on the turn_end path, cancellation resilience, suspension lifecycle incl. clearing when pressure drops, stale ctx, post-compaction threshold reset).
- 3 positional navigation counts in `tests/configure-overlay.test.ts` updated for the new overlay field.
- Full suite: **804/804 passing**, `tsc --noEmit` clean, `eslint src/` clean.

## Notes for review

- I kept the existing `agent_end` path (and its measurement semantics) untouched apart from the guard extraction — this PR is purely additive on trigger coverage. A follow-up could migrate the post-run path to the `agent_settled` event (fires exactly once when the agent is truly idle, after retries/queued continuations), which would remove the isIdle polling loop and the `RETRYABLE_ERROR_RE` heuristic; happy to send that separately if there's interest.
- Also potentially worth a follow-up: using `ctx.getContextUsage()` (real usage incl. system prompt/tool schemas) alongside the chars/4 entry estimate, e.g. as an optional percent-of-context-window threshold.
