### PR TITLE
feat: add midRunCompactAfterTokens for separate mid-run compaction threshold

### DIFF
--- a/src/core/unified-config.ts
+++ b/src/core/unified-config.ts
@@ -80,8 +80,13 @@ export interface UnifiedConfig {
 	observeAfterTokens: number;
 	/** Token threshold for reflector and dropper. */
 	reflectAfterTokens: number;
-	/** Token threshold for proactive auto-compaction. */
+	/** Token threshold for proactive auto-compaction (agent_end / turn-end). */
 	compactAfterTokens: number;
+	/** Token threshold for mid-run compaction (turn_end trigger, fires while the
+	 *  agent is still executing tool loops). When unset, falls back to
+	 *  compactAfterTokens (single shared threshold). Set higher than
+	 *  compactAfterTokens to make mid-run compaction more reluctant than turn-end. */
+	midRunCompactAfterTokens?: number;
 	/** Observation pool token pressure for full fold. */
 	observationsPoolMaxTokens: number;
 	/** Treat every compaction as a full-fold boundary so early reflections/drops
@@ -262,7 +267,7 @@ function parseConfig(raw: Record<string, unknown>): Partial<UnifiedConfig> {
 	if (typeof raw.debugLog === "boolean") c.debugLog = raw.debugLog;
 
 	// Numeric fields — use nonNegativeInt for observerPreambleMaxTokens (0 = auto)
-	const numKeys = ["observeAfterTokens", "reflectAfterTokens", "compactAfterTokens", "observationsPoolMaxTokens", "observationsPoolTargetTokens", "reflectorInputMaxTokens", "dropperInputMaxTokens", "observerChunkMaxTokens", "observerPreambleMaxTokens", "agentMaxTurns"] as const;
+	const numKeys = ["observeAfterTokens", "reflectAfterTokens", "compactAfterTokens", "midRunCompactAfterTokens", "observationsPoolMaxTokens", "observationsPoolTargetTokens", "reflectorInputMaxTokens", "dropperInputMaxTokens", "observerChunkMaxTokens", "observerPreambleMaxTokens", "agentMaxTurns"] as const;
 
 	// dropperPressureThreshold: fractional, must be in (0, 1]
 	if (typeof raw.dropperPressureThreshold === "number" && Number.isFinite(raw.dropperPressureThreshold) && raw.dropperPressureThreshold > 0 && raw.dropperPressureThreshold <= 1) {

--- a/src/om/compaction-trigger.ts
+++ b/src/om/compaction-trigger.ts
@@ -116,7 +116,8 @@ function handleTurnEnd(ctx: any, runtime: Runtime, pi: ExtensionAPI): void {
 
 	const entries = ctx.sessionManager.getBranch() as Entry[];
 	const tokens = rawTokensSinceLastCompaction(entries);
-	if (tokens < runtime.config.compactAfterTokens) {
+	const midRunThreshold = runtime.config.midRunCompactAfterTokens ?? runtime.config.compactAfterTokens;
+	if (tokens < midRunThreshold) {
 		// Pressure relieved (a compaction ran) — lift any failure suspension.
 		runtime.midRunCompactionSuspended = false;
 		return;
@@ -131,7 +132,7 @@ function handleTurnEnd(ctx: any, runtime: Runtime, pi: ExtensionAPI): void {
 
 	const hasUI = ctx.hasUI;
 	const ui = ctx.ui;
-	dbg("compaction_trigger.turn_end.threshold_reached", { tokens, threshold: runtime.config.compactAfterTokens, mode });
+	dbg("compaction_trigger.turn_end.threshold_reached", { tokens, threshold: midRunThreshold, mode });
 	runtime.tryEmitInfo(hasUI, ui,
 		`Observational memory: compaction threshold reached mid-run (~${tokens.toLocaleString()} tokens); compacting${mode === "resume" ? " and resuming" : ""}`);
 

--- a/tests/compaction-trigger.test.ts
+++ b/tests/compaction-trigger.test.ts
@@ -48,6 +48,9 @@ function captureHandler(args: {
 	compactionEngine?: "blackhole" | "pi-default";
 	/** NEW: Mid-run (turn_end) compaction behavior */
 	midRunCompaction?: "resume" | "pause" | "off";
+	/** NEW: Separate token threshold for mid-run (turn_end) compaction.
+	 *  When unset, handleTurnEnd falls back to compactAfterTokens. */
+	midRunCompactAfterTokens?: number;
 } = {}) {
 	let agentEndHandler: ((event: unknown, ctx: unknown) => void) | undefined;
 	let agentStartHandler: (() => void) | undefined;
@@ -80,6 +83,8 @@ function captureHandler(args: {
 			compactionEngine: args.compactionEngine,
 			/** NEW: Mid-run (turn_end) compaction behavior */
 			midRunCompaction: args.midRunCompaction,
+			/** NEW: Separate mid-run threshold (undefined → fallback to compactAfterTokens) */
+			midRunCompactAfterTokens: args.midRunCompactAfterTokens,
 		},
 		compactInFlight: args.compactInFlight ?? false,
 		autoCompactionController: null as AbortController | null,
@@ -688,5 +693,69 @@ describe("mid-run compaction cancellation resilience", () => {
 		ctx.compact.mock.calls[0][0].onError({ message: "Compaction cancelled" });
 
 		expect(pi.sendMessage).not.toHaveBeenCalled();
+	});
+});
+
+describe("mid-run compaction threshold (midRunCompactAfterTokens)", () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	// 20 chars → ceil(20/4) = 5 tokens; sits above compactAfterTokens (3) and at a
+	// higher midRunCompactAfterTokens (5) so the two thresholds can be told apart.
+	const midRunDueBranch = [textCustomMessage("raw-mid", "aaaaaaaaaaaaaaaaaaaa")];
+
+	it("MR1: when set, turn_end compacts at midRunCompactAfterTokens — not compactAfterTokens", () => {
+		// compactAfterTokens=3 would fire on the 3-token dueBranch at agent_end,
+		// but the mid-run threshold is 5: turn_end must NOT compact at 3 tokens.
+		const { turnHandler, runtime } = captureHandler({
+			compactAfterTokens: 3,
+			midRunCompactAfterTokens: 5,
+		});
+		const belowMidCtx = fakeCtx([dueBranch]); // 3 tokens < 5
+
+		turnHandler(turnEnd(), belowMidCtx);
+
+		expect(runtime.compactInFlight).toBe(false);
+		expect(belowMidCtx.compact).not.toHaveBeenCalled();
+
+		// At the mid-run threshold (5 tokens) turn_end DOES compact.
+		const atMidCtx = fakeCtx([midRunDueBranch]);
+		turnHandler(turnEnd(), atMidCtx);
+
+		expect(runtime.compactInFlight).toBe(true);
+		expect(atMidCtx.compact).toHaveBeenCalledTimes(1);
+	});
+
+	it("MR2: when unset, turn_end falls back to compactAfterTokens", () => {
+		// No midRunCompactAfterTokens → single shared threshold (3).
+		// dueBranch (3 tokens) is at threshold → compacts mid-run.
+		const { turnHandler, runtime } = captureHandler({
+			compactAfterTokens: 3,
+		});
+		const ctx = fakeCtx([dueBranch]);
+
+		turnHandler(turnEnd(), ctx);
+
+		expect(runtime.compactInFlight).toBe(true);
+		expect(ctx.compact).toHaveBeenCalledTimes(1);
+	});
+
+	it("MR3: agent_end always uses compactAfterTokens, ignoring midRunCompactAfterTokens", async () => {
+		// mid-run threshold is higher (5), but agent_end must still fire at 3.
+		const { handler } = captureHandler({
+			compactAfterTokens: 3,
+			midRunCompactAfterTokens: 5,
+		});
+		const ctx = fakeCtx([dueBranch]); // 3 tokens
+
+		handler(agentEnd(), ctx);
+		await flushAll();
+
+		expect(ctx.compact).toHaveBeenCalledTimes(1);
 	});
 });


### PR DESCRIPTION
## Problem

Both compaction paths — turn-end (`agent_end`) and mid-run (`turn_end`) — share a single `compactAfterTokens` threshold. There is no way to make mid-run compaction more reluctant than turn-end compaction: if you raise the threshold to avoid interrupting long tool loops, turn-end compaction also becomes reluctant; if you lower it to keep turn-end eager, mid-run compaction interrupts tool loops too aggressively.

## Solution

Add an optional `midRunCompactAfterTokens` config key. The `turn_end` trigger (`handleTurnEnd`) now uses `midRunCompactAfterTokens ?? compactAfterTokens` as its threshold. The `agent_end` path (`handleAgentEnd`) is unchanged and continues to use `compactAfterTokens`.

This lets users set a **higher** mid-run threshold so compaction stays eager at turn-end but reluctant during tool loops:

```json
{
  "compactAfterTokens": 200000,
  "midRunCompactAfterTokens": 300000
}
```

With the above, compaction fires at 200k tokens when the agent finishes a run, but only at 300k tokens while the agent is still working through tool calls.

## Backward compatibility

`midRunCompactAfterTokens` is optional. When unset, `handleTurnEnd` falls back to `compactAfterTokens` — identical to current behavior. It is deliberately omitted from `DEFAULTS` and `REQUIRED_NUMERIC_KEYS` so existing configs need no changes.

## Changes

- `src/core/unified-config.ts` — add optional `midRunCompactAfterTokens?: number` to `UnifiedConfig`; register it in the parsed numeric `numKeys` (validated as a positive int when present). Not added to `DEFAULTS` or `REQUIRED_NUMERIC_KEYS` (optional, fallback-driven).
- `src/om/compaction-trigger.ts` — `handleTurnEnd` resolves `midRunThreshold = midRunCompactAfterTokens ?? compactAfterTokens` and uses it for both the threshold check and the debug log. `handleAgentEnd` is untouched.
- `tests/compaction-trigger.test.ts` — 3 new tests (`MR1`–`MR3`): mid-run threshold is honored when set, falls back to `compactAfterTokens` when unset, and `agent_end` still uses `compactAfterTokens` regardless of `midRunCompactAfterTokens`.

## Verification

- `pnpm check` (tsc --noEmit) — pass
- `vitest run` — 822 tests pass (incl. the 3 new ones)
- `pnpm lint` (eslint src/) — pass
