### PR TITLE
feat: migrate /blackhole configure to pi-base modal overlay + complete noAutoCompact migration

### DIFF
--- a/src/commands/memory.ts
+++ b/src/commands/memory.ts
@@ -24,6 +24,7 @@ import {
 	type Projection,
 } from "../om/ledger/index.js";
 import { readPendingState } from "../om/pending.js";
+import { isManualMode } from "../core/unified-config.js";
 
 function firstArg(args: unknown): string | undefined {
 	if (Array.isArray(args)) return typeof args[0] === "string" ? args[0] : undefined;
@@ -132,9 +133,9 @@ export function registerMemoryCommand(pi: ExtensionAPI, runtime: Runtime): void 
 			let dropProgress = rawTokensSinceDropCoverage(entries);
 			const compactionProgress = rawTokensSinceLastCompaction(entries);
 
-			// In noAutoCompact mode, pending coversUpToId entries act as virtual coverage markers
+			// In manual mode, pending coversUpToId entries act as virtual coverage markers
 			// that aren't reflected in the branch. Adjust accumulated counts accordingly.
-			if (runtime.config.noAutoCompact) {
+			if (isManualMode(runtime.config)) {
 				const pending = readPendingState(sessionId);
 				if (pending.observation?.coversUpToId) {
 					const idx = entryIndexForId(entries, pending.observation.coversUpToId);
@@ -169,19 +170,19 @@ export function registerMemoryCommand(pi: ExtensionAPI, runtime: Runtime): void 
 				`Observer:       ~${obsProgress.toLocaleString()} tokens (triggers at ${runtime.config.observeAfterTokens.toLocaleString()})`,
 				`Reflector:      ~${reflectionProgress.toLocaleString()} tokens (triggers at ${runtime.config.reflectAfterTokens.toLocaleString()})`,
 				`Dropper:        ~${dropProgress.toLocaleString()} tokens (triggers at ${runtime.config.reflectAfterTokens.toLocaleString()})`,
-				`Compaction:     ~${compactionProgress.toLocaleString()} tokens` + (runtime.config.noAutoCompact ? " [auto-disabled]" : ` (triggers at ${runtime.config.compactAfterTokens.toLocaleString()})`),
+				`Compaction:     ~${compactionProgress.toLocaleString()} tokens` + (isManualMode(runtime.config) ? " [manual]" : ` (triggers at ${runtime.config.compactAfterTokens.toLocaleString()})`),
 				`Obs pool:       ~${visibleObservationTokens.toLocaleString()} / ${runtime.config.observationsPoolMaxTokens.toLocaleString()} tokens (${pct(visibleObservationTokens, runtime.config.observationsPoolMaxTokens)}%)`,
 				`Reflect pool:   ~${visibleReflectionTokens.toLocaleString()} tokens`,
 			];
 
-			// Show pending data when noAutoCompact is active
-			if (runtime.config.noAutoCompact) {
+			// Show pending data when manual mode is active
+			if (isManualMode(runtime.config)) {
 				const pending = readPendingState(sessionId);
 				const hasObs = !!pending.observation;
 				const hasRef = !!pending.reflection;
 				const hasDrop = !!pending.dropped;
 				if (hasObs || hasRef || hasDrop) {
-					lines.push("", "── Pending (noAutoCompact) ──");
+					lines.push("", "── Pending (manual mode) ──");
 					if (hasObs) lines.push("Observation:  waiting in pending.json");
 					if (hasRef) lines.push("Reflection:   waiting in pending.json");
 					if (hasDrop) lines.push("Dropper:      waiting in pending.json");

--- a/src/commands/pi-vcc.ts
+++ b/src/commands/pi-vcc.ts
@@ -52,18 +52,35 @@ export const registerPiVccCommand = (pi: ExtensionAPI, runtime: Runtime) => {
 				await handleCleanup(ctx);
 				return;
 			}
-					if (trimmed === "om-off") {
-			config.save({ ...config.load(ctx.cwd, GLOBAL_CONFIG_DIR), memory: false }, "global", ctx.cwd, GLOBAL_CONFIG_DIR);
-			runtime.config = config.loadWithWarnings(ctx.cwd, GLOBAL_CONFIG_DIR).config;
-			ctx.ui.notify("Observational memory disabled. Use /blackhole om-on to re-enable.", "info");
-			return;
-		}
-		if (trimmed === "om-on") {
-			config.save({ ...config.load(ctx.cwd, GLOBAL_CONFIG_DIR), memory: true }, "global", ctx.cwd, GLOBAL_CONFIG_DIR);
-			runtime.config = config.loadWithWarnings(ctx.cwd, GLOBAL_CONFIG_DIR).config;
-			ctx.ui.notify("Observational memory enabled.", "info");
-			return;
-		}// Warn if input starts with a known subcommand but isn't an exact match.
+			if (trimmed === "om-off") {
+				try {
+					config.save({ ...config.load(ctx.cwd, GLOBAL_CONFIG_DIR), memory: false }, "global", ctx.cwd, GLOBAL_CONFIG_DIR);
+					runtime.config = config.loadWithWarnings(ctx.cwd, GLOBAL_CONFIG_DIR).config;
+					ctx.ui.notify("Observational memory disabled. Use /blackhole om-on to re-enable.", "info");
+				} catch {
+					ctx.ui.notify(
+						"Failed to save config — the config file may be read-only (e.g., managed by Nix). " +
+						"Runtime state updated for this session only.",
+						"warning",
+					);
+				}
+				return;
+			}
+			if (trimmed === "om-on") {
+				try {
+					config.save({ ...config.load(ctx.cwd, GLOBAL_CONFIG_DIR), memory: true }, "global", ctx.cwd, GLOBAL_CONFIG_DIR);
+					runtime.config = config.loadWithWarnings(ctx.cwd, GLOBAL_CONFIG_DIR).config;
+					ctx.ui.notify("Observational memory enabled.", "info");
+				} catch {
+					ctx.ui.notify(
+						"Failed to save config — the config file may be read-only (e.g., managed by Nix). " +
+						"Runtime state updated for this session only.",
+						"warning",
+					);
+				}
+				return;
+			}
+			// Warn if input starts with a known subcommand but isn't an exact match.
 			// Prevents "/blackhole configure foo" from silently becoming a follow-up.
 			const SUBCOMMAND_NAMES = ["configure", "cleanup", "om-off", "om-on"];
 			const nearMiss = SUBCOMMAND_NAMES.find(

--- a/src/commands/pi-vcc.ts
+++ b/src/commands/pi-vcc.ts
@@ -9,7 +9,6 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import type { Runtime } from "../om/runtime.js";
 import { PI_VCC_COMPACT_INSTRUCTION, notifyMigrationReminder, formatCompactionStats } from "../hooks/before-compact";
-import { saveUnifiedConfig } from "../core/unified-config.js";
 import { readPendingState, clearPendingState, hasPendingData } from "../om/pending.js";
 import {
 	OM_OBSERVATIONS_DROPPED,
@@ -17,7 +16,7 @@ import {
 	OM_REFLECTIONS_RECORDED,
 } from "../om/ledger/index.js";
 import { handleCleanup } from "./cleanup.js";
-import { openBlackholeSettings } from "../pi-base/blackhole-settings.js";
+import { openBlackholeSettings, config, GLOBAL_CONFIG_DIR } from "../pi-base/blackhole-settings.js";
 
 export const registerPiVccCommand = (pi: ExtensionAPI, runtime: Runtime) => {
 	const prefixMatch = (value: string, prefix: string): boolean => {
@@ -53,36 +52,18 @@ export const registerPiVccCommand = (pi: ExtensionAPI, runtime: Runtime) => {
 				await handleCleanup(ctx);
 				return;
 			}
-			if (trimmed === "om-off") {
-				const saved = saveUnifiedConfig({ memory: false });
-				runtime.config.memory = false;
-				if (saved) {
-					ctx.ui.notify("Observational memory disabled. Use /blackhole om-on to re-enable.", "info");
-				} else {
-					ctx.ui.notify(
-						"Failed to save config — the config file may be read-only (e.g., managed by Nix). " +
-						"Runtime state updated for this session only.",
-						"warning",
-					);
-				}
-				return;
-			}
-			if (trimmed === "om-on") {
-				const saved = saveUnifiedConfig({ memory: true });
-				runtime.config.memory = true;
-				if (saved) {
-					ctx.ui.notify("Observational memory enabled.", "info");
-				} else {
-					ctx.ui.notify(
-						"Failed to save config — the config file may be read-only (e.g., managed by Nix). " +
-						"Runtime state updated for this session only.",
-						"warning",
-					);
-				}
-				return;
-			}
-
-			// Warn if input starts with a known subcommand but isn't an exact match.
+					if (trimmed === "om-off") {
+			config.save({ ...config.load(ctx.cwd, GLOBAL_CONFIG_DIR), memory: false }, "global", ctx.cwd, GLOBAL_CONFIG_DIR);
+			runtime.config = config.loadWithWarnings(ctx.cwd, GLOBAL_CONFIG_DIR).config;
+			ctx.ui.notify("Observational memory disabled. Use /blackhole om-on to re-enable.", "info");
+			return;
+		}
+		if (trimmed === "om-on") {
+			config.save({ ...config.load(ctx.cwd, GLOBAL_CONFIG_DIR), memory: true }, "global", ctx.cwd, GLOBAL_CONFIG_DIR);
+			runtime.config = config.loadWithWarnings(ctx.cwd, GLOBAL_CONFIG_DIR).config;
+			ctx.ui.notify("Observational memory enabled.", "info");
+			return;
+		}// Warn if input starts with a known subcommand but isn't an exact match.
 			// Prevents "/blackhole configure foo" from silently becoming a follow-up.
 			const SUBCOMMAND_NAMES = ["configure", "cleanup", "om-off", "om-on"];
 			const nearMiss = SUBCOMMAND_NAMES.find(

--- a/src/commands/pi-vcc.ts
+++ b/src/commands/pi-vcc.ts
@@ -3,7 +3,7 @@
  *
  * Upstream: https://github.com/sting8k/pi-vcc (src/commands/pi-vcc.ts)
  * Modified by pi-vcc-om:
- * - Flushes pending OM state (observations/reflections/dropped) when noAutoCompact is active
+ * - Flushes pending OM state (observations/reflections/dropped) when manual mode is active
  *   before triggering compaction, so the compaction summary includes all accumulated memory.
  */
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";

--- a/src/commands/pi-vcc.ts
+++ b/src/commands/pi-vcc.ts
@@ -9,15 +9,15 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import type { Runtime } from "../om/runtime.js";
 import { PI_VCC_COMPACT_INSTRUCTION, notifyMigrationReminder, formatCompactionStats } from "../hooks/before-compact";
-import { saveUnifiedConfig, configPath } from "../core/unified-config.js";
+import { saveUnifiedConfig } from "../core/unified-config.js";
 import { readPendingState, clearPendingState, hasPendingData } from "../om/pending.js";
-import { createConfigureOverlay } from "../om/configure-overlay.js";
 import {
 	OM_OBSERVATIONS_DROPPED,
 	OM_OBSERVATIONS_RECORDED,
 	OM_REFLECTIONS_RECORDED,
 } from "../om/ledger/index.js";
 import { handleCleanup } from "./cleanup.js";
+import { openBlackholeSettings } from "../pi-base/blackhole-settings.js";
 
 export const registerPiVccCommand = (pi: ExtensionAPI, runtime: Runtime) => {
 	const prefixMatch = (value: string, prefix: string): boolean => {
@@ -46,20 +46,7 @@ export const registerPiVccCommand = (pi: ExtensionAPI, runtime: Runtime) => {
 			const trimmed = (typeof args === "string" ? args : "").trim();
 			if (trimmed === "configure") {
 				// Open the config overlay
-				const result = await ctx.ui.custom<{ saved: boolean; path: string; error?: string } | undefined>(
-					(tui, theme, _kb, done) => createConfigureOverlay(configPath(), theme, tui, done),
-					{ overlay: true },
-				);
-				if (result) {
-					if (result.error) {
-						ctx.ui.notify(result.error, "warning");
-					} else if (result.saved) {
-						runtime.reloadConfig(ctx.cwd, (msg) => ctx.ui?.notify?.(msg, "warning"));
-						ctx.ui.notify("Configuration saved.", "info");
-					} else {
-						ctx.ui.notify("Failed to save configuration — the config file may be read-only (e.g., managed by Nix).", "warning");
-					}
-				}
+				await openBlackholeSettings(ctx);
 				return;
 			}
 			if (trimmed === "cleanup") {

--- a/src/core/unified-config.ts
+++ b/src/core/unified-config.ts
@@ -544,3 +544,20 @@ export function configFileNeedsMigration(): boolean {
 		return false;
 	}
 }
+
+/**
+ * Check whether the OM pipeline is in manual mode.
+ *
+ * In manual mode, observations/reflections/dropped are saved to the
+ * per-session pending file instead of being appended to the branch.
+ * On `/blackhole`, pending entries are flushed to the branch and
+ * the pending file is cleared.
+ *
+ * Handles both the new `compaction: "manual"` key and the legacy
+ * `noAutoCompact: true` key for backward compatibility.
+ *
+ * @param config — The current runtime config (may include legacy noAutoCompact)
+ */
+export function isManualMode(config: { compaction?: string; noAutoCompact?: boolean }): boolean {
+	return config.compaction === "manual" || config.noAutoCompact === true;
+}

--- a/src/core/unified-config.ts
+++ b/src/core/unified-config.ts
@@ -7,8 +7,26 @@
  */
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
-import { getAgentDir } from "@earendil-works/pi-coding-agent";
+import { getAgentDir as originalGetAgentDir } from "@earendil-works/pi-coding-agent";
 import type { ModelThinkingLevel } from "@earendil-works/pi-ai";
+
+// ── getAgentDir with PI_CODING_AGENT_DIR override ───────────────────────────
+
+let __lastAgentDirEnv: string | undefined;
+let __cachedAgentDir: string | null = null;
+
+/**
+ * Get the canonical pi-agent data directory.
+ * Respects the `PI_CODING_AGENT_DIR` environment variable when set.
+ * Memoized — only recomputes when the env var changes.
+ */
+export function getAgentDir(): string {
+	const current = process.env.PI_CODING_AGENT_DIR?.trim();
+	if (current === __lastAgentDirEnv && __cachedAgentDir !== null) return __cachedAgentDir;
+	__lastAgentDirEnv = current;
+	__cachedAgentDir = current || originalGetAgentDir();
+	return __cachedAgentDir;
+}
 
 // ── Config path ──────────────────────────────────────────────────────────────
 
@@ -426,63 +444,29 @@ export function loadUnifiedConfig(cwd: string, onWarn?: WarnFn): UnifiedConfig {
 		}
 	}
 
-	// Env override — new compaction surface
+	// Merge defaults then override
+	const merged = { ...DEFAULTS, ...parsed };
+
+	// ── Env override — compaction ──
 	const envCompaction = process.env.PI_BLACKHOLE_COMPACTION;
 	if (envCompaction !== undefined) {
 		const trimmed = envCompaction.trim().toLowerCase();
 		if (isCompaction(trimmed)) {
-			parsed.compaction = trimmed as "auto" | "manual" | "off";
+			merged.compaction = trimmed as "auto" | "manual" | "off";
 		} else {
 			console.warn(`blackhole: invalid PI_BLACKHOLE_COMPACTION value "${envCompaction}"; ignoring`);
 		}
 	}
 
+	// ── Env override — compaction engine ──
 	const envCompactionEngine = process.env.PI_BLACKHOLE_COMPACTION_ENGINE;
 	if (envCompactionEngine !== undefined) {
 		const trimmed = envCompactionEngine.trim().toLowerCase();
 		if (isCompactionEngine(trimmed)) {
-			parsed.compactionEngine = trimmed as "blackhole" | "pi-default";
+			merged.compactionEngine = trimmed as "blackhole" | "pi-default";
 		} else {
 			console.warn(`blackhole: invalid PI_BLACKHOLE_COMPACTION_ENGINE value "${envCompactionEngine}"; ignoring`);
 		}
-	}
-
-	// Merge defaults then override
-	const merged = { ...DEFAULTS, ...parsed };
-
-	// ── Validate all numeric fields ──
-	// Prevents NaN/undefined from leaking into runtime math.
-	// Required numeric keys — must be >= 1 (or >= 0 for observerPreambleMaxTokens)
-	const REQUIRED_NUMERIC_KEYS: ReadonlyArray<keyof UnifiedConfig> = [
-		"observeAfterTokens", "reflectAfterTokens", "compactAfterTokens",
-		"observationsPoolMaxTokens", "observationsPoolTargetTokens",
-		"reflectorInputMaxTokens", "dropperInputMaxTokens",
-		"observerChunkMaxTokens", "observerPreambleMaxTokens",
-		"agentMaxTurns",
-	];
-	for (const k of REQUIRED_NUMERIC_KEYS) {
-		const v = (merged as Record<string, unknown>)[k];
-		// observerPreambleMaxTokens=0 means "auto-compute from observerChunkMaxTokens (30%)"
-		// so 0 is valid for those fields. All other numeric fields must be strictly positive.
-		const minVal = (k === "observerPreambleMaxTokens") ? 0 : 1;
-		if (typeof v !== "number" || !Number.isFinite(v) || v < minVal) {
-			(merged as Record<string, unknown>)[k] = DEFAULTS[k];
-		}
-	}
-
-
-
-	// Validate dropperPressureThreshold — must be in (0, 1]
-	if (typeof merged.dropperPressureThreshold !== "number" || !Number.isFinite(merged.dropperPressureThreshold) || merged.dropperPressureThreshold <= 0 || merged.dropperPressureThreshold > 1) {
-		merged.dropperPressureThreshold = DEFAULTS.dropperPressureThreshold;
-	}
-
-	// Derive observationsPoolTargetTokens if still unset or invalid (must be < max)
-	if (
-		merged.observationsPoolTargetTokens === undefined ||
-		merged.observationsPoolTargetTokens >= merged.observationsPoolMaxTokens
-	) {
-		merged.observationsPoolTargetTokens = Math.floor(merged.observationsPoolMaxTokens / 2);
 	}
 
 	return merged;

--- a/src/core/unified-config.ts
+++ b/src/core/unified-config.ts
@@ -396,6 +396,15 @@ export function loadUnifiedConfig(cwd: string, onWarn?: WarnFn): UnifiedConfig {
 		raw = merged;
 	}
 
+	// Project-local override: <cwd>/.pi/pi-blackhole-config.json
+	const projectConfigPath = join(cwd, ".pi", CONFIG_FILE);
+	const projectResult = readJson(projectConfigPath);
+	const projectRaw = projectResult.data;
+	if (projectResult.error && onWarn) onWarn(projectResult.error);
+	if (projectRaw && isRecord(projectRaw)) {
+		raw = { ...raw, ...projectRaw };
+	}
+
 	const parsed = parseConfig(raw);
 
 	// ── Migration: old → new knobs ──
@@ -486,6 +495,36 @@ export function saveUnifiedConfig(settings: Partial<UnifiedConfig>): boolean {
 	try {
 		const path = configPath();
 		const dir = dirname(path);
+		if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+		const existingResult = readJson(path);
+		const existing = existingResult.data ?? {};
+		if (existingResult.error) {
+			console.warn("blackhole: overwriting corrupt config file at " + path);
+		}
+		const next = { ...existing, ...settings };
+		writeFileSync(path, `${JSON.stringify(next, null, 2)}\n`);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * Write settings back to disk for a specific scope.
+ *
+ * - global: writes to `<agentDir>/pi-blackhole/pi-blackhole-config.json`
+ * - project: writes to `<cwd>/.pi/pi-blackhole-config.json`
+ *
+ * Preserves unknown keys in the target file.
+ */
+export function saveUnifiedConfigScoped(
+	settings: Partial<UnifiedConfig>,
+	scope: "global" | "project",
+	cwd: string,
+): boolean {
+	try {
+		const dir = scope === "project" ? join(cwd, ".pi") : join(getAgentDir(), "pi-blackhole");
+		const path = join(dir, CONFIG_FILE);
 		if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
 		const existingResult = readJson(path);
 		const existing = existingResult.data ?? {};

--- a/src/hooks/before-compact.ts
+++ b/src/hooks/before-compact.ts
@@ -278,7 +278,7 @@ export const registerBeforeCompactHook = (pi: ExtensionAPI, omRuntime: Runtime) 
       customInstructions,
       isPiVcc: customInstructions === PI_VCC_COMPACT_INSTRUCTION,
       overrideDefaultCompaction: omRuntime.config.overrideDefaultCompaction,
-      noAutoCompact: omRuntime.config.noAutoCompact,
+      manualMode: omRuntime.config.compaction === "manual" || omRuntime.config.noAutoCompact === true,
       branchLength: branchEntries.length,
       hasPreviousSummary: !!preparation.previousSummary,
     });
@@ -313,8 +313,8 @@ export const registerBeforeCompactHook = (pi: ExtensionAPI, omRuntime: Runtime) 
         return;
       }
 
-      if (omRuntime.config.noAutoCompact && !isPiVcc) {
-        trace("before_compact.cancel", { reason: "noAutoCompact and not /blackhole" });
+      if ((omRuntime.config.compaction === "manual" || omRuntime.config.noAutoCompact) && !isPiVcc) {
+        trace("before_compact.cancel", { reason: "manual mode and not /blackhole" });
         return { cancel: true };
       }
     }

--- a/src/om/cleanup.ts
+++ b/src/om/cleanup.ts
@@ -3,7 +3,7 @@
  * session JSONL files to find orphaned entries safe to delete.
  *
  * Per-session pending files under ~/.pi/agent/pi-blackhole/ accumulate when:
- * - compaction is set to "manual" (noAutoCompact legacy) — OM outputs are
+ * - compaction is set to "manual" — OM outputs are
  *   buffered rather than appended to the session
  * - sessions are forked, abandoned, or deleted — the pending files remain
  * - stale backup files (-pending.stale.json) persist after write-safe renames

--- a/src/om/compaction-trigger.ts
+++ b/src/om/compaction-trigger.ts
@@ -49,7 +49,7 @@ function autoCompactionSkipReason(runtime: Runtime): string | null {
 	// LEGACY: old config key guards — only apply when new keys are absent (unmigrated config)
 	if (runtime.config.compaction === undefined && runtime.config.compactionEngine === undefined) {
 		if (runtime.config.passive === true) return "passive";
-		if (runtime.config.noAutoCompact === true) return "noAutoCompact";
+		if (runtime.config.noAutoCompact === true) return "manual";
 		// Don't force Pi to compact unless the user explicitly opted into blackhole's pipeline.
 		if (runtime.config.overrideDefaultCompaction === false) return "overrideDefaultCompaction_false";
 	}
@@ -194,7 +194,7 @@ function handleAgentEnd(event: any, ctx: any, runtime: Runtime): void {
 		dbg("compaction_trigger.agent_end", {
 			passive: runtime.config.passive,
 			memory: runtime.config.memory,
-			noAutoCompact: runtime.config.noAutoCompact,
+			manualMode: runtime.config.compaction === "manual" || runtime.config.noAutoCompact === true,
 			overrideDefaultCompaction: runtime.config.overrideDefaultCompaction,
 			compactInFlight: runtime.compactInFlight,
 			compactAfterTokens: runtime.config.compactAfterTokens,

--- a/src/om/consolidation.ts
+++ b/src/om/consolidation.ts
@@ -29,6 +29,7 @@ import {
 	isObservationChunkPending,
 	PendingOMState,
 } from "./pending.js";
+import { isManualMode } from "../core/unified-config.js";
 import {
 	OM_OBSERVATIONS_DROPPED,
 	OM_OBSERVATIONS_RECORDED,
@@ -154,7 +155,7 @@ function mergeReflections(existing: Reflection[], additional: Reflection[]): Ref
 /**
  * Extract all pending observations from accumulated batches that were recorded
  * after a given coverage ID (e.g., the last reflection or drop coverage ID).
- * This is needed in noAutoCompact mode because the reflector/dropper may skip
+ * This is needed in manual mode (pending-based) because the reflector/dropper may skip
  * a pipeline cycle, leaving unprocessed batches in observationBatches that
  * should still be served as "new" on subsequent runs.
  */
@@ -467,7 +468,7 @@ function maybeLaunchConsolidation(pi: ExtensionAPI, runtime: Runtime, ctx: Conso
 	}
 	// In manual mode, the branch has no OM markers — pending state provides
 	// pool fullness and new‑data visibility for reflector/dropper checks.
-	const pending = runtime.config.noAutoCompact ? readPendingState(sessionId) : undefined;
+	const pending = isManualMode(runtime.config) ? readPendingState(sessionId) : undefined;
 	if (!anyStageDue(entries, runtime, pending)) return;
 
 	const runId = `consolidation-${Date.now().toString(36)}-${Math.random().toString(16).slice(2, 8)}`;
@@ -606,12 +607,12 @@ async function runObserverStage(
 	let priorReflections = memory.reflections.map(reflectionToSummaryLine);
 	let priorObservations = memory.observations.map(observationToSummaryLine);
 
-	// In noAutoCompact, append accumulated batch history to whatever
+	// In manual mode, append accumulated batch history to whatever
 	// fullProjection found in the branch (preserving pre-switch markers
-	// when transitioning from autoCompact to noAutoCompact mid-session).
+	// when transitioning from autoCompact to manual mode mid-session).
 	// The preamble is capped via observerPreambleMaxTokens so accumulated
 	// observations don't grow unbounded across turns.
-	if (runtime.config.noAutoCompact) {
+	if (isManualMode(runtime.config)) {
 		const pendingCtx = readPendingState(sessionId);
 		const accumulatedReflections = (pendingCtx.reflectionBatches ?? [])
 			.flatMap(b => (b.data as any).reflections ?? []);
@@ -633,8 +634,8 @@ async function runObserverStage(
 		];
 	}
 
-	// If noAutoCompact: skip if this exact chunk was already processed
-	if (runtime.config.noAutoCompact && isObservationChunkPending(sessionId, coversUpToId)) {
+	// If manual mode: skip if this exact chunk was already processed
+	if (isManualMode(runtime.config) && isObservationChunkPending(sessionId, coversUpToId)) {
 		debugLog("observer.pending_skip", { coversUpToId, sessionId });
 		return "continue";
 	}
@@ -643,9 +644,9 @@ async function runObserverStage(
 		const resolved = await resolveModel("observer");
 		if (!resolved) return "abort";
 
-		// Adjust accumulated for pending coverage in noAutoCompact mode
+		// Adjust accumulated for pending coverage in manual mode
 		let effectiveTokens = tokens;
-		if (runtime.config.noAutoCompact) {
+		if (isManualMode(runtime.config)) {
 			const pending = readPendingState(sessionId);
 			if (pending.observation?.coversUpToId) {
 				const idx = entryIndexForId(entries, pending.observation.coversUpToId);
@@ -688,7 +689,7 @@ async function runObserverStage(
 				const data = buildObservationsRecordedData(result.observations, coversUpToId);
 				if (!data) { runtime.advanceCursor("observer", coversUpToId, "empty"); return "continue"; }
 				debugLog("observer.records", { count: result.observations.length, observationTokens: result.observations.reduce((s: number, o: any) => s + o.tokenCount, 0), coversUpToId });
-				if (runtime.config.noAutoCompact) {
+				if (isManualMode(runtime.config)) {
 					savePendingObservation(sessionId, { coversUpToId, data });
 					debugLog("observer.pending", { count: result.observations.length, coversUpToId, sessionId });
 				} else {
@@ -770,7 +771,7 @@ async function runReflectorStage(
 	}
 	let reflectionTokens = 0;
 	let observationCoverageId: string | undefined;
-	if (runtime.config.noAutoCompact) {
+	if (isManualMode(runtime.config)) {
 		const pending = readPendingState(sessionId);
 		// Check any accumulated batch for unprocessed observations, not just the latest
 		const hasPendingObs = (pending.observationBatches ?? []).some((b: any) => (b.data as any)?.observations?.length);
@@ -802,7 +803,7 @@ async function runReflectorStage(
 
 		// Compute ahead for an accurate notification
 		const folded = foldLedger(entries);
-		const pending = runtime.config.noAutoCompact ? readPendingState(sessionId) : undefined;
+		const pending = isManualMode(runtime.config) ? readPendingState(sessionId) : undefined;
 		const lastReflectionIdx = pending ? -1 : latestCoverageIndex(entries, OM_REFLECTIONS_RECORDED);
 		const newObservations = pending
 			? pendingObservationsCreatedAfter(pending, entries, pending.reflection?.coversUpToId)
@@ -814,9 +815,9 @@ async function runReflectorStage(
 		);
 		const summaryBudget = Math.floor(runtime.config.reflectorInputMaxTokens * 0.15) * 2;
 		const reflectorInputTokens = Math.min(newItemsTokens + summaryBudget, runtime.config.reflectorInputMaxTokens);
-		// Adjust accumulated for pending coverage in noAutoCompact mode
+		// Adjust accumulated for pending coverage in manual mode
 		let effectiveReflectionTokens = reflectionTokens;
-		if (runtime.config.noAutoCompact) {
+		if (isManualMode(runtime.config)) {
 			if (pending?.reflection?.coversUpToId) {
 				const idx = entryIndexForId(entries, pending.reflection.coversUpToId);
 				if (idx >= 0) effectiveReflectionTokens = rawTokensAfterIndex(entries, idx);
@@ -843,7 +844,7 @@ async function runReflectorStage(
 
 		try {
 			// Existing memory summaries for context (capped).
-			// In noAutoCompact, merge accumulated pending batches with
+			// In manual mode, merge accumulated pending batches with
 			// branch data (preserving pre-switch markers).
 			const sourceReflections = pending
 				? [...folded.reflections, ...(pending.reflectionBatches ?? []).flatMap((b: any) => (b.data as any)?.reflections ?? [])]
@@ -886,7 +887,7 @@ async function runReflectorStage(
 				runtime.advanceCursor("reflector", observationCoverageId, "empty");
 				return { outcome: "continue", sameRunReflections: [] };
 			}
-			if (runtime.config.noAutoCompact) {
+			if (isManualMode(runtime.config)) {
 				savePendingReflection(sessionId, { coversUpToId: data.coversUpToId, data });
 			} else {
 				appendEntry(pi, OM_REFLECTIONS_RECORDED, data);
@@ -937,7 +938,7 @@ async function runDropperStage(
 	}
 	let dropTokens = 0;
 	let observationCoverageId: string | undefined;
-	if (runtime.config.noAutoCompact) {
+	if (isManualMode(runtime.config)) {
 		const pending = readPendingState(sessionId);
 		// Check any accumulated batch for unprocessed observations, not just the latest
 		const hasPendingObs = (pending.observationBatches ?? []).some((b: any) => (b.data as any)?.observations?.length);
@@ -969,7 +970,7 @@ async function runDropperStage(
 
 		// Compute ahead for an accurate notification
 		const folded = foldLedger(entries);
-		const pending = runtime.config.noAutoCompact ? readPendingState(sessionId) : undefined;
+		const pending = isManualMode(runtime.config) ? readPendingState(sessionId) : undefined;
 		const lastDropIdx = pending ? -1 : latestCoverageIndex(entries, OM_OBSERVATIONS_DROPPED);
 		const newObservations = pending
 			? pendingObservationsCreatedAfter(pending, entries, pending.dropped?.coversUpToId)
@@ -979,9 +980,9 @@ async function runDropperStage(
 		);
 		const dropperSummaryBudget = Math.floor(runtime.config.dropperInputMaxTokens * 0.2);
 		const dropperInputTokens = Math.min(dropperNewObsTokens + dropperSummaryBudget, runtime.config.dropperInputMaxTokens);
-		// Adjust accumulated for pending coverage in noAutoCompact mode
+		// Adjust accumulated for pending coverage in manual mode
 		let effectiveDropTokens = dropTokens;
-		if (runtime.config.noAutoCompact) {
+		if (isManualMode(runtime.config)) {
 			if (pending?.dropped?.coversUpToId) {
 				const idx = entryIndexForId(entries, pending.dropped.coversUpToId);
 				if (idx >= 0) effectiveDropTokens = rawTokensAfterIndex(entries, idx);
@@ -992,7 +993,7 @@ async function runDropperStage(
 
 		try {
 			// Existing active observations summary for context (capped).
-			// In noAutoCompact, merge accumulated pending batches with
+			// In manual mode, merge accumulated pending batches with
 			// branch data (preserving pre-switch markers).
 			const sourceObsForDropper = pending
 				? [...folded.activeObservations, ...(pending.observationBatches ?? []).flatMap((b: any) => (b.data as any)?.observations ?? [])]
@@ -1001,7 +1002,7 @@ async function runDropperStage(
 				sourceObsForDropper.filter((o: any) => !newObservations.some((no: any) => no.id === o.id)),
 				Math.floor(runtime.config.dropperInputMaxTokens * 0.2),
 			);
-			// In noAutoCompact, merge accumulated reflection batches with
+			// In manual mode, merge accumulated reflection batches with
 			// branch data (preserving pre-switch markers), matching the
 			// dropper's full autoCompact context.
 			const pendingReflections = pending
@@ -1035,14 +1036,14 @@ async function runDropperStage(
 				maxTurns: runtime.config.agentMaxTurns,
 				thinkingLevel: stageThinkingLevel(runtime, "dropper", stageModelForThinking),
 			});
-			const latestReflectionCoverageId = runtime.config.noAutoCompact
+			const latestReflectionCoverageId = isManualMode(runtime.config)
 				? pending?.reflection?.coversUpToId
 				: latestCoverageMarkerId(entries, OM_REFLECTIONS_RECORDED);
 			const effectiveReflectionCoverageId = sameRunReflectionCoverageId ?? latestReflectionCoverageId;
 			const coversUpToId = earlierCoverageMarkerId(entries, observationCoverageId, effectiveReflectionCoverageId);
 			const data = coversUpToId && droppedIds ? buildObservationsDroppedData(droppedIds, coversUpToId) : undefined;
 			if (data && coversUpToId) {
-				if (runtime.config.noAutoCompact) {
+				if (isManualMode(runtime.config)) {
 					savePendingDropped(sessionId, { coversUpToId, data });
 				} else {
 					appendEntry(pi, OM_OBSERVATIONS_DROPPED, data);

--- a/src/om/pending.ts
+++ b/src/om/pending.ts
@@ -1,12 +1,12 @@
 /**
  * Pending OM state persistence.
  *
- * When `noAutoCompact` is enabled, observations, reflections, and dropper
+ * When `compaction: "manual"` is enabled (or legacy `noAutoCompact`), observations, reflections, and dropper
  * results are saved to disk instead of being appended to the conversation.
  * Each new pipeline run replaces the previous result (latest subsumes earlier
  * since every run processes all entries since the last actual branch append).
  *
- * On manual `/pi-vcc` trigger, pending entries are flushed to the branch
+ * On manual `/blackhole` trigger, pending entries are flushed to the branch
  * and the file is cleared.
  *
  * Per-session files: each session gets its own <sessionId>-pending.json
@@ -41,18 +41,18 @@ export interface PendingOMState {
 	/** Latest dropper run (replaced each time, not accumulated). */
 	dropped?: PendingDropped;
 	/**
-	 * All observation batches accumulated across noAutoCompact pipeline runs.
+	 * All observation batches accumulated across manual mode pipeline runs.
 	 * Each batch preserves per-run coverage (coversUpToId) matching the normal
 	 * branch-marker pattern. Used for LLM context and /blackhole flush.
 	 */
 	observationBatches?: PendingObservation[];
 	/**
-	 * All reflection batches accumulated across noAutoCompact pipeline runs.
+	 * All reflection batches accumulated across manual mode pipeline runs.
 	 * Preserves per-run coverage for LLM context and /blackhole flush.
 	 */
 	reflectionBatches?: PendingReflection[];
 	/**
-	 * All dropper batches accumulated across noAutoCompact pipeline runs.
+	 * All dropper batches accumulated across manual mode pipeline runs.
 	 * Each batch preserves which observations were dropped in that run.
 	 * Without accumulation, earlier drops are lost when the next dropper
 	 * run overwrites pending.dropped, causing them to be "un-dropped" on

--- a/src/pi-base/blackhole-settings.ts
+++ b/src/pi-base/blackhole-settings.ts
@@ -1,0 +1,256 @@
+/**
+ * Blackhole settings modal — replaces the hand-rolled configure overlay
+ * with pi-base's `openSettingsModal`.
+ *
+ * Keeps the existing config path, field set, validation, and save behavior.
+ * The only change is the UI: scope-aware modal instead of inline overlay.
+ */
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { openSettingsModal, type Field } from "./settings/index.js";
+import { getPiAgentDir } from "./paths.js";
+import {
+	DEFAULTS,
+	loadUnifiedConfig,
+	saveUnifiedConfigScoped,
+} from "../core/unified-config.js";
+import type { UnifiedConfig } from "../core/unified-config.js";
+
+const CONFIG_FILENAME = "pi-blackhole-config.json";
+
+function getGlobalConfigDir(): string {
+	return join(getPiAgentDir(), "pi-blackhole");
+}
+
+function buildFields(config: UnifiedConfig): Field[] {
+	return [
+		// ── Compaction ──
+		{
+			key: "compaction",
+			type: "enum",
+			label: "Compaction mode",
+			description: "auto=trigger on threshold, manual=only /blackhole, off=auto:Pi handles, /blackhole:blackhole pipeline",
+			value: config.compaction,
+			options: ["auto", "manual", "off"],
+			optionLabels: {
+				auto: "auto — trigger on threshold",
+				manual: "manual — only /blackhole",
+				off: "off — auto:Pi handles, /blackhole:blackhole pipeline",
+			},
+		},
+		{
+			key: "compactionEngine",
+			type: "enum",
+			label: "Compaction engine",
+			description: "blackhole=structured summary+OM, pi-default=built-in Pi summarization",
+			value: config.compactionEngine,
+			options: ["blackhole", "pi-default"],
+			optionLabels: {
+				blackhole: "blackhole — structured summary + OM",
+				"pi-default": "pi-default — built-in Pi summarization",
+			},
+		},
+		{
+			key: "tailBehavior",
+			type: "enum",
+			label: "Visible tail",
+			description: "minimal=keep last user message only (default), pi-default=keep Pi's preserved visible context",
+			value: config.tailBehavior,
+			options: ["minimal", "pi-default"],
+			optionLabels: {
+				minimal: "minimal — keep last user message only (default)",
+				"pi-default": "pi-default — keep Pi's preserved visible context",
+			},
+		},
+		{
+			key: "midRunCompaction",
+			type: "enum",
+			label: "Mid-run compaction",
+			description: "resume=compact at threshold during tool loops and continue (default), pause=compact and stop, off=only check when run ends",
+			value: config.midRunCompaction,
+			options: ["resume", "pause", "off"],
+			optionLabels: {
+				resume: "resume — compact and continue (default)",
+				pause: "pause — compact and stop",
+				off: "off — only check when run ends",
+			},
+		},
+		{
+			key: "compactAfterTokens",
+			type: "number",
+			label: "Auto-compact threshold",
+			description: "Token count that triggers auto-compaction when reached",
+			value: config.compactAfterTokens,
+			min: 1000,
+			max: 500_000,
+			step: 1000,
+		},
+
+		// ── Observational Memory ──
+		{
+			key: "memory",
+			type: "boolean",
+			label: "Observational memory",
+			description: "Enable OM workers (observer, reflector, dropper) and content injection",
+			value: config.memory,
+			valueDescriptions: {
+				on: "Active — OM workers + content injection enabled",
+				off: "Suspended — OM disabled",
+			},
+		},
+		{
+			key: "sessionFallback",
+			type: "boolean",
+			label: "Session model fallback",
+			description: "off=skip stage when all OM models fail, instead of falling back to the main coding model",
+			value: config.sessionFallback ?? true,
+		},
+		{
+			key: "observeAfterTokens",
+			type: "number",
+			label: "Observer threshold",
+			description: "Tokens accumulated since last observer run before triggering next observe",
+			value: config.observeAfterTokens,
+			min: 1000,
+			max: 200_000,
+			step: 1000,
+		},
+		{
+			key: "reflectAfterTokens",
+			type: "number",
+			label: "Reflect + dropper threshold",
+			description: "Tokens accumulated since last reflect before triggering reflector and dropper",
+			value: config.reflectAfterTokens,
+			min: 1000,
+			max: 200_000,
+			step: 1000,
+		},
+		{
+			key: "observationsPoolMaxTokens",
+			type: "number",
+			label: "Observation pool max",
+			description: "Max tokens in observation pool before dropper prunes (fold pressure)",
+			value: config.observationsPoolMaxTokens,
+			min: 1000,
+			max: 200_000,
+			step: 1000,
+		},
+		{
+			key: "observationsPoolTargetTokens",
+			type: "number",
+			label: "Observation pool target",
+			description: "Target tokens after dropper prunes (defaults to half of pool max)",
+			value: config.observationsPoolTargetTokens,
+			min: 500,
+			max: 200_000,
+			step: 500,
+		},
+		{
+			key: "reflectorInputMaxTokens",
+			type: "number",
+			label: "Reflector input max",
+			description: "Max prompt tokens for reflector model input (rolling window cap)",
+			value: config.reflectorInputMaxTokens,
+			min: 1000,
+			max: 500_000,
+			step: 1000,
+		},
+		{
+			key: "dropperInputMaxTokens",
+			type: "number",
+			label: "Dropper input max",
+			description: "Max prompt tokens for dropper model input (rolling window cap)",
+			value: config.dropperInputMaxTokens,
+			min: 1000,
+			max: 500_000,
+			step: 1000,
+		},
+		{
+			key: "observerChunkMaxTokens",
+			type: "number",
+			label: "Observer chunk max",
+			description: "Max source entry tokens sent to observer per chunk",
+			value: config.observerChunkMaxTokens,
+			min: 1000,
+			max: 200_000,
+			step: 1000,
+		},
+		{
+			key: "observerPreambleMaxTokens",
+			type: "number",
+			label: "Observer preamble max",
+			description: "Preamble budget in manual compaction mode (0=auto-compute 30% of chunk)",
+			value: config.observerPreambleMaxTokens,
+			min: 0,
+			max: 100_000,
+			step: 500,
+		},
+		{
+			key: "dropperPressureThreshold",
+			type: "number",
+			label: "Dropper pressure threshold",
+			description: "Fraction of reflectorInputMaxTokens that triggers pressure-driven dropper (0-1, default 0.70)",
+			value: config.dropperPressureThreshold,
+			min: 0.01,
+			max: 1,
+			step: 0.01,
+		},
+		{
+			key: "agentMaxTurns",
+			type: "number",
+			label: "Max turns per agent",
+			description: "Shared turn cap for background memory agents",
+			value: config.agentMaxTurns,
+			min: 1,
+			max: 100,
+			step: 1,
+		},
+		{
+			key: "fullFoldAlways",
+			type: "boolean",
+			label: "Preserve OM on first compaction",
+			description: "When true, early reflections/drops survive the first compaction in a fresh session",
+			value: config.fullFoldAlways,
+		},
+
+		// ── Debug ──
+		{
+			key: "debug",
+			type: "boolean",
+			label: "Debug snapshots",
+			description: "Write detailed debug snapshots to /tmp/pi-blackhole-debug.json",
+			value: config.debug,
+		},
+		{
+			key: "debugLog",
+			type: "boolean",
+			label: "Debug JSONL logging",
+			description: "Write structured JSONL debug logs to agent directory",
+			value: config.debugLog,
+		},
+	];
+}
+
+export async function openBlackholeSettings(ctx: ExtensionContext): Promise<void> {
+	const config = loadUnifiedConfig(ctx.cwd);
+	const fields = buildFields(config);
+
+	await openSettingsModal(ctx, {
+		title: "pi-blackhole",
+		configFilename: CONFIG_FILENAME,
+		mode: "buffered",
+		defaults: DEFAULTS as unknown as Record<string, unknown>,
+		globalConfigDir: getGlobalConfigDir(),
+		inferDefaultScope: () =>
+			existsSync(join(ctx.cwd, ".pi", CONFIG_FILENAME)) ? "project" : "global",
+		fields,
+		onSave: async (values, scope) => {
+			const updated = { ...config, ...values } as UnifiedConfig;
+			const saved = saveUnifiedConfigScoped(updated, scope, ctx.cwd);
+			if (!saved) {
+				ctx.ui.notify("Failed to save config — the config file may be read-only (e.g., managed by Nix).", "warning");
+			}
+		},
+	});
+}

--- a/src/pi-base/blackhole-settings.ts
+++ b/src/pi-base/blackhole-settings.ts
@@ -1,37 +1,52 @@
 /**
- * Blackhole settings modal — replaces the hand-rolled configure overlay
- * with pi-base's `openSettingsModal`.
+ * Blackhole settings — modal-based configuration via ConfigManager.
  *
- * Keeps the existing config path, field set, validation, and save behavior.
- * The only change is the UI: scope-aware modal instead of inline overlay.
+ * Replaces the hand-rolled configure overlay (src/om/configure-overlay.ts)
+ * with pi-base's ConfigManager + openSettingsModal.
+ *
+ * Env-var overrides are applied by ConfigManager after load + validate,
+ * so they take effect for both the runtime path (loadUnifiedConfig) and
+ * the modal path (config.load / config.openSettings).
  */
-import { existsSync } from "node:fs";
+
 import { join } from "node:path";
 import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
-import { openSettingsModal, type Field } from "./settings/index.js";
-import { getPiAgentDir } from "./paths.js";
-import {
-	DEFAULTS,
-	loadUnifiedConfig,
-	saveUnifiedConfigScoped,
-} from "../core/unified-config.js";
-import type { UnifiedConfig } from "../core/unified-config.js";
+import { ConfigManager } from "../pi-base/config-manager.js";
+import { getPiAgentDir } from "../pi-base/paths.js";
+import { DEFAULTS, type UnifiedConfig } from "../core/unified-config.js";
 
 const CONFIG_FILENAME = "pi-blackhole-config.json";
 
-function getGlobalConfigDir(): string {
-	return join(getPiAgentDir(), "pi-blackhole");
+export const GLOBAL_CONFIG_DIR = join(getPiAgentDir(), "pi-blackhole");
+
+// ── Env-var parsers ──────────────────────────────────────────────────────────
+
+function parseCompactionEnv(raw: string): "auto" | "manual" | "off" | undefined {
+	const trimmed = raw.trim().toLowerCase();
+	return ["auto", "manual", "off"].includes(trimmed) ? (trimmed as "auto" | "manual" | "off") : undefined;
 }
 
-function buildFields(config: UnifiedConfig): Field[] {
-	return [
+function parseCompactionEngineEnv(raw: string): "blackhole" | "pi-default" | undefined {
+	const trimmed = raw.trim().toLowerCase();
+	return ["blackhole", "pi-default"].includes(trimmed) ? (trimmed as "blackhole" | "pi-default") : undefined;
+}
+
+// ── ConfigManager instance ───────────────────────────────────────────────────
+
+export const config = new ConfigManager<UnifiedConfig>({
+	id: "pi-blackhole",
+	label: "pi-blackhole",
+	filename: CONFIG_FILENAME,
+	defaults: DEFAULTS,
+
+	fields: (cfg) => [
 		// ── Compaction ──
 		{
 			key: "compaction",
 			type: "enum",
 			label: "Compaction mode",
 			description: "auto=trigger on threshold, manual=only /blackhole, off=auto:Pi handles, /blackhole:blackhole pipeline",
-			value: config.compaction,
+			value: cfg.compaction,
 			options: ["auto", "manual", "off"],
 			optionLabels: {
 				auto: "auto — trigger on threshold",
@@ -44,7 +59,7 @@ function buildFields(config: UnifiedConfig): Field[] {
 			type: "enum",
 			label: "Compaction engine",
 			description: "blackhole=structured summary+OM, pi-default=built-in Pi summarization",
-			value: config.compactionEngine,
+			value: cfg.compactionEngine,
 			options: ["blackhole", "pi-default"],
 			optionLabels: {
 				blackhole: "blackhole — structured summary + OM",
@@ -56,7 +71,7 @@ function buildFields(config: UnifiedConfig): Field[] {
 			type: "enum",
 			label: "Visible tail",
 			description: "minimal=keep last user message only (default), pi-default=keep Pi's preserved visible context",
-			value: config.tailBehavior,
+			value: cfg.tailBehavior,
 			options: ["minimal", "pi-default"],
 			optionLabels: {
 				minimal: "minimal — keep last user message only (default)",
@@ -68,7 +83,7 @@ function buildFields(config: UnifiedConfig): Field[] {
 			type: "enum",
 			label: "Mid-run compaction",
 			description: "resume=compact at threshold during tool loops and continue (default), pause=compact and stop, off=only check when run ends",
-			value: config.midRunCompaction,
+			value: cfg.midRunCompaction,
 			options: ["resume", "pause", "off"],
 			optionLabels: {
 				resume: "resume — compact and continue (default)",
@@ -81,10 +96,10 @@ function buildFields(config: UnifiedConfig): Field[] {
 			type: "number",
 			label: "Auto-compact threshold",
 			description: "Token count that triggers auto-compaction when reached",
-			value: config.compactAfterTokens,
-			min: 1000,
+			value: cfg.compactAfterTokens,
+			min: 1_000,
 			max: 500_000,
-			step: 1000,
+			step: 1_000,
 		},
 
 		// ── Observational Memory ──
@@ -93,7 +108,7 @@ function buildFields(config: UnifiedConfig): Field[] {
 			type: "boolean",
 			label: "Observational memory",
 			description: "Enable OM workers (observer, reflector, dropper) and content injection",
-			value: config.memory,
+			value: cfg.memory,
 			valueDescriptions: {
 				on: "Active — OM workers + content injection enabled",
 				off: "Suspended — OM disabled",
@@ -104,44 +119,44 @@ function buildFields(config: UnifiedConfig): Field[] {
 			type: "boolean",
 			label: "Session model fallback",
 			description: "off=skip stage when all OM models fail, instead of falling back to the main coding model",
-			value: config.sessionFallback ?? true,
+			value: cfg.sessionFallback ?? true,
 		},
 		{
 			key: "observeAfterTokens",
 			type: "number",
 			label: "Observer threshold",
 			description: "Tokens accumulated since last observer run before triggering next observe",
-			value: config.observeAfterTokens,
-			min: 1000,
+			value: cfg.observeAfterTokens,
+			min: 1_000,
 			max: 200_000,
-			step: 1000,
+			step: 1_000,
 		},
 		{
 			key: "reflectAfterTokens",
 			type: "number",
 			label: "Reflect + dropper threshold",
 			description: "Tokens accumulated since last reflect before triggering reflector and dropper",
-			value: config.reflectAfterTokens,
-			min: 1000,
+			value: cfg.reflectAfterTokens,
+			min: 1_000,
 			max: 200_000,
-			step: 1000,
+			step: 1_000,
 		},
 		{
 			key: "observationsPoolMaxTokens",
 			type: "number",
 			label: "Observation pool max",
 			description: "Max tokens in observation pool before dropper prunes (fold pressure)",
-			value: config.observationsPoolMaxTokens,
-			min: 1000,
+			value: cfg.observationsPoolMaxTokens,
+			min: 1_000,
 			max: 200_000,
-			step: 1000,
+			step: 1_000,
 		},
 		{
 			key: "observationsPoolTargetTokens",
 			type: "number",
 			label: "Observation pool target",
 			description: "Target tokens after dropper prunes (defaults to half of pool max)",
-			value: config.observationsPoolTargetTokens,
+			value: cfg.observationsPoolTargetTokens,
 			min: 500,
 			max: 200_000,
 			step: 500,
@@ -151,37 +166,37 @@ function buildFields(config: UnifiedConfig): Field[] {
 			type: "number",
 			label: "Reflector input max",
 			description: "Max prompt tokens for reflector model input (rolling window cap)",
-			value: config.reflectorInputMaxTokens,
-			min: 1000,
+			value: cfg.reflectorInputMaxTokens,
+			min: 1_000,
 			max: 500_000,
-			step: 1000,
+			step: 1_000,
 		},
 		{
 			key: "dropperInputMaxTokens",
 			type: "number",
 			label: "Dropper input max",
 			description: "Max prompt tokens for dropper model input (rolling window cap)",
-			value: config.dropperInputMaxTokens,
-			min: 1000,
+			value: cfg.dropperInputMaxTokens,
+			min: 1_000,
 			max: 500_000,
-			step: 1000,
+			step: 1_000,
 		},
 		{
 			key: "observerChunkMaxTokens",
 			type: "number",
 			label: "Observer chunk max",
 			description: "Max source entry tokens sent to observer per chunk",
-			value: config.observerChunkMaxTokens,
-			min: 1000,
+			value: cfg.observerChunkMaxTokens,
+			min: 1_000,
 			max: 200_000,
-			step: 1000,
+			step: 1_000,
 		},
 		{
 			key: "observerPreambleMaxTokens",
 			type: "number",
 			label: "Observer preamble max",
 			description: "Preamble budget in manual compaction mode (0=auto-compute 30% of chunk)",
-			value: config.observerPreambleMaxTokens,
+			value: cfg.observerPreambleMaxTokens,
 			min: 0,
 			max: 100_000,
 			step: 500,
@@ -191,7 +206,7 @@ function buildFields(config: UnifiedConfig): Field[] {
 			type: "number",
 			label: "Dropper pressure threshold",
 			description: "Fraction of reflectorInputMaxTokens that triggers pressure-driven dropper (0-1, default 0.70)",
-			value: config.dropperPressureThreshold,
+			value: cfg.dropperPressureThreshold,
 			min: 0.01,
 			max: 1,
 			step: 0.01,
@@ -201,7 +216,7 @@ function buildFields(config: UnifiedConfig): Field[] {
 			type: "number",
 			label: "Max turns per agent",
 			description: "Shared turn cap for background memory agents",
-			value: config.agentMaxTurns,
+			value: cfg.agentMaxTurns,
 			min: 1,
 			max: 100,
 			step: 1,
@@ -211,7 +226,7 @@ function buildFields(config: UnifiedConfig): Field[] {
 			type: "boolean",
 			label: "Preserve OM on first compaction",
 			description: "When true, early reflections/drops survive the first compaction in a fresh session",
-			value: config.fullFoldAlways,
+			value: cfg.fullFoldAlways,
 		},
 
 		// ── Debug ──
@@ -220,37 +235,159 @@ function buildFields(config: UnifiedConfig): Field[] {
 			type: "boolean",
 			label: "Debug snapshots",
 			description: "Write detailed debug snapshots to /tmp/pi-blackhole-debug.json",
-			value: config.debug,
+			value: cfg.debug,
 		},
 		{
 			key: "debugLog",
 			type: "boolean",
 			label: "Debug JSONL logging",
 			description: "Write structured JSONL debug logs to agent directory",
-			value: config.debugLog,
+			value: cfg.debugLog,
 		},
-	];
-}
+	],
+
+	/**
+	 * Validate raw loaded data, apply legacy migration, clamp numeric fields,
+	 * and apply all env-var overrides (both declarative env-map and legacy
+	 * passive/compaction env vars).
+	 */
+	validate: (raw) => {
+		const parsed = { ...raw } as Partial<UnifiedConfig>;
+
+		// ── Migration: legacy keys → new surface ──
+		if (parsed.compaction === undefined && parsed.compactionEngine === undefined) {
+			if (parsed.passive === true) {
+				parsed.compaction = "off";
+				parsed.memory = false;
+			} else if (parsed.noAutoCompact === true) {
+				parsed.compaction = "manual";
+			}
+			if (parsed.overrideDefaultCompaction === true) {
+				parsed.compactionEngine = "blackhole";
+				if (parsed.tailBehavior === undefined) {
+					parsed.tailBehavior = "minimal";
+				}
+			} else if (parsed.overrideDefaultCompaction === false) {
+				parsed.compactionEngine = "pi-default";
+			}
+			delete (parsed as Record<string, unknown>).passive;
+			delete (parsed as Record<string, unknown>).noAutoCompact;
+			delete (parsed as Record<string, unknown>).overrideDefaultCompaction;
+		}
+
+		// ── Legacy passive env vars (Layer 4, highest priority) ──
+		const envPassive = process.env.PI_BLACKHOLE_PASSIVE
+			?? process.env.PI_VCC_OM_PASSIVE
+			?? process.env.PI_OBSERVATIONAL_MEMORY_PASSIVE;
+		if (envPassive !== undefined) {
+			const v = envPassive.trim().toLowerCase();
+			if (["1", "true", "yes", "on"].includes(v)) {
+				parsed.compaction = "off";
+				parsed.memory = false;
+			} else if (["0", "false", "no", "off"].includes(v)) {
+				if (raw.passive === true) {
+					delete parsed.compaction;
+					delete (parsed as Record<string, unknown>).memory;
+				}
+			}
+		}
+
+		// ── New compaction env vars ──
+		const envCompaction = process.env.PI_BLACKHOLE_COMPACTION;
+		if (envCompaction !== undefined) {
+			const parsedEnv = parseCompactionEnv(envCompaction);
+			if (parsedEnv) {
+				parsed.compaction = parsedEnv;
+			} else {
+				console.warn(`blackhole: invalid PI_BLACKHOLE_COMPACTION value "${envCompaction}"; ignoring`);
+			}
+		}
+
+		const envCompactionEngine = process.env.PI_BLACKHOLE_COMPACTION_ENGINE;
+		if (envCompactionEngine !== undefined) {
+			const parsedEnv = parseCompactionEngineEnv(envCompactionEngine);
+			if (parsedEnv) {
+				parsed.compactionEngine = parsedEnv;
+			} else {
+				console.warn(`blackhole: invalid PI_BLACKHOLE_COMPACTION_ENGINE value "${envCompactionEngine}"; ignoring`);
+			}
+		}
+
+		// ── Merge with defaults ──
+		const merged = { ...DEFAULTS, ...parsed } as UnifiedConfig;
+
+		// ── Numeric field validation ──
+		const REQUIRED_NUMERIC_KEYS: readonly (keyof UnifiedConfig)[] = [
+			"observeAfterTokens",
+			"reflectAfterTokens",
+			"compactAfterTokens",
+			"observationsPoolMaxTokens",
+			"observationsPoolTargetTokens",
+			"reflectorInputMaxTokens",
+			"dropperInputMaxTokens",
+			"observerChunkMaxTokens",
+			"observerPreambleMaxTokens",
+			"agentMaxTurns",
+		];
+		for (const k of REQUIRED_NUMERIC_KEYS) {
+			const v = (merged as unknown as Record<string, unknown>)[k];
+			const minVal = k === "observerPreambleMaxTokens" ? 0 : 1;
+			if (typeof v !== "number" || !Number.isFinite(v) || v < minVal) {
+				(merged as unknown as Record<string, unknown>)[k] = DEFAULTS[k];
+			}
+		}
+
+		// dropperPressureThreshold — must be in (0, 1]
+		const dpt = merged.dropperPressureThreshold;
+		if (typeof dpt !== "number" || !Number.isFinite(dpt) || dpt <= 0 || dpt > 1) {
+			merged.dropperPressureThreshold = DEFAULTS.dropperPressureThreshold;
+		}
+
+		// observationsPoolTargetTokens — must be < max
+		if (
+			merged.observationsPoolTargetTokens === undefined ||
+			merged.observationsPoolTargetTokens >= merged.observationsPoolMaxTokens
+		) {
+			merged.observationsPoolTargetTokens = Math.floor(merged.observationsPoolMaxTokens / 2);
+		}
+
+		return merged;
+	},
+
+	env: {
+		// Declarative boolean overrides
+		memory: "PI_BLACKHOLE_MEMORY",
+		debug: "PI_BLACKHOLE_DEBUG",
+		debugLog: "PI_BLACKHOLE_DEBUG_LOG",
+		sessionFallback: "PI_BLACKHOLE_SESSION_FALLBACK",
+		fullFoldAlways: "PI_BLACKHOLE_FULL_FOLD_ALWAYS",
+
+		// Declarative numeric overrides
+		compactAfterTokens: "PI_BLACKHOLE_COMPACT_AFTER_TOKENS",
+		observeAfterTokens: "PI_BLACKHOLE_OBSERVE_AFTER_TOKENS",
+		reflectAfterTokens: "PI_BLACKHOLE_REFLECT_AFTER_TOKENS",
+		observationsPoolMaxTokens: "PI_BLACKHOLE_OBSERVATIONS_POOL_MAX_TOKENS",
+		observationsPoolTargetTokens: "PI_BLACKHOLE_OBSERVATIONS_POOL_TARGET_TOKENS",
+		reflectorInputMaxTokens: "PI_BLACKHOLE_REFLECTOR_INPUT_MAX_TOKENS",
+		dropperInputMaxTokens: "PI_BLACKHOLE_DROPPER_INPUT_MAX_TOKENS",
+		observerChunkMaxTokens: "PI_BLACKHOLE_OBSERVER_CHUNK_MAX_TOKENS",
+		observerPreambleMaxTokens: "PI_BLACKHOLE_OBSERVER_PREAMBLE_MAX_TOKENS",
+		agentMaxTurns: "PI_BLACKHOLE_AGENT_MAX_TURNS",
+		dropperPressureThreshold: {
+			var: "PI_BLACKHOLE_DROPPER_PRESSURE_THRESHOLD",
+			parse: (raw) => {
+				const n = Number.parseFloat(raw);
+				return Number.isFinite(n) && n > 0 && n <= 1 ? n : undefined;
+			},
+		},
+	},
+});
+
+// ── Public entry point ───────────────────────────────────────────────────────
 
 export async function openBlackholeSettings(ctx: ExtensionContext): Promise<void> {
-	const config = loadUnifiedConfig(ctx.cwd);
-	const fields = buildFields(config);
-
-	await openSettingsModal(ctx, {
-		title: "pi-blackhole",
-		configFilename: CONFIG_FILENAME,
-		mode: "buffered",
-		defaults: DEFAULTS as unknown as Record<string, unknown>,
-		globalConfigDir: getGlobalConfigDir(),
-		inferDefaultScope: () =>
-			existsSync(join(ctx.cwd, ".pi", CONFIG_FILENAME)) ? "project" : "global",
-		fields,
-		onSave: async (values, scope) => {
-			const updated = { ...config, ...values } as UnifiedConfig;
-			const saved = saveUnifiedConfigScoped(updated, scope, ctx.cwd);
-			if (!saved) {
-				ctx.ui.notify("Failed to save config — the config file may be read-only (e.g., managed by Nix).", "warning");
-			}
-		},
-	});
+	await config.openSettings(ctx, ctx.cwd, (_updated) => {
+		// onSave is called after the config is persisted; caller (pi-vcc.ts)
+		// is responsible for reloading runtime.config from this instance.
+	}, GLOBAL_CONFIG_DIR);
 }

--- a/src/pi-base/config-manager.ts
+++ b/src/pi-base/config-manager.ts
@@ -355,6 +355,7 @@ export class ConfigManager<T extends object> {
       configFilename: this.opts.filename,
       mode: "buffered",
       defaults: this.opts.defaults as unknown as Record<string, unknown>,
+      globalConfigDir: configDir,
       inferDefaultScope: () =>
         existsSync(join(cwd, ".pi", this.opts.filename)) ? "project" : "global",
       fields,

--- a/src/pi-base/config-manager.ts
+++ b/src/pi-base/config-manager.ts
@@ -269,7 +269,13 @@ export class ConfigManager<T extends object> {
     // every untouched key exactly where it was while updating only the
     // fields the user actually changed in this session.
     const merged = { ...existing, ...diff };
-    writeConfig(this.opts.filename, merged as Partial<T>, dir);
+    const wrote = writeConfig(this.opts.filename, merged as Partial<T>, dir);
+    if (!wrote) {
+      throw new Error(
+        `Failed to save ${this.opts.filename} — the config file may be read-only (e.g., managed by Nix). ` +
+        `Runtime state was updated for this session only.`,
+      );
+    }
   }
 
   /**

--- a/src/pi-base/config-manager.ts
+++ b/src/pi-base/config-manager.ts
@@ -1,0 +1,440 @@
+/**
+ * ConfigManager — declarative config management for pi extensions.
+ *
+ * Packages configure a single `ConfigManager<T>` with their config shape,
+ * defaults, field definitions, optional validation, and optional env-var
+ * overrides. The manager handles loading, saving, and modal wiring.
+ */
+
+import { join } from "node:path";
+import { existsSync } from "node:fs";
+import {
+  loadConfig,
+  readBooleanEnv,
+  readPositiveIntEnv,
+  writeConfig,
+  readConfig,
+  deleteConfig,
+  getExtensionsDir,
+  deepEqual,
+  checkConfigFile,
+} from "./config.ts";
+import { openSettingsModal } from "./settings/index.ts";
+import { validateFieldValue } from "./settings/validate-field.ts";
+import type { Field } from "./settings/types.ts";
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
+
+// ── Types ──────────────────────────────────────────────────────────────
+
+export interface ConfigManagerOptions<T extends object = object> {
+  /** Extension identifier — e.g. "bash-timeout" */
+  id: string;
+  /** Human-readable label shown in the UI */
+  label: string;
+  /** Config file name — e.g. "bash-timeout-config.json" */
+  filename: string;
+  /** Default config values (the complete object) */
+  defaults: T;
+  /** Build Field[] from current config values */
+  fields: (config: T) => Field[];
+  /**
+   * Optional validator. Receives raw merged data and returns a fully
+   * coerced config. If omitted, the manager does a simple spread merge.
+   */
+  validate?: (raw: Record<string, unknown>) => T;
+  /**
+   * Optional env-var overrides. Maps config keys to env var names.
+   * Boolean types use `readBooleanEnv`, numeric types use `readPositiveIntEnv`.
+   * For custom parsing, use a parser object with a `parse` function.
+   */
+  env?: Partial<Record<keyof T, string | EnvParser>>;
+}
+
+export interface EnvParser {
+  /** Env var name */
+  var: string;
+  /** Custom parse function (receives raw string, returns parsed value) */
+  parse: (raw: string, current: unknown) => unknown;
+}
+
+export interface ConfigLoadWarning {
+  /** Scope where the warning originated */
+  scope: "global" | "project";
+  /** Human-readable warning message */
+  message: string;
+  /** Config key involved (if applicable) */
+  key?: string;
+}
+
+export interface ConfigLoadResult<T> {
+  /** Fully resolved config value */
+  config: T;
+  /** Non-fatal warnings discovered during loading (bad values, unknown keys, etc.) */
+  warnings: ConfigLoadWarning[];
+}
+
+// ── ConfigManager ───────────────────────────────────────────────────────
+
+export class ConfigManager<T extends object> {
+  private opts: ConfigManagerOptions<T>;
+
+  constructor(opts: ConfigManagerOptions<T>) {
+    this.opts = opts;
+  }
+
+  /**
+   * Load config with layered resolution:
+   *   defaults ← global file ← project file ← env overrides
+   *
+   * @param cwd Working directory for project-local override
+   * @param configDir Global config directory (defaults to getExtensionsDir())
+   */
+  load(cwd?: string, configDir?: string): T {
+    return this.loadWithWarnings(cwd, configDir).config;
+  }
+
+  /**
+   * Load config with warnings. Same as `load()` but also returns per-field
+   * validation warnings and unknown-key warnings discovered during loading.
+   *
+   * Extensions that open a modal can surface these warnings in the UI;
+   * extensions that load config programmatically can log or inspect them.
+   */
+  loadWithWarnings(cwd?: string, configDir?: string): ConfigLoadResult<T> {
+    const warnings: ConfigLoadWarning[] = [];
+
+    const loaded = loadConfig(this.opts.filename, this.opts.defaults, {
+      cwd,
+      configDir,
+      merge: "deep",
+    });
+
+    // Run validate if provided
+    const config = this.opts.validate
+      ? this.opts.validate(loaded as Record<string, unknown>)
+      : (loaded as T);
+
+    // Validate each field value and collect warnings
+    try {
+      const fields = this.opts.fields(config);
+      const scope = "global";
+      for (const field of fields) {
+        if (field.type === "action" || field.type === "custom") continue;
+        const warning = validateFieldValue(field, field.value);
+        if (warning) {
+          warnings.push({
+            scope: scope as "global" | "project",
+            key: String(field.key),
+            message: `"${field.label}": ${warning}`,
+          });
+        }
+      }
+    } catch {
+      // Fields function may fail for partial configs; skip validation
+    }
+
+    // Apply env overrides
+    const final = this.applyEnvOverrides(config);
+
+    return { config: final, warnings };
+  }
+
+  private applyEnvOverrides(config: T): T {
+    const env = this.opts.env;
+    if (!env) return config;
+
+    const result = { ...config } as Record<string, unknown>;
+
+    for (const [key, value] of Object.entries(env)) {
+      if (!value) continue;
+
+      const defaultValue = (this.opts.defaults as Record<string, unknown>)[key];
+
+      if (typeof value === "string") {
+        // Auto-detect type from default value
+        const envName = value;
+        if (typeof defaultValue === "boolean") {
+          result[key] = readBooleanEnv(
+            envName,
+            (result[key] as boolean) ?? (defaultValue as boolean),
+          );
+        } else if (typeof defaultValue === "number") {
+          if (Number.isInteger(defaultValue) && defaultValue > 0) {
+            result[key] = readPositiveIntEnv(
+              envName,
+              (result[key] as number) ?? (defaultValue as number),
+            );
+          } else {
+            // Float — parse and preserve
+            const raw = process.env[envName]?.trim();
+            if (raw) {
+              const parsed = Number.parseFloat(raw);
+              if (Number.isFinite(parsed)) {
+                result[key] = parsed;
+              }
+            }
+          }
+        }
+      } else {
+        // Custom EnvParser
+        const parser = value as EnvParser;
+        const raw = process.env[parser.var]?.trim();
+        if (raw) {
+          result[key] = parser.parse(raw, result[key]);
+        }
+      }
+    }
+
+    return result as T;
+  }
+
+  /**
+   * Save config scoped to global or project directory.
+   *
+   * Writes only the fields that differ from the existing file content
+   * (diff-based save against the file). This means:
+   *
+   * - **First save** (no file exists): writes ALL fields — the file is
+   *   fully populated with every value the user confirmed.
+   * - **Subsequent saves**: only the fields that actually changed in the
+   *   current session are written. Everything else stays untouched.
+   * - **Unknown keys** (hand-edited extras outside the schema) are
+   *   automatically preserved by the read-patch-write cycle.
+   * - **No automatic removal**: only explicit reset/delete removes keys
+   *   from the file.
+   *
+   * Reads the existing file, patches it with the deltas, and writes the
+   * merged result. This prevents accidental overwrites of fields the user
+   * never touched while keeping the file consistent with the UI.
+   *
+   * @param config Config to persist
+   * @param scope Target scope
+   * @param cwd Working directory (required for "project" scope)
+   * @param configDir Override the global config dir (for tests)
+   */
+  save(config: T, scope: "global" | "project", cwd?: string, configDir?: string): void {
+    if (scope === "project" && !cwd) {
+      throw new Error("cwd is required for project-scoped config save");
+    }
+
+    const dir = scope === "project" && cwd ? join(cwd, ".pi") : (configDir ?? getExtensionsDir());
+    const knownKeys = new Set(Object.keys(this.opts.defaults));
+
+    // Read the existing file. If none exists, start from an empty object.
+    const existing = readConfig<Record<string, unknown>>(this.opts.filename, dir) ?? {};
+
+    // Build field map for validation
+    const fieldMap = new Map<string, Field>();
+    try {
+      const fields = this.opts.fields(config);
+      for (const f of fields) fieldMap.set(String(f.key), f);
+    } catch {
+      // Fields function may fail for partial configs; skip validation
+    }
+
+    // Compute diff: compare each known key's modal value against the
+    // existing file value. Only fields that actually changed are written.
+    const diff: Record<string, unknown> = {};
+    let hasDiff = false;
+
+    for (const key of Object.keys(this.opts.defaults) as (keyof T)[]) {
+      const modalVal = config[key];
+      const fileVal = existing[String(key)];
+
+      if (deepEqual(modalVal, fileVal)) continue;
+
+      // Validate before persisting — skip invalid values to repair
+      // config files (invalid values fall back to defaults next load).
+      const field = fieldMap.get(String(key));
+      if (field && !(field.type === "action" || field.type === "custom")) {
+        const warning = validateFieldValue(field, modalVal);
+        if (warning) continue;
+      }
+
+      diff[String(key)] = modalVal;
+      hasDiff = true;
+    }
+
+    // Preserve unknown keys from the existing file.
+    for (const [key, val] of Object.entries(existing)) {
+      if (!knownKeys.has(key)) {
+        diff[key] = val;
+        hasDiff = true;
+      }
+    }
+
+    if (!hasDiff) return;
+
+    // Merge: start from the existing file, overlay the diff. This keeps
+    // every untouched key exactly where it was while updating only the
+    // fields the user actually changed in this session.
+    const merged = { ...existing, ...diff };
+    writeConfig(this.opts.filename, merged as Partial<T>, dir);
+  }
+
+  /**
+   * Open the settings modal with scope tabs, auto-generated onSave, etc.
+   *
+   * Before opening the modal, checks global and project-local config files
+   * for malformed JSON. If either is invalid, a warning notification is
+   * shown so the user knows their config couldn't be fully loaded.
+   *
+   * @param ctx Extension context
+   * @param cwd Working directory for project-local override
+   * @param onSave Called with the validated config after the user saves
+   * @param configDir Override the global config dir (for tests)
+   */
+  /**
+   * Open the settings modal with scope tabs, auto-generated onSave, scope
+   * actions (reset/delete), etc.
+   *
+   * Before opening the modal, checks global and project-local config files
+   * for malformed JSON. If either is invalid, a warning notification is
+   * shown so the user knows their config couldn't be fully loaded.
+   *
+   * @param ctx Extension context
+   * @param cwd Working directory for project-local override
+   * @param onSave Called with the validated config after the user saves
+   * @param configDir Override the global config dir (for tests)
+   * @param onChange Optional per-field change handler passed through to
+   *                 the settings modal. Called synchronously when any
+   *                 field value changes (including in buffered mode).
+   */
+  async openSettings(
+    ctx: ExtensionContext,
+    cwd: string,
+    onSave: (updated: T) => void,
+    configDir?: string,
+    onChange?: (key: string, value: unknown) => void,
+  ): Promise<void> {
+    // Check for malformed config files before opening the modal
+    this.warnOnMalformedConfig(ctx, cwd, configDir);
+
+    const config = this.load(cwd, configDir);
+    const fields = this.opts.fields(config);
+
+    // Auto-populate field-level defaults from the config defaults so
+    // field-level reset (ctrl+r/ctrl+d) works without every extension
+    // manually setting `default` on each field definition.
+    const configDefaults = this.opts.defaults as Record<string, unknown>;
+    for (const field of fields) {
+      if (field.type === "action" || field.type === "custom") continue;
+      if (field.default === undefined) {
+        const key = String(field.key);
+        if (key in configDefaults) {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          (field as any).default = configDefaults[key];
+        }
+      }
+    }
+
+    // Validate loaded field values and warn about inconsistencies.
+    // Per-field warnings are also shown inline in the modal UI.
+    const loadWarnings: string[] = [];
+    for (const field of fields) {
+      if (field.type === "action" || field.type === "custom") continue;
+      const warning = validateFieldValue(field, field.value);
+      if (warning) loadWarnings.push(`"${field.label}": ${warning}`);
+    }
+    if (loadWarnings.length > 0) {
+      const msg =
+        loadWarnings.length === 1
+          ? `Config warning: ${loadWarnings[0]}`
+          : `Config has ${loadWarnings.length} warnings. First: ${loadWarnings[0]}`;
+      ctx.ui.notify(msg, "warning");
+    }
+
+    await openSettingsModal(ctx, {
+      title: this.opts.label,
+      configFilename: this.opts.filename,
+      mode: "buffered",
+      defaults: this.opts.defaults as unknown as Record<string, unknown>,
+      inferDefaultScope: () =>
+        existsSync(join(cwd, ".pi", this.opts.filename)) ? "project" : "global",
+      fields,
+      onChange,
+      onSave: async (values: Record<string, unknown>, scope: "global" | "project") => {
+        const merged = { ...config, ...values };
+        const updated = this.opts.validate
+          ? this.opts.validate(merged as Record<string, unknown>)
+          : (merged as T);
+        this.save(updated, scope, cwd, configDir);
+        onSave(updated);
+      },
+      onResetScope: async (scope) => {
+        this.resetScope(scope, cwd, configDir);
+      },
+      onDeleteScope: async (scope) => {
+        this.deleteScope(scope, cwd, configDir);
+      },
+    });
+  }
+
+  /**
+   * Reset a scope's configuration to defaults. Known config keys
+   * (those defined in the schema) are removed from the file; unknown
+   * keys (from future versions or user additions) are preserved so
+   * forward-compatibility is maintained. Next load will use defaults
+   * for all known fields.
+   *
+   * After this call, the file contains only unknown keys. If no
+   * unknown keys exist, the file is deleted entirely.
+   */
+  resetScope(scope: "global" | "project", cwd?: string, configDir?: string): void {
+    if (scope === "project" && !cwd) {
+      throw new Error("cwd is required for project-scoped config reset");
+    }
+    const dir = scope === "project" && cwd ? join(cwd, ".pi") : (configDir ?? getExtensionsDir());
+    const knownKeys = new Set(Object.keys(this.opts.defaults));
+    const existing = readConfig<Record<string, unknown>>(this.opts.filename, dir);
+    const unknownKeys: Record<string, unknown> = {};
+    if (existing && typeof existing === "object") {
+      for (const [key, val] of Object.entries(existing)) {
+        if (!knownKeys.has(key)) unknownKeys[key] = val;
+      }
+    }
+    if (Object.keys(unknownKeys).length > 0) {
+      writeConfig(this.opts.filename, unknownKeys as T, dir);
+    } else {
+      deleteConfig(this.opts.filename, dir);
+    }
+  }
+
+  /**
+   * Delete the entire config file for a scope. Unlike `resetScope`,
+   * this removes unknown keys as well — the file is completely gone.
+   * Next load will use nothing but defaults.
+   */
+  deleteScope(scope: "global" | "project", cwd?: string, configDir?: string): void {
+    if (scope === "project" && !cwd) {
+      throw new Error("cwd is required for project-scoped config delete");
+    }
+    const dir = scope === "project" && cwd ? join(cwd, ".pi") : (configDir ?? getExtensionsDir());
+    deleteConfig(this.opts.filename, dir);
+  }
+
+  /**
+   * Check global and project-local config files for malformed JSON.
+   * Warns via ctx.ui.notify if any are found.
+   */
+  private warnOnMalformedConfig(ctx: ExtensionContext, cwd: string, configDir?: string): void {
+    const filename = this.opts.filename;
+
+    const globalStatus = checkConfigFile(filename, configDir);
+    if (globalStatus.exists && !globalStatus.valid) {
+      ctx.ui.notify(
+        `Config file "${filename}" is ${globalStatus.error}. Using defaults.`,
+        "warning",
+      );
+    }
+
+    const projectDir = join(cwd, ".pi");
+    const projectStatus = checkConfigFile(filename, projectDir);
+    if (projectStatus.exists && !projectStatus.valid) {
+      ctx.ui.notify(
+        `Project config file ".pi/${filename}" is ${projectStatus.error}. Using defaults.`,
+        "warning",
+      );
+    }
+  }
+}

--- a/src/pi-base/config.ts
+++ b/src/pi-base/config.ts
@@ -155,7 +155,7 @@ export function writeConfig<T>(filename: string, data: T, configDir?: string): b
     writeFileSync(path, `${JSON.stringify(data, null, 2)}\n`, "utf-8");
     return true;
   } catch (error) {
-    console.warn(`[pi-base] Failed to write "${path}": ${error}`);
+    console.warn(`[pi-base] Failed to write "${path}": ${String(error)}`);
     return false;
   }
 }

--- a/src/pi-base/config.ts
+++ b/src/pi-base/config.ts
@@ -1,0 +1,441 @@
+/**
+ * config.ts — Unified configuration API for pi extensions.
+ *
+ * Named-file config (one file per package):
+ *   ~/.pi/agent/extensions/<package>-config.json   (global)
+ *   <cwd>/.pi/<package>-config.json                 (project-local)
+ *
+ * Resolution order: defaults ← global file ← project-local file.
+ *
+ * Test safety: writeConfig / deleteConfig refuse to operate when vitest
+ * is detected AND no explicit `configDir` is provided. Pass `configDir`
+ * in tests (e.g. a temp dir) to disable the gate.
+ */
+
+import { existsSync, mkdirSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { getPiAgentDir } from "./paths.js";
+
+interface CacheHit {
+  mtime: number;
+  size: number;
+  data: unknown;
+}
+
+const _configCache = new Map<string, CacheHit>();
+const CACHE_LIMIT = 128;
+
+function cacheSet(key: string, value: CacheHit): void {
+  _configCache.delete(key);
+  _configCache.set(key, value);
+  if (_configCache.size > CACHE_LIMIT) {
+    const firstKey = _configCache.keys().next().value;
+    if (firstKey !== undefined) {
+      _configCache.delete(firstKey);
+    }
+  }
+}
+
+// ── Path helpers ──────────────────────────────────────────────────────
+
+/**
+ * Canonical config directory: ~/.pi/agent/extensions/
+ */
+export function getExtensionsDir(): string {
+  return join(getPiAgentDir(), "extensions");
+}
+
+function resolveConfigDir(configDir: string | undefined): string {
+  return configDir ?? getExtensionsDir();
+}
+
+/** Check if a directory path points to a real user home (not a test temp). */
+function isRealDir(dir: string): boolean {
+  return !dir.startsWith("/tmp") && !dir.startsWith("/var/folders");
+}
+
+/**
+ * Guard writes/deletes against the real user config directory in tests.
+ * Returns true if the operation should proceed.
+ */
+function guardRealDir(
+  filename: string,
+  configDir: string | undefined,
+  operation: "write" | "delete",
+): boolean {
+  // Explicit configDir — caller's responsibility
+  if (configDir !== undefined) return true;
+  // Not in vitest — real pi process, allowed
+  if (process.env.VITEST !== "true") return true;
+
+  const dir = resolveConfigDir(configDir);
+  if (isRealDir(dir)) {
+    console.warn(
+      `[pi-base] Blocked ${operation} of "${filename}" — running in vitest ` +
+        `without explicit configDir, and the target directory (${dir}) ` +
+        `looks like a real user home. ` +
+        `Pass an explicit configDir parameter to enable ${operation}s in tests.`,
+    );
+    return false;
+  }
+  return true;
+}
+
+// ── Read ──────────────────────────────────────────────────────────────
+
+/**
+ * Read a named config file. Returns parsed object or null.
+ * Optimized with in-memory caching and mtime validation to bypass redundant filesystem checks.
+ *
+ * @param filename  e.g. "pi-window-title-config.json"
+ * @param configDir Directory to read from. Defaults to getExtensionsDir().
+ */
+export function readConfig<T>(filename: string, configDir?: string): T | null {
+  const path = join(resolveConfigDir(configDir), filename);
+  try {
+    // Utilize { throwIfNoEntry: false } to avoid expensive exceptions when configuration files are missing
+    const stats = statSync(path, { throwIfNoEntry: false });
+    if (!stats) {
+      _configCache.delete(path);
+      return null;
+    }
+
+    const hit = _configCache.get(path);
+    if (hit && hit.mtime === stats.mtimeMs && hit.size === stats.size) {
+      // Refresh LRU order on hit
+      _configCache.delete(path);
+      _configCache.set(path, hit);
+      return structuredClone(hit.data) as T;
+    }
+
+    const raw = readFileSync(path, "utf-8");
+    const trimmed = raw.trim();
+    if (trimmed.length === 0) {
+      cacheSet(path, { data: null, mtime: stats.mtimeMs, size: stats.size });
+      return null;
+    }
+    const parsed = JSON.parse(trimmed);
+    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+      cacheSet(path, { data: null, mtime: stats.mtimeMs, size: stats.size });
+      return null;
+    }
+
+    // Cache the parsed JSON data, validating both mtime and size
+    cacheSet(path, {
+      data: structuredClone(parsed),
+      mtime: stats.mtimeMs,
+      size: stats.size,
+    });
+    return parsed as T;
+  } catch {
+    _configCache.delete(path);
+    return null;
+  }
+}
+
+// ── Write ─────────────────────────────────────────────────────────────
+
+/**
+ * Write a named config file. Returns true on success.
+ *
+ * Safety gate: in vitest, if no explicit `configDir` is provided,
+ * warns and returns false to prevent accidental writes to the real
+ * ~/.pi/agent/extensions/ directory.
+ *
+ * @param filename  e.g. "pi-window-title-config.json"
+ * @param data      Object to serialize as JSON
+ * @param configDir Directory to write to. Defaults to getExtensionsDir().
+ */
+export function writeConfig<T>(filename: string, data: T, configDir?: string): boolean {
+  if (!guardRealDir(filename, configDir, "write")) return false;
+  const path = join(resolveConfigDir(configDir), filename);
+  _configCache.delete(path);
+  try {
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(path, `${JSON.stringify(data, null, 2)}\n`, "utf-8");
+    return true;
+  } catch (error) {
+    console.warn(`[pi-base] Failed to write "${path}": ${error}`);
+    return false;
+  }
+}
+
+// ── Delete ────────────────────────────────────────────────────────────
+
+/**
+ * Delete a named config file. No-op if the file doesn't exist.
+ */
+export function deleteConfig(filename: string, configDir?: string): void {
+  if (!guardRealDir(filename, configDir, "delete")) return;
+  const path = join(resolveConfigDir(configDir), filename);
+  _configCache.delete(path);
+  try {
+    rmSync(path, { force: true });
+  } catch {
+    // No-op if file doesn't exist or can't be deleted
+  }
+}
+
+// ── deepMerge ─────────────────────────────────────────────────────────
+
+/**
+ * Recursively merge `overrides` into `base`.
+ *
+ * - Plain objects are recursively merged (not replaced).
+ * - `null` in overrides replaces the base value (explicit reset).
+ * - `undefined` in overrides leaves the base value unchanged.
+ * - Arrays, primitives, and non-plain objects are replaced wholesale.
+ * - Does not mutate the base object (returns a new object).
+ */
+export function deepMerge<T extends Record<string, unknown>>(base: T, overrides: Partial<T>): T {
+  if (!overrides || typeof overrides !== "object") {
+    return { ...base };
+  }
+  const result = { ...base };
+
+  for (const key of Object.keys(overrides)) {
+    const overrideVal = (overrides as Record<string, unknown>)[key];
+
+    if (overrideVal === undefined) {
+      continue;
+    }
+
+    if (overrideVal === null) {
+      (result as Record<string, unknown>)[key] = null;
+      continue;
+    }
+
+    const baseVal = (result as Record<string, unknown>)[key];
+
+    if (isPlainObject(baseVal) && isPlainObject(overrideVal)) {
+      (result as Record<string, unknown>)[key] = deepMerge(
+        baseVal as Record<string, unknown>,
+        overrideVal as Record<string, unknown>,
+      );
+    } else {
+      (result as Record<string, unknown>)[key] = overrideVal;
+    }
+  }
+
+  return result as T;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    !Array.isArray(value) &&
+    Object.getPrototypeOf(value) === Object.prototype
+  );
+}
+
+// ── deepEqual ─────────────────────────────────────────────────────────
+
+/**
+ * Deep equality check for two values.
+ * - Handles primitives, Date, RegExp, Map, Set, arrays, and plain objects.
+ * - Non-plain-object instances are compared by reference (strict equality).
+ */
+export function deepEqual(a: unknown, b: unknown): boolean {
+  if (Object.is(a, b)) return true;
+
+  if (a === null || b === null || typeof a !== typeof b) return false;
+
+  // Date
+  if (a instanceof Date && b instanceof Date) {
+    return a.getTime() === b.getTime();
+  }
+
+  // RegExp
+  if (a instanceof RegExp && b instanceof RegExp) {
+    return a.source === b.source && a.flags === b.flags;
+  }
+
+  // Map
+  if (a instanceof Map && b instanceof Map) {
+    if (a.size !== b.size) return false;
+    for (const [k, v] of a) {
+      if (!b.has(k) || !deepEqual(v, b.get(k))) return false;
+    }
+    return true;
+  }
+
+  // Set
+  if (a instanceof Set && b instanceof Set) {
+    if (a.size !== b.size) return false;
+    for (const v of a) {
+      if (!b.has(v)) return false;
+    }
+    return true;
+  }
+
+  // Arrays
+  if (Array.isArray(a) && Array.isArray(b)) {
+    if (a.length !== b.length) return false;
+    for (let i = 0; i < a.length; i++) {
+      if (!deepEqual(a[i], b[i])) return false;
+    }
+    return true;
+  }
+
+  // Plain objects
+  if (isPlainObject(a) && isPlainObject(b)) {
+    const keysA = Object.keys(a);
+    const keysB = Object.keys(b);
+    if (keysA.length !== keysB.length) return false;
+    for (const key of keysA) {
+      if (!Object.prototype.hasOwnProperty.call(b, key)) return false;
+      if (!deepEqual(a[key], b[key])) return false;
+    }
+    return true;
+  }
+
+  return false;
+}
+
+// ── checkConfigFile ───────────────────────────────────────────────────
+
+export interface ConfigFileStatus {
+  /** Whether the file exists on disk */
+  exists: boolean;
+  /** Whether the file contains valid config data (valid JSON + a plain object) */
+  valid: boolean;
+  /** Human-readable error description when valid is false */
+  error?: string;
+}
+
+/**
+ * Check whether a config file exists and has valid JSON content.
+ * Does NOT cache — every call reads the file header / full content.
+ *
+ * Use this before `readConfig` to distinguish "file not found" from
+ * "file exists but is malformed".
+ */
+export function checkConfigFile(filename: string, configDir?: string): ConfigFileStatus {
+  const path = join(resolveConfigDir(configDir), filename);
+  try {
+    const stats = statSync(path, { throwIfNoEntry: false });
+    if (!stats) {
+      return { exists: false, valid: true };
+    }
+
+    const raw = readFileSync(path, "utf-8");
+    const trimmed = raw.trim();
+
+    if (trimmed.length === 0) {
+      return { exists: true, valid: false, error: "Config file is empty" };
+    }
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(trimmed);
+    } catch (e) {
+      return {
+        exists: true,
+        valid: false,
+        error: `Invalid JSON: ${(e as Error).message}`,
+      };
+    }
+
+    if (!isPlainObject(parsed)) {
+      return {
+        exists: true,
+        valid: false,
+        error: "Config file must contain a plain JSON object at the top level",
+      };
+    }
+
+    return { exists: true, valid: true };
+  } catch {
+    return { exists: true, valid: false, error: "Cannot read config file" };
+  }
+}
+
+// ── loadConfig ────────────────────────────────────────────────────────
+
+export interface LoadConfigOptions {
+  /**
+   * Working directory for project-local overrides.
+   * When set, reads from `<cwd>/.pi/<filename>` in addition to global.
+   */
+  cwd?: string;
+
+  /**
+   * Merge strategy for combining defaults ← global ← project.
+   * - "shallow" (default): `{ ...defaults, ...global, ...project }`
+   * - "deep": recursively merges nested objects.
+   */
+  merge?: "shallow" | "deep";
+
+  /**
+   * Explicit config directory. Defaults to getExtensionsDir().
+   * Use in tests to read/write from a temporary or fixture directory.
+   */
+  configDir?: string;
+}
+
+/**
+ * Load configuration with defaults, global file, and optional project-local override.
+ *
+ * Resolution order: defaults ← global file ← project-local file.
+ * Each layer shallow-merges (or deep-merges if `merge: "deep"`).
+ *
+ * Always returns a full config object — null is never returned.
+ * Missing keys fall back to defaults.
+ */
+export function loadConfig<T extends object>(
+  filename: string,
+  defaults: T,
+  opts: LoadConfigOptions = {},
+): T {
+  const dir = resolveConfigDir(opts.configDir);
+  const mergeFn =
+    opts.merge === "deep"
+      ? (base: T, over: Partial<T>) =>
+          deepMerge(
+            base as Record<string, unknown>,
+            over as Record<string, unknown>,
+          ) as unknown as T
+      : shallowMerge<T>;
+
+  let config = defaults;
+
+  // Layer 1: global
+  config = mergeFn(config, readConfig<Partial<T>>(filename, dir) ?? ({} as Partial<T>));
+
+  // Layer 2: project-local
+  if (opts.cwd) {
+    const projectDir = join(opts.cwd, ".pi");
+    config = mergeFn(config, readConfig<Partial<T>>(filename, projectDir) ?? ({} as Partial<T>));
+  }
+
+  return config;
+}
+
+function shallowMerge<T extends object>(base: T, overrides: Partial<T>): T {
+  const result = { ...base } as Record<string, unknown>;
+  for (const key of Object.keys(overrides as Record<string, unknown>)) {
+    const val = (overrides as Record<string, unknown>)[key];
+    if (val !== undefined) {
+      result[key] = val;
+    }
+  }
+  return result as unknown as T;
+}
+
+// ── Env helpers ───────────────────────────────────────────────────────
+
+export function readBooleanEnv(name: string, fallback: boolean): boolean {
+  const raw = process.env[name]?.trim().toLowerCase();
+  if (!raw) return fallback;
+  if (["1", "true", "yes", "on"].includes(raw)) return true;
+  if (["0", "false", "no", "off"].includes(raw)) return false;
+  return fallback;
+}
+
+export function readPositiveIntEnv(name: string, fallback: number): number {
+  const raw = process.env[name]?.trim();
+  if (!raw) return fallback;
+  const value = Number.parseInt(raw, 10);
+  return Number.isFinite(value) && value > 0 ? value : fallback;
+}

--- a/src/pi-base/config.ts
+++ b/src/pi-base/config.ts
@@ -12,7 +12,7 @@
  * in tests (e.g. a temp dir) to disable the gate.
  */
 
-import { existsSync, mkdirSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { mkdirSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { getPiAgentDir } from "./paths.js";
 

--- a/src/pi-base/paths.ts
+++ b/src/pi-base/paths.ts
@@ -1,0 +1,44 @@
+import { getAgentDir } from "@earendil-works/pi-coding-agent";
+
+let lastEnvVal: string | undefined = undefined;
+let cachedPiAgentDir: string | null = null;
+
+/**
+ * Get the root directory for pi-agent data.
+ * Optimized with in-memory memoization that detects environmental updates.
+ */
+export function getPiAgentDir(): string {
+  const currentEnvVal = process.env.PI_CODING_AGENT_DIR;
+  if (cachedPiAgentDir !== null && currentEnvVal === lastEnvVal) {
+    return cachedPiAgentDir;
+  }
+  lastEnvVal = currentEnvVal;
+  cachedPiAgentDir = currentEnvVal?.trim() || getAgentDir();
+  return cachedPiAgentDir;
+}
+
+/**
+ * Shorten a working directory path by replacing the user's home directory
+ * prefix with `~`. Returns the path unchanged if not under $HOME.
+ *
+ * @param cwd  The current working directory to shorten
+ * @param home Optional home directory override (defaults to `$HOME`)
+ */
+export function shortCwd(cwd: string, home?: string): string {
+  const h = (home ?? process.env.HOME ?? process.env.USERPROFILE ?? "").replace(/[\\/]+$/, "");
+  if (!h) return cwd;
+  if (cwd === h) return "~";
+  const sep = h.includes("\\") ? "\\" : "/";
+  if (cwd.startsWith(h + sep)) {
+    return `~${cwd.slice(h.length)}`;
+  }
+  return cwd;
+}
+
+/**
+ * Shorten a working directory path by replacing the user's home directory
+ * prefix with `~`. Returns the path unchanged if not under $HOME.
+ *
+ * @param cwd  The current working directory to shorten
+ * @param home Optional home directory override (defaults to `$HOME`)
+ */

--- a/src/pi-base/settings/body.ts
+++ b/src/pi-base/settings/body.ts
@@ -548,6 +548,7 @@ export function createSettingsModalBody<F extends Field>(
       // to flush microtasks.
       const maybeThenable = result as unknown;
       if (maybeThenable && typeof (maybeThenable as Promise<void>).then === "function") {
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises
         (await maybeThenable) as Promise<void>;
       }
       args.close();

--- a/src/pi-base/settings/body.ts
+++ b/src/pi-base/settings/body.ts
@@ -1,0 +1,1518 @@
+/**
+ * `SettingsModalBody` — the renderable+inputtable component that
+ * `createSettingsModal` and `openSettingsModal` mount inside an
+ * overlay. Owns:
+ *
+ *   - Tab strip across the top (when `tabs` is non-empty).
+ *   - Optional fuzzy search bar (when `enableSearch` is true).
+ *   - The list of rows, with one focused at a time.
+ *   - Per-row inline-edit state (string/number/secret/path).
+ *   - Submenu mounting (enum long-list, model widget, custom openSubmenu).
+ *   - Auto-generated footer hint reflecting the focused row's keybindings.
+ *
+ * The modal is **stateless about disk** — it calls `onChange` on every
+ * commit and lets the caller persist however they like. In buffered
+ * mode (`options.mode === "buffered"`), the modal holds edits in
+ * memory and persists only on explicit save via `options.onSave`.
+ */
+
+import type { ExtensionContext, Theme } from "@earendil-works/pi-coding-agent";
+import {
+  matchesKey,
+  truncateToWidth,
+  visibleWidth,
+  type Component,
+  type TUI,
+} from "@earendil-works/pi-tui";
+import { loadConfig, getExtensionsDir } from "../config.ts";
+import { validateFieldValue } from "./validate-field.ts";
+import type {
+  Field,
+  FieldKeyHint,
+  FieldRenderContext,
+  NumberField,
+  SettingsModalOptions,
+  Tab,
+  VisibilityContext,
+} from "./types";
+import { RENDERERS } from "./fields/index";
+import {
+  divider,
+  formatHintLine,
+  frame,
+  frameContentWidth,
+  pad,
+  responsiveInnerRows,
+  wrapLine,
+  type FrameOptions,
+} from "./frame";
+import { deleteWordBackward, type InlineEditState } from "./inline-edit";
+
+const PREFERRED_INNER_ROWS = 30;
+const LABEL_PAD_TARGET = 28;
+
+interface InternalRow {
+  field: Field;
+  /** Live displayed value, written back through `onChange`. */
+  value: unknown;
+  globalValue?: unknown;
+  projectValue?: unknown;
+  /** Inline-edit toggle for editable types. */
+  isEditing: boolean;
+  /** Pre-computed lowercased search index string for fuzzy filtering. */
+  searchIndex: string;
+  /** Pre-computed truncated label text. */
+  labelText: string;
+  /** Pre-computed label padding. */
+  labelPadding: string;
+}
+
+interface ConfirmSubmenuState {
+  selectedIndex: number;
+  dirtyKeys: Set<string>;
+  initialValues: Map<string, unknown>;
+}
+
+interface ConfirmOption {
+  label: string;
+  action: "save-global" | "save-project" | "discard" | "cancel";
+}
+
+const confirmOptions: ConfirmOption[] = [
+  { label: "Save to Global", action: "save-global" },
+  { label: "Save to Project Local", action: "save-project" },
+  { label: "Discard", action: "discard" },
+  { label: "Cancel", action: "cancel" },
+];
+
+/**
+ * Build the body component. The factory is independent of overlay
+ * lifecycle — `createSettingsModal` (in modal.ts) wraps it for the
+ * `ctx.ui.custom` shape; advanced callers can mount the body directly.
+ */
+export function createSettingsModalBody<F extends Field>(
+  options: SettingsModalOptions<F>,
+  args: {
+    tui: TUI;
+    theme: Theme;
+    ctx: ExtensionContext;
+    /** Called when the user closes (Esc / ctrl+c / outer dismissal). */
+    close: () => void;
+  },
+): Component {
+  const useScopeTabs = options.configFilename !== undefined;
+  const tabs: Tab[] = useScopeTabs
+    ? [
+        { id: "global", label: "Global" },
+        { id: "project", label: "Project Local" },
+      ]
+    : (options.tabs ?? []);
+  const fields: Field[] = options.fields as Field[];
+  const mode = options.mode ?? "immediate";
+  const isBuffered = mode === "buffered";
+
+  let globalConfig: Record<string, unknown> = {};
+  let projectConfig: Record<string, unknown> = {};
+  if (useScopeTabs && options.configFilename) {
+    const fn = options.configFilename;
+    const defs = options.defaults ?? {};
+    const globalDir = options.globalConfigDir ?? getExtensionsDir();
+    globalConfig = loadConfig(fn, defs, { configDir: globalDir });
+    projectConfig = loadConfig(fn, defs, { cwd: args.ctx.cwd, configDir: globalDir });
+  }
+
+  let activeTabId: string | undefined = options.initialTab ?? tabs[0]?.id;
+
+  // Per-row state lives in this array, indexed parallel to a snapshot
+  // of `fields`. We never reorder it — search filters use a separate
+  // `filteredIndices` view.
+  const rows: InternalRow[] = fields.map((field) => {
+    let globalVal: unknown;
+    let projectVal: unknown;
+
+    if (useScopeTabs) {
+      globalVal = getNestedValue(globalConfig, field.key);
+      if (globalVal === undefined) {
+        globalVal = getNestedValue(options.defaults ?? {}, field.key);
+      }
+      if (globalVal === undefined) {
+        globalVal = extractInitialValue(field);
+      }
+
+      projectVal = getNestedValue(projectConfig, field.key);
+      if (projectVal === undefined) {
+        projectVal = globalVal;
+      }
+    } else {
+      globalVal = extractInitialValue(field);
+      projectVal = globalVal;
+    }
+
+    const labelText = truncateToWidth(field.label, LABEL_PAD_TARGET, "…");
+    const labelPadding = " ".repeat(Math.max(1, LABEL_PAD_TARGET - visibleWidth(labelText)));
+
+    return {
+      field,
+      get globalValue() {
+        return globalVal;
+      },
+      set globalValue(v) {
+        globalVal = v;
+      },
+      get projectValue() {
+        return projectVal;
+      },
+      set projectValue(v) {
+        projectVal = v;
+      },
+      get value() {
+        return activeTabId === "project" ? projectVal : globalVal;
+      },
+      set value(v) {
+        if (activeTabId === "project") {
+          projectVal = v;
+        } else {
+          globalVal = v;
+        }
+      },
+      isEditing: false,
+      searchIndex: `${field.label}\n${field.description ?? ""}\n${field.key}`.toLowerCase(),
+      labelText,
+      labelPadding,
+    };
+  }) as unknown as InternalRow[];
+
+  // Inline-edit state registry: keyed by field.key. Renderers reach
+  // into this through `ctx.editStates` (see fields/string.ts).
+  const editStates: Map<string, InlineEditState> = new Map();
+
+  // Buffered mode: snapshot initial values and track dirty keys.
+  const initialGlobalValues = new Map<string, unknown>();
+  const initialProjectValues = new Map<string, unknown>();
+  const dirtyGlobalKeys = new Set<string>();
+  const dirtyProjectKeys = new Set<string>();
+
+  if (isBuffered) {
+    for (const row of rows) {
+      const gVal = row.globalValue;
+      initialGlobalValues.set(
+        row.field.key,
+        typeof gVal === "object" && gVal !== null ? JSON.parse(JSON.stringify(gVal)) : gVal,
+      );
+      const pVal = row.projectValue;
+      initialProjectValues.set(
+        row.field.key,
+        typeof pVal === "object" && pVal !== null ? JSON.parse(JSON.stringify(pVal)) : pVal,
+      );
+    }
+  }
+
+  function getInitialValues() {
+    return activeTabId === "project" ? initialProjectValues : initialGlobalValues;
+  }
+
+  function getDirtyKeys() {
+    return activeTabId === "project" ? dirtyProjectKeys : dirtyGlobalKeys;
+  }
+  let search = "";
+  let fieldSelected = 0;
+  let scroll = 0;
+  let tabActionFocus = -1;
+  let submenu: Component | undefined;
+  let submenuKey: string | undefined;
+  let confirmState: ConfirmSubmenuState | undefined;
+  let scopeActionConfirm: { action: "reset" | "delete"; selectedIndex: number } | undefined;
+  // Scope default inferred once at mount via the extension's callback.
+  const defaultScope: "global" | "project" = (options.inferDefaultScope?.() ?? "global") as
+    | "global"
+    | "project";
+
+  const fieldRenderContext: FieldRenderContext & {
+    editStates: Map<string, InlineEditState>;
+  } = {
+    theme: args.theme,
+    tui: args.tui,
+    ctx: args.ctx,
+    requestRender: () => args.tui.requestRender(),
+    editStates,
+  };
+
+  // Action rows (only visible at the bottom of scope tabs when callbacks are provided)
+  const actionRows: { id: string; label: string; description: string }[] = [];
+  if (useScopeTabs && (options.onResetScope || options.onDeleteScope)) {
+    if (options.onResetScope) {
+      actionRows.push({
+        id: "reset",
+        label: "Reset to defaults",
+        description: "Remove all config keys for this scope — values fall back to defaults.",
+      });
+    }
+    if (options.onDeleteScope) {
+      actionRows.push({
+        id: "delete",
+        label: "Delete config",
+        description: "Remove the entire config file for this scope.",
+      });
+    }
+  }
+
+  // Optimization: Cache the visible row indices list to avoid redundant array
+  // allocations, lowercase conversions, and substring checks inside hot rendering
+  // and search filtering loops.
+  let cachedVisibleIndices: number[] = [];
+
+  function buildVisibilityContext(field: Field, scope: string): VisibilityContext {
+    return {
+      get: (key: string) => {
+        const r = rows.find((rr) => rr.field.key === key);
+        return r?.value;
+      },
+      getScoped: (key: string, targetScope?: string) => {
+        const r = rows.find((rr) => rr.field.key === key);
+        if (!r) return undefined;
+        if (!targetScope || targetScope === scope) return r.value;
+        return targetScope === "project" ? r.projectValue : r.globalValue;
+      },
+      scope,
+    };
+  }
+
+  function totalVisibleItems(): number {
+    return cachedVisibleIndices.length;
+  }
+
+  function updateVisibleIndices(): void {
+    const query = search.trim().toLowerCase();
+    const out: number[] = [];
+    for (let i = 0; i < rows.length; i += 1) {
+      const row = rows[i]!;
+      if (activeTabId !== undefined && tabs.length > 0 && !useScopeTabs) {
+        // When tabs are configured, fields without an explicit `tab` id
+        // surface only on the first tab — same convention as a default
+        // landing tab in browser-style chrome.
+        const fallbackTab = tabs[0]!.id;
+        const rowTab = row.field.tab ?? fallbackTab;
+        if (rowTab !== activeTabId) continue;
+      }
+      // visibleWhen: fields can conditionally hide based on sibling values
+      if (row.field.visibleWhen) {
+        const scope = activeTabId ?? "global";
+        if (!row.field.visibleWhen(buildVisibilityContext(row.field, scope))) continue;
+      }
+      if (!query) {
+        out.push(i);
+        continue;
+      }
+      if (row.searchIndex.includes(query)) out.push(i);
+    }
+    cachedVisibleIndices = out;
+  }
+
+  // Compute the initial visible indices.
+  updateVisibleIndices();
+
+  function visibleRowIndices(): number[] {
+    return cachedVisibleIndices;
+  }
+
+  function clampSelection(visibleRows: number): void {
+    const count = totalVisibleItems();
+    fieldSelected = Math.max(0, Math.min(fieldSelected, Math.max(0, count - 1)));
+    if (fieldSelected < scroll) scroll = fieldSelected;
+    else if (fieldSelected >= scroll + visibleRows) scroll = fieldSelected - visibleRows + 1;
+    scroll = Math.max(0, Math.min(scroll, Math.max(0, count - visibleRows)));
+  }
+
+  function focusedIndex(): number | undefined {
+    const indices = visibleRowIndices();
+    if (indices.length === 0) return undefined;
+    const safe = Math.max(0, Math.min(fieldSelected, indices.length - 1));
+    return indices[safe];
+  }
+
+  function focusedRow(): InternalRow | undefined {
+    const idx = focusedIndex();
+    return idx === undefined ? undefined : rows[idx];
+  }
+
+  function focusedAction(): (typeof actionRows)[number] | undefined {
+    if (tabActionFocus >= tabs.length) {
+      const actionIdx = tabActionFocus - tabs.length;
+      return actionRows[actionIdx] ?? undefined;
+    }
+    return undefined;
+  }
+
+  function isDirty(): boolean {
+    if (!isBuffered) return false;
+    return dirtyGlobalKeys.size > 0 || dirtyProjectKeys.size > 0;
+  }
+
+  /** Update dirty state for a key by comparing current value against
+   *  the initial snapshot. Removes the key if the value has reverted
+   *  to its original; adds it otherwise. */
+  function syncDirtyState(key: string): void {
+    if (!isBuffered) return;
+    const initial = getInitialValues().get(key);
+    const current = rows.find((r) => r.field.key === key)?.value;
+    const isClean =
+      typeof initial === "object" && initial !== null
+        ? JSON.stringify(current) === JSON.stringify(initial)
+        : current === initial;
+    if (isClean) {
+      getDirtyKeys().delete(key);
+    } else {
+      getDirtyKeys().add(key);
+    }
+  }
+
+  function commitValue(row: InternalRow, value: unknown): void {
+    const previous = row.value;
+    const key = row.field.key;
+
+    row.value = value;
+    if (isBuffered) {
+      syncDirtyState(key);
+    }
+
+    try {
+      const ret = options.onChange?.(row.field.key as never, value as never, row.field as never);
+      if (ret && typeof (ret as Promise<void>).then === "function") {
+        // Async onChange: dirty state is already set above. On
+        // rejection, roll the row back and re-sync dirty state.
+        (ret as Promise<void>)
+          .then(() => {
+            if (isBuffered) {
+              args.tui.requestRender();
+            }
+          })
+          .catch((err) => {
+            if (row.value === value) {
+              row.value = previous;
+            }
+            if (isBuffered) {
+              syncDirtyState(key);
+            }
+            notifyError(args.ctx, err);
+            args.tui.requestRender();
+          });
+      }
+    } catch (err) {
+      row.value = previous;
+      if (isBuffered) {
+        syncDirtyState(key);
+      }
+      notifyError(args.ctx, err);
+      args.tui.requestRender();
+    }
+  }
+
+  function mountSubmenu(
+    factory: NonNullable<ReturnType<(typeof RENDERERS)[Field["type"]]["handleKey"]>["submenu"]>,
+    row: InternalRow,
+  ): void {
+    submenu = factory((value) => {
+      submenu = undefined;
+      submenuKey = undefined;
+      if (value !== undefined) commitValue(row, value);
+      args.tui.requestRender();
+    });
+    submenuKey = row.field.key;
+    args.tui.requestRender();
+  }
+
+  function mountConfirmSubmenu(): void {
+    const scopeToUse = useScopeTabs ? activeTabId : defaultScope;
+    confirmState = {
+      selectedIndex: scopeToUse === "project" ? 1 : 0,
+      dirtyKeys: new Set(getDirtyKeys()),
+      initialValues: new Map(getInitialValues()),
+    };
+    args.tui.requestRender();
+  }
+
+  function mountScopeActionConfirm(action: "reset" | "delete"): void {
+    scopeActionConfirm = { action, selectedIndex: 0 };
+    args.tui.requestRender();
+  }
+
+  function setEditing(row: InternalRow, value: boolean): void {
+    row.isEditing = value;
+  }
+
+  function rendererFor(field: Field) {
+    return RENDERERS[field.type];
+  }
+
+  function dispatchKey(data: string): void {
+    const row = focusedRow();
+    if (!row) return;
+    const renderer = rendererFor(row.field);
+    try {
+      const result = renderer.handleKey(
+        { field: row.field as never, value: row.value as never },
+        data,
+        {
+          isEditing: row.isEditing,
+          ctx: fieldRenderContext,
+          setEditing: (v) => setEditing(row, v),
+        },
+      );
+      if (result.commit !== undefined) commitValue(row, result.commit);
+      if (result.submenu) mountSubmenu(result.submenu, row);
+    } catch (err) {
+      notifyError(args.ctx, err);
+    }
+  }
+
+  /**
+   * Apply an alt+↑ / alt+↓ reorder request originating from `handleInput`.
+   *
+   * Returns `true` when the reorder consumed the keystroke (success
+   * or graceful no-op at an edge); `false` when the focused row isn't
+   * `reorderable` and the modal should fall through to the default
+   * alt-arrow handling (which is currently nothing — alt-arrows are
+   * inert in non-reorderable contexts).
+   *
+   * Reorder is restricted to swaps with the immediate `reorderable`
+   * neighbour in `visibleRowIndices` order. We do NOT skip over
+   * intervening non-reorderable rows: callers are expected to group
+   * reorderable rows contiguously, which keeps the visual behaviour
+   * predictable.
+   */
+  function handleReorder(direction: -1 | 1): boolean {
+    const focusedIdx = focusedIndex();
+    if (focusedIdx === undefined) return false;
+    const focusedRowInternal = rows[focusedIdx];
+    if (!focusedRowInternal?.field.reorderable) return false;
+
+    const indices = visibleRowIndices();
+    const visiblePos = indices.indexOf(focusedIdx);
+    const targetVisiblePos = visiblePos + direction;
+    if (targetVisiblePos < 0 || targetVisiblePos >= indices.length) {
+      // At the edge — still consume the keystroke so it doesn't bleed
+      // into the bare up/down handler below.
+      return true;
+    }
+    const targetIdx = indices[targetVisiblePos]!;
+    const targetRow = rows[targetIdx];
+    if (!targetRow?.field.reorderable) {
+      // Adjacent neighbour isn't reorderable — treat as edge.
+      return true;
+    }
+
+    // Compute the from/to indices counting ONLY reorderable peers so
+    // callers that interleave non-reorderable rows (e.g. a Separator
+    // field at the bottom of a Layout tab) still receive contiguous
+    // 0..N-1 positions matching their own data structure.
+    const reorderablePeerIdxs = indices.filter((i) => rows[i]?.field.reorderable);
+    const fromPeerPos = reorderablePeerIdxs.indexOf(focusedIdx);
+    const toPeerPos = reorderablePeerIdxs.indexOf(targetIdx);
+
+    // Swap the two rows in-place.
+    rows[focusedIdx] = targetRow;
+    rows[targetIdx] = focusedRowInternal;
+
+    // Update `fieldSelected` so focus follows the moved row.
+    // `fieldSelected` indexes into the visible-rows view; the row
+    // we swapped to `targetIdx` is at visible position
+    // `targetVisiblePos`.
+    fieldSelected = targetVisiblePos;
+
+    // Recompute cached visible indices as the internal rows order has changed
+    updateVisibleIndices();
+
+    try {
+      options.onReorder?.({
+        fieldKey: focusedRowInternal.field.key,
+        fromIndex: fromPeerPos,
+        toIndex: toPeerPos,
+      });
+    } catch (err) {
+      notifyError(args.ctx, err);
+    }
+
+    args.tui.requestRender();
+    return true;
+  }
+
+  function allValues(scope?: "global" | "project"): Record<string, unknown> {
+    const out: Record<string, unknown> = {};
+    for (const row of rows) {
+      if (useScopeTabs) {
+        out[row.field.key] = scope === "project" ? row.projectValue : row.globalValue;
+      } else {
+        out[row.field.key] = row.value;
+      }
+    }
+    return out;
+  }
+
+  async function performSave(scope: "global" | "project"): Promise<void> {
+    if (!options.onSave) return;
+    try {
+      const result = options.onSave(allValues(scope), scope);
+      // If onSave returned a thenable, await it; otherwise close
+      // synchronously so synchronous callers (e.g. tests) don't need
+      // to flush microtasks.
+      const maybeThenable = result as unknown;
+      if (maybeThenable && typeof (maybeThenable as Promise<void>).then === "function") {
+        (await maybeThenable) as Promise<void>;
+      }
+      args.close();
+    } catch (err) {
+      notifyError(args.ctx, err);
+      // Keep modal open on error — user can retry or cancel.
+    }
+  }
+
+  function handleConfirmInput(data: string): void {
+    if (!confirmState) return;
+    if (matchesKey(data, "up")) {
+      confirmState.selectedIndex = Math.max(0, confirmState.selectedIndex - 1);
+      args.tui.requestRender();
+      return;
+    }
+    if (matchesKey(data, "down")) {
+      const count = confirmOptions.length;
+      confirmState.selectedIndex = Math.min(count - 1, confirmState.selectedIndex + 1);
+      args.tui.requestRender();
+      return;
+    }
+    if (matchesKey(data, "escape")) {
+      // Cancel: unmount submenu, preserve edits.
+      confirmState = undefined;
+      args.tui.requestRender();
+      return;
+    }
+    if (matchesKey(data, "enter") || matchesKey(data, "return")) {
+      const choice = confirmOptions[confirmState.selectedIndex];
+      if (!choice) return;
+      if (choice.action === "save-global") {
+        void performSave("global");
+      } else if (choice.action === "save-project") {
+        void performSave("project");
+      } else if (choice.action === "discard") {
+        try {
+          options.onCancel?.();
+        } catch {
+          // Caller-supplied onCancel must not break the confirm teardown.
+        }
+        args.close();
+      } else {
+        // cancel
+        confirmState = undefined;
+        args.tui.requestRender();
+      }
+    }
+  }
+
+  function renderConfirmSubmenu(width: number): string[] {
+    const lines: string[] = [];
+    lines.push("");
+    lines.push("  You have unsaved changes:");
+    lines.push("");
+
+    for (let i = 0; i < confirmOptions.length; i++) {
+      const opt = confirmOptions[i]!;
+      const isSelected = i === confirmState!.selectedIndex;
+      const prefix = isSelected ? args.theme.fg("accent", "▌ ") : "  ";
+      const label = isSelected
+        ? args.theme.fg("text", opt.label)
+        : args.theme.fg("muted", opt.label);
+      lines.push(`${prefix}${label}`);
+    }
+
+    lines.push("");
+    const needsReload = Array.from(confirmState!.dirtyKeys).some((key) => {
+      const row = rows.find((r) => r.field.key === key);
+      return (row?.field as { requiresReload?: boolean } | undefined)?.requiresReload === true;
+    });
+    if (needsReload) {
+      lines.push(args.theme.fg("muted", "  Some changes require /reload to take effect."));
+    }
+    lines.push(args.theme.fg("muted", "  ↑↓ select  enter confirm  esc cancel"));
+
+    return lines;
+  }
+
+  function handleScopeActionConfirmInput(data: string): void {
+    if (!scopeActionConfirm) return;
+    if (matchesKey(data, "up")) {
+      scopeActionConfirm.selectedIndex = Math.max(0, scopeActionConfirm.selectedIndex - 1);
+      args.tui.requestRender();
+      return;
+    }
+    if (matchesKey(data, "down")) {
+      const max = 2; // global, project, cancel
+      scopeActionConfirm.selectedIndex = Math.min(max, scopeActionConfirm.selectedIndex + 1);
+      args.tui.requestRender();
+      return;
+    }
+    if (matchesKey(data, "escape")) {
+      scopeActionConfirm = undefined;
+      args.tui.requestRender();
+      return;
+    }
+    if (matchesKey(data, "enter") || matchesKey(data, "return")) {
+      const act = scopeActionConfirm.action;
+      const options = getScopeActionOptions(act);
+      const choice = options[scopeActionConfirm.selectedIndex];
+      scopeActionConfirm = undefined;
+      if (choice && choice.scope !== null) {
+        void handleScopeAction(act, choice.scope);
+      } else {
+        args.tui.requestRender();
+      }
+    }
+  }
+
+  function getScopeActionOptions(
+    action: "reset" | "delete",
+  ): Array<{ label: string; scope: "global" | "project" | null }> {
+    const verb = action === "reset" ? "Reset to defaults" : "Delete config";
+    return [
+      { label: `${verb} (global)`, scope: "global" },
+      { label: `${verb} (project-local)`, scope: "project" },
+      { label: "Cancel", scope: null },
+    ];
+  }
+
+  function renderScopeActionConfirm(width: number): string[] {
+    const lines: string[] = [];
+    const isReset = scopeActionConfirm!.action === "reset";
+    const options = getScopeActionOptions(scopeActionConfirm!.action);
+    lines.push("");
+    lines.push(isReset ? "  Reset config to defaults" : "  Delete config file");
+    lines.push("");
+    lines.push(args.theme.fg("muted", "  Select scope:"));
+    lines.push("");
+
+    for (let i = 0; i < options.length; i++) {
+      const isSelected = i === scopeActionConfirm!.selectedIndex;
+      const prefix = isSelected ? args.theme.fg("accent", "▌ ") : "  ";
+      const label = isSelected
+        ? args.theme.fg("text", options[i]!.label)
+        : args.theme.fg("muted", options[i]!.label);
+      lines.push(`${prefix}${label}`);
+    }
+
+    lines.push("");
+    lines.push(args.theme.fg("muted", "  ↑↓ select  enter confirm  esc cancel"));
+    return lines;
+  }
+
+  function handleInput(data: string): void {
+    if (submenu) {
+      submenu.handleInput?.(data);
+      return;
+    }
+    if (confirmState) {
+      handleConfirmInput(data);
+      return;
+    }
+    if (scopeActionConfirm) {
+      handleScopeActionConfirmInput(data);
+      return;
+    }
+    const row = focusedRow();
+
+    if (row?.isEditing) {
+      // While editing, only the renderer (and esc/enter) gets to see
+      // input — cursor & nav keys are reserved for the inline editor.
+      dispatchKey(data);
+      args.tui.requestRender();
+      return;
+    }
+
+    if (matchesKey(data, "ctrl+s")) {
+      if (isBuffered && isDirty()) {
+        mountConfirmSubmenu();
+      } else if (isBuffered) {
+        // No changes — save directly to the inferred default scope.
+        // This lets users deploy a fresh config without editing anything.
+        const scope: "global" | "project" = useScopeTabs
+          ? ((activeTabId ?? defaultScope) as "global" | "project")
+          : defaultScope;
+        void performSave(scope);
+      }
+      return;
+    }
+    // ctrl+r: contextual — field-level reset when on field, scope reset when on action row
+    if (matchesKey(data, "ctrl+r")) {
+      if (tabActionFocus >= tabs.length && actionRows.length > 0) {
+        // Action row focused → scope reset
+        if (options.onResetScope) {
+          mountScopeActionConfirm("reset");
+        }
+      } else {
+        // Field focused → field-level reset
+        const row = focusedRow();
+        if (row && !row.field.disabled && !row.isEditing) {
+          const def = row.field.default;
+          if (def !== undefined) {
+            const clonedDef =
+              typeof def === "object" && def !== null ? JSON.parse(JSON.stringify(def)) : def;
+            commitValue(row, clonedDef);
+          }
+        }
+      }
+      args.tui.requestRender();
+      return;
+    }
+    // ctrl+d: field-level reset when on field, scope delete when on action row
+    if (matchesKey(data, "ctrl+d")) {
+      if (tabActionFocus >= tabs.length && actionRows.length > 0) {
+        // Action row focused → scope delete
+        if (options.onDeleteScope) {
+          mountScopeActionConfirm("delete");
+        }
+      } else {
+        // Field focused → field-level reset (same as ctrl+r)
+        const row = focusedRow();
+        if (row && !row.field.disabled && !row.isEditing) {
+          const def = row.field.default;
+          if (def !== undefined) {
+            const clonedDef =
+              typeof def === "object" && def !== null ? JSON.parse(JSON.stringify(def)) : def;
+            commitValue(row, clonedDef);
+          }
+        }
+      }
+      args.tui.requestRender();
+      return;
+    }
+    // ctrl+shift+r: always scope reset (from anywhere)
+    if (matchesKey(data, "ctrl+shift+r")) {
+      if (options.onResetScope) {
+        mountScopeActionConfirm("reset");
+      }
+      args.tui.requestRender();
+      return;
+    }
+    // ctrl+shift+d: always scope delete (from anywhere)
+    if (matchesKey(data, "ctrl+shift+d")) {
+      if (options.onDeleteScope) {
+        mountScopeActionConfirm("delete");
+      }
+      args.tui.requestRender();
+      return;
+    }
+    if (matchesKey(data, "escape")) {
+      // If Tab focus is on action row/tab, first escape returns to field zone
+      if (tabActionFocus >= 0) {
+        tabActionFocus = -1;
+        args.tui.requestRender();
+        return;
+      }
+      if (options.enableSearch && search !== "") {
+        search = "";
+        fieldSelected = 0;
+        updateVisibleIndices();
+        args.tui.requestRender();
+        return;
+      }
+      if (isBuffered && isDirty()) {
+        mountConfirmSubmenu();
+      } else {
+        args.close();
+      }
+      return;
+    }
+    if (matchesKey(data, "ctrl+c")) {
+      if (isBuffered && isDirty()) {
+        mountConfirmSubmenu();
+      } else {
+        args.close();
+      }
+      return;
+    }
+    // Tab/Shift+Tab: cycle through tabs + action row
+    if (matchesKey(data, "tab")) {
+      const stopCount = tabs.length + actionRows.length;
+      if (stopCount === 0) {
+        args.tui.requestRender();
+        return;
+      }
+      if (tabActionFocus === -1) {
+        // Start from the next stop after the current active tab,
+        // so Tab never "rewinds" to the first stop.
+        const currentTabIdx = tabs.findIndex((t) => t.id === activeTabId);
+        if (currentTabIdx >= 0) {
+          tabActionFocus = (currentTabIdx + 1) % stopCount;
+        } else {
+          tabActionFocus = 0;
+        }
+      } else {
+        tabActionFocus = (tabActionFocus + 1) % stopCount;
+      }
+      // Auto-switch active tab when a tab is focused
+      if (tabActionFocus < tabs.length) {
+        const tab = tabs[tabActionFocus];
+        if (tab && tab.id !== activeTabId) {
+          activeTabId = tab.id;
+          fieldSelected = 0;
+          scroll = 0;
+          updateVisibleIndices();
+        }
+      }
+      args.tui.requestRender();
+      return;
+    }
+    if (matchesKey(data, "shift+tab")) {
+      const stopCount = tabs.length + actionRows.length;
+      if (stopCount === 0) {
+        args.tui.requestRender();
+        return;
+      }
+      if (tabActionFocus === -1) {
+        // Start from the previous stop before the current active tab.
+        const currentTabIdx = tabs.findIndex((t) => t.id === activeTabId);
+        if (currentTabIdx >= 0) {
+          tabActionFocus = (currentTabIdx - 1 + stopCount) % stopCount;
+        } else {
+          tabActionFocus = stopCount - 1;
+        }
+      } else {
+        tabActionFocus = (tabActionFocus - 1 + stopCount) % stopCount;
+      }
+      if (tabActionFocus < tabs.length) {
+        const tab = tabs[tabActionFocus];
+        if (tab && tab.id !== activeTabId) {
+          activeTabId = tab.id;
+          fieldSelected = 0;
+          scroll = 0;
+          updateVisibleIndices();
+        }
+      }
+      args.tui.requestRender();
+      return;
+    }
+    // Alt+↑ / Alt+↓ reorders the focused row among its `reorderable`
+    // peers. Has to run before the bare up/down handlers so the
+    // modifier prefix is what dispatches — otherwise `matchesKey(data,
+    // "up")` could match the alt-modified variant first depending on
+    // the terminal's escape sequence.
+    if (matchesKey(data, "alt+up")) {
+      if (handleReorder(-1)) return;
+    }
+    if (matchesKey(data, "alt+down")) {
+      if (handleReorder(1)) return;
+    }
+    if (matchesKey(data, "alt+r")) {
+      const row = focusedRow();
+      if (row && !row.field.disabled && !row.isEditing) {
+        const def = row.field.default;
+        if (def !== undefined) {
+          const clonedDef =
+            typeof def === "object" && def !== null ? JSON.parse(JSON.stringify(def)) : def;
+          commitValue(row, clonedDef);
+          args.tui.requestRender();
+          return;
+        }
+      }
+    }
+    // Arrow keys navigate fields only (field zone). They also switch
+    // Tab focus back to the field zone.
+    const totalCount = totalVisibleItems();
+    const lastIndex = Math.max(0, totalCount - 1);
+    if (
+      matchesKey(data, "up") ||
+      matchesKey(data, "down") ||
+      matchesKey(data, "pageUp") ||
+      matchesKey(data, "pageDown")
+    ) {
+      tabActionFocus = -1;
+    }
+    if (matchesKey(data, "up")) {
+      fieldSelected = Math.max(0, fieldSelected - 1);
+      args.tui.requestRender();
+      return;
+    }
+    if (matchesKey(data, "down")) {
+      fieldSelected = Math.min(lastIndex, fieldSelected + 1);
+      args.tui.requestRender();
+      return;
+    }
+    if (matchesKey(data, "pageUp")) {
+      fieldSelected = Math.max(0, fieldSelected - 5);
+      args.tui.requestRender();
+      return;
+    }
+    if (matchesKey(data, "pageDown")) {
+      fieldSelected = Math.min(lastIndex, fieldSelected + 5);
+      args.tui.requestRender();
+      return;
+    }
+    // Enter on a tab switches focus to field zone (tab already auto-switched).
+    // Then lets Enter fall through to dispatchKey for field toggling/editing.
+    // Enter on action row activates the focused action with confirmation.
+    if ((matchesKey(data, "enter") || matchesKey(data, "return")) && tabActionFocus >= 0) {
+      if (tabActionFocus < tabs.length) {
+        // Tab focused — return to field zone, then let Enter fall through
+        // to dispatchKey for field toggling/editing.
+        tabActionFocus = -1;
+        // Do NOT return — fall through to dispatchKey below
+      } else if (actionRows.length > 0) {
+        // Action row focused — determine which action by index
+        const actionIdx = tabActionFocus - tabs.length;
+        const action = actionRows[actionIdx];
+        if (action) {
+          const act = action.id === "reset" ? "reset" : "delete";
+          const cb = act === "reset" ? options.onResetScope : options.onDeleteScope;
+          if (cb) {
+            mountScopeActionConfirm(act);
+          }
+        }
+        args.tui.requestRender();
+        return;
+      }
+    }
+
+    if (options.enableSearch) {
+      if (matchesKey(data, "backspace") || matchesKey(data, "ctrl+h")) {
+        search = search.slice(0, -1);
+        fieldSelected = 0;
+        updateVisibleIndices();
+        args.tui.requestRender();
+        return;
+      }
+      if (matchesKey(data, "ctrl+u")) {
+        search = "";
+        fieldSelected = 0;
+        updateVisibleIndices();
+        args.tui.requestRender();
+        return;
+      }
+      if (matchesKey(data, "ctrl+w")) {
+        search = deleteWordBackward(search);
+        fieldSelected = 0;
+        updateVisibleIndices();
+        args.tui.requestRender();
+        return;
+      }
+    }
+
+    // Enter / value-key falls through to the renderer.
+    dispatchKey(data);
+    if (
+      options.enableSearch &&
+      data.length === 1 &&
+      data >= " " &&
+      data !== "\x7f" &&
+      !row?.isEditing
+    ) {
+      // Plain printable input that the renderer didn't claim joins the
+      // search query. Booleans / enums never claim it (their
+      // handleKey returns `consumed:false` for non-Enter), so users
+      // can still type to filter.
+      // We detect "renderer didn't claim it" by checking the row state
+      // didn't change to editing — a heuristic that works for every
+      // built-in. Custom renderers that want to swallow letters should
+      // mark the row as editing first.
+      if (!row || !row.isEditing) {
+        search += data;
+        fieldSelected = 0;
+        updateVisibleIndices();
+      }
+    }
+    args.tui.requestRender();
+  }
+
+  function cycleTab(delta: number): void {
+    if (tabs.length === 0) return;
+    const idx = tabs.findIndex((t) => t.id === activeTabId);
+    const nextIdx = ((idx === -1 ? 0 : idx) + delta + tabs.length) % tabs.length;
+    activeTabId = tabs[nextIdx]!.id;
+    fieldSelected = 0;
+    scroll = 0;
+    tabActionFocus = -1;
+    updateVisibleIndices();
+    args.tui.requestRender();
+  }
+
+  function renderTabBar(width: number): string {
+    if (tabs.length === 0) return "";
+    const cells: string[] = [];
+    for (const tab of tabs) {
+      let label = tab.label;
+      if (isBuffered) {
+        const isTabDirty = useScopeTabs
+          ? tab.id === "project"
+            ? dirtyProjectKeys.size > 0
+            : dirtyGlobalKeys.size > 0
+          : Array.from(getDirtyKeys()).some((key) => {
+              const row = rows.find((r) => r.field.key === key);
+              const fallbackTab = tabs[0]?.id;
+              const rowTab = row?.field.tab ?? fallbackTab;
+              return rowTab === tab.id;
+            });
+        if (isTabDirty) {
+          label += " ● Unsaved";
+        }
+      }
+      if (tab.id === activeTabId) {
+        const padded = ` ▸ ${label} `;
+        cells.push(args.theme.fg("accent", args.theme.inverse(args.theme.bold(padded))));
+      } else {
+        const padded = `   ${label} `;
+        cells.push(args.theme.bg("selectedBg", args.theme.fg("accent", padded)));
+      }
+    }
+    return pad(cells.join(" "), width);
+  }
+
+  function renderSearchBar(width: number, hasMatches = true): string {
+    const cursor = args.theme.inverse(" ");
+    let text: string;
+    if (search === "") {
+      const placeholder = args.theme.fg("muted", "Search settings...");
+      text = ` > ${cursor}${placeholder}`;
+    } else {
+      if (!hasMatches) {
+        text = ` > ${args.theme.fg("warning", search)}${cursor}`;
+      } else {
+        text = ` > ${search}${cursor}`;
+      }
+    }
+    return args.theme.bg("toolPendingBg", pad(text, width));
+  }
+
+  function renderFooter(width: number): string[] {
+    const row = focusedRow();
+    let rowHints: FieldKeyHint[] = [];
+    if (row) {
+      const renderer = rendererFor(row.field);
+      rowHints = renderer.hints(
+        { field: row.field as never, value: row.value as never },
+        { isEditing: row.isEditing },
+      );
+    }
+
+    // Always-present hints: nav, field-reset, save, search
+    const line1: FieldKeyHint[] = [];
+    if (tabs.length > 0 || actionRows.length > 0) {
+      line1.push({ key: "tab/shift+tab", label: "cycle" });
+    }
+    line1.push({ key: "↑↓", label: "move" });
+    if (!row?.isEditing && row?.field.reorderable) {
+      line1.push({ key: "alt+↑↓", label: "reorder" });
+    }
+    const anyFieldHasDefault = fields.some(
+      (f) => (f as { default?: unknown }).default !== undefined,
+    );
+    if (anyFieldHasDefault && !row?.isEditing) {
+      line1.push({ key: "ctrl+r", label: "reset field" });
+      line1.push({ key: "ctrl+d", label: "reset field" });
+    }
+    if (isBuffered) {
+      line1.push({ key: "ctrl+s", label: "save" });
+    }
+    if (options.enableSearch && !row?.isEditing) {
+      if (search === "") {
+        line1.push({ key: "type", label: "to search" });
+      } else {
+        line1.push({ key: "ctrl+u", label: "clear" });
+      }
+    }
+
+    // Line 2: field-specific hints + dismiss
+    const line2: FieldKeyHint[] = [];
+    line2.push(...rowHints);
+    if (confirmState) {
+      line2.push({ key: "↑↓", label: "select" });
+      line2.push({ key: "enter", label: "confirm" });
+      line2.push({ key: "esc", label: "cancel" });
+    } else if (options.enableSearch && search !== "" && !row?.isEditing) {
+      line2.push({ key: "esc", label: "clear search" });
+    } else if (isBuffered && isDirty()) {
+      line2.push({ key: "esc", label: "confirm →" });
+    } else {
+      line2.push({ key: "esc", label: "close" });
+    }
+
+    const lines: string[] = [formatHintLine(line1, args.theme)];
+    if (line2.length > 1 || (line2.length === 1 && line2[0]!.key !== "esc")) {
+      lines.push(formatHintLine(line2, args.theme));
+    }
+    return lines;
+  }
+
+  function renderRow(row: InternalRow, width: number, isSelected: boolean): string {
+    const labelText = row.labelText;
+    // Per-field `dim` overrides the default focus-based coloring. The
+    // override is binary — fields that opt in are saying "this row is
+    // semantically active / inactive, color me regardless of focus".
+    // Selection background still applies on top either way, so a
+    // focused dimmed row stays visibly highlighted via the prefix
+    // chip + selectedBg, just with a muted label.
+    const dimRaw = row.field.disabled ? true : row.field.dim;
+    const dimFlag = typeof dimRaw === "function" ? dimRaw() : dimRaw;
+    const labelColor =
+      dimFlag === true ? "muted" : dimFlag === false ? "text" : isSelected ? "text" : "muted";
+    const label = args.theme.fg(labelColor, labelText);
+    const renderer = rendererFor(row.field);
+    const valueText = renderer.renderValue(
+      { field: row.field as never, value: row.value as never },
+      {
+        width: Math.max(1, width - LABEL_PAD_TARGET - 4),
+        selected: isSelected,
+        isEditing: row.isEditing,
+        ctx: fieldRenderContext,
+      },
+    );
+    const padding = row.labelPadding;
+    const depthIndent = "  ".repeat(row.field.depth ?? 0);
+    const prefix = isSelected ? args.theme.fg("accent", `${depthIndent}▌ `) : `${depthIndent}  `;
+
+    // Scope note: when in a scope tab, show where the value originates
+    // from (other scope or default). E.g. "(Global: on)" or "(default: 10)".
+    let note = "";
+    if (useScopeTabs && activeTabId) {
+      const sn = scopeNoteFor(row, activeTabId);
+      if (sn) note = ` ${args.theme.fg("dim", sn)}`;
+    }
+
+    const composed = `${prefix}${label}${padding}${valueText}${note}`;
+    if (isSelected) return args.theme.bg("selectedBg", pad(composed, width));
+    return truncateToWidth(composed, width, "…");
+  }
+
+  function scopeNoteFor(row: InternalRow, scope: string): string | undefined {
+    if (!useScopeTabs || !options.defaults) return undefined;
+    const defaultValue = (options.defaults as Record<string, unknown>)[row.field.key];
+    const gv = row.globalValue;
+    const pv = row.projectValue;
+    const format = (v: unknown): string => {
+      if (v === undefined || v === null) return "unset";
+      if (row.field.type === "boolean") return v ? "on" : "off";
+      if (row.field.type === "number") return String(v);
+      if (row.field.type === "string" || row.field.type === "text")
+        return JSON.stringify(String(v));
+      if (row.field.type === "enum") return String(v);
+      return String(v);
+    };
+    if (scope === "project") {
+      if (pv !== undefined) return undefined; // project has explicit value — no note needed
+      if (gv !== undefined) return `(Global: ${format(gv)})`;
+      return `(default: ${format(defaultValue)})`;
+    }
+    // Global tab
+    if (gv !== undefined) return undefined; // global has explicit value
+    return `(default: ${format(defaultValue)})`;
+  }
+
+  function renderBody(width: number, innerRows: number): string[] {
+    const lines: string[] = [];
+    if (tabs.length > 0) {
+      lines.push(renderTabBar(width));
+    }
+    const indices = visibleRowIndices();
+    if (options.enableSearch) {
+      if (lines.length > 0) lines.push("");
+      lines.push(renderSearchBar(width, indices.length > 0));
+    }
+    if (lines.length > 0) {
+      lines.push("");
+      lines.push(divider(width, args.theme));
+    }
+    const visibleListRows = Math.max(3, innerRows - lines.length - 2 - estimateDescriptionRows());
+    clampSelection(visibleListRows);
+
+    const fieldCount = indices.length;
+    const slice = indices.slice(scroll, scroll + visibleListRows);
+    if (slice.length === 0) {
+      lines.push(args.theme.fg("muted", "  No matching settings. (press esc to clear)"));
+    } else {
+      if (scroll > 0) lines.push(args.theme.fg("dim", `  ↑ ${scroll} earlier`));
+      for (const [visIdx, idx] of slice.entries()) {
+        const realIdx = scroll + visIdx;
+        const row = rows[idx]!;
+        lines.push(renderRow(row, width, realIdx === fieldSelected));
+      }
+      const hidden = Math.max(0, fieldCount - (scroll + visibleListRows));
+      if (hidden > 0) lines.push(args.theme.fg("dim", `  ↓ ${hidden} more`));
+    }
+
+    // Description for the focused field
+    const focused = focusedRow();
+    if (focused) {
+      renderFieldDesc(lines, width, focused);
+    }
+
+    // Pad to fill remaining space (footer and actions are added at frame level)
+    while (lines.length < innerRows) lines.push("");
+    return lines;
+  }
+
+  function renderFieldDesc(lines: string[], width: number, focused: InternalRow): void {
+    let desc = focused.field.description ?? "";
+    const field = focused.field;
+    if (field.type === "number") {
+      const parts: string[] = [];
+      if (field.values) {
+        parts.push(`values: ${field.values.join(", ")}`);
+      } else {
+        if (typeof field.min === "number" && typeof field.max === "number") {
+          parts.push(`range: ${field.min} to ${field.max}`);
+        } else if (typeof field.min === "number") {
+          parts.push(`min: ${field.min}`);
+        } else if (typeof field.max === "number") {
+          parts.push(`max: ${field.max}`);
+        }
+        if (field.integer) parts.push("integer only");
+      }
+      if (parts.length > 0) {
+        const suffix = `(${parts.join(", ")})`;
+        desc = desc ? `${desc} ${suffix}` : suffix;
+      }
+    }
+
+    if (desc) {
+      lines.push("");
+      for (const line of wrapLine(desc, Math.max(1, width - 4))) {
+        lines.push(args.theme.fg("muted", `  ${line}`));
+      }
+    }
+
+    // valueDescriptions: per-value help text for boolean/enum/number
+    let vdText: string | undefined;
+    if (field.type === "boolean") {
+      const vd = field.valueDescriptions;
+      if (vd) {
+        const key = field.value ? "on" : "off";
+        vdText = vd[key as "on" | "off"];
+      }
+    } else if (field.type === "enum") {
+      const vd = field.valueDescriptions;
+      if (vd) {
+        vdText = vd[field.value];
+      }
+    } else if (field.type === "number") {
+      const vd = field.valueDescriptions;
+      if (vd) {
+        vdText = vd[String(field.value)];
+      }
+    }
+    if (vdText) {
+      lines.push("");
+      for (const line of wrapLine(args.theme.fg("accent", vdText), Math.max(1, width - 4))) {
+        lines.push(`  ${line}`);
+      }
+    }
+
+    // Validation warning: show when the focused row's current value
+    // violates its type constraints (enum membership, number range, etc.).
+    const warning = validateFieldValue(focused.field, focused.value);
+    if (warning) {
+      lines.push("");
+      for (const line of wrapLine(warning, Math.max(1, width - 4))) {
+        lines.push(args.theme.fg("warning", `  ${line}`));
+      }
+    }
+  }
+
+  /** Tiny heuristic so renderBody knows roughly how much room the
+   *  description block will eat. Real content is recomputed per render
+   *  but we want the list to start scrolling before that math kicks in. */
+  function estimateDescriptionRows(): number {
+    const focused = focusedRow();
+    if (!focused) return 0;
+    let estimate = 0;
+    if (focused.field.description) estimate = 2;
+    const field = focused.field;
+    if (field.type === "number") {
+      if (typeof field.min === "number" || typeof field.max === "number" || field.integer) {
+        estimate = Math.max(estimate, 2);
+      }
+    }
+    // Validation warning
+    const warning = validateFieldValue(focused.field, focused.value);
+    if (warning) estimate = Math.max(estimate, 1);
+    return estimate;
+  }
+
+  /** Handle reset/delete scope actions: call the callback and reload configs. */
+  async function handleScopeAction(
+    action: "reset" | "delete",
+    scope: "global" | "project",
+  ): Promise<void> {
+    const cb = action === "reset" ? options.onResetScope : options.onDeleteScope;
+    if (!cb) return;
+    try {
+      await cb(scope);
+    } catch (err) {
+      notifyError(args.ctx, err);
+      return;
+    }
+    // Reload configs and update rows with fresh values
+    if (useScopeTabs && options.configFilename) {
+      const fn = options.configFilename;
+      const defs = options.defaults ?? {};
+      const freshGlobal = loadConfig<Record<string, unknown>>(fn, defs, {
+        configDir: options.globalConfigDir ?? getExtensionsDir(),
+      });
+      const freshProject = loadConfig<Record<string, unknown>>(fn, defs, {
+        cwd: args.ctx.cwd,
+        configDir: options.globalConfigDir ?? getExtensionsDir(),
+      });
+      for (const rr of rows) {
+        const gv = getNestedValue(freshGlobal, rr.field.key);
+        rr.globalValue =
+          gv !== undefined
+            ? gv
+            : (extractInitialValue(rr.field) ??
+              (options.defaults as Record<string, unknown>)?.[rr.field.key]);
+        const pv = getNestedValue(freshProject, rr.field.key);
+        rr.projectValue = pv !== undefined ? pv : rr.globalValue;
+      }
+    }
+    // Clear dirty state for the affected scope
+    if (isBuffered) {
+      const dk = scope === "project" ? dirtyProjectKeys : dirtyGlobalKeys;
+      dk.clear();
+      const iv = scope === "project" ? initialProjectValues : initialGlobalValues;
+      for (const rr of rows) {
+        const initVal = scope === "project" ? rr.projectValue : rr.globalValue;
+        iv.set(
+          rr.field.key,
+          typeof initVal === "object" && initVal !== null
+            ? JSON.parse(JSON.stringify(initVal))
+            : initVal,
+        );
+      }
+    }
+    args.tui.requestRender();
+  }
+
+  return {
+    render(width: number): string[] {
+      const inner = responsiveInnerRows(args.tui.terminal.rows ?? 24, PREFERRED_INNER_ROWS, 14);
+      if (submenu) {
+        // Render the submenu inside the same frame so the popup chrome
+        // doesn't change shape mid-flow.
+        const lines = submenu.render(frameContentWidth(width));
+        const opts: FrameOptions = {
+          title: submenuTitle(submenuKey),
+          fixedInnerRows: inner,
+        };
+        return frame(lines, width, args.theme, opts);
+      }
+      if (confirmState) {
+        const lines = renderConfirmSubmenu(frameContentWidth(width));
+        const title = options.title
+          ? `${options.title}${isBuffered && isDirty() ? " " + args.theme.fg("accent", "● Unsaved") : ""} — Save changes?`
+          : "Save changes?";
+        const opts: FrameOptions = {
+          title,
+          fixedInnerRows: inner,
+        };
+        return frame(lines, width, args.theme, opts);
+      }
+      if (scopeActionConfirm) {
+        const lines = renderScopeActionConfirm(frameContentWidth(width));
+        const dialogTitle =
+          scopeActionConfirm.action === "reset" ? "Reset scope?" : "Delete config?";
+        const opts: FrameOptions = {
+          title: options.title ? `${options.title} — ${dialogTitle}` : dialogTitle,
+          fixedInnerRows: inner,
+        };
+        return frame(lines, width, args.theme, opts);
+      }
+
+      // Footer hints + action buttons are rendered OUTSIDE the frame
+      // body truncation so they are ALWAYS visible at the bottom.
+      const contentWidth = frameContentWidth(width);
+      const footerRows = renderFooter(contentWidth);
+      const footerSectionHeight = 1 + footerRows.length; // divider + hints
+      const actionSectionHeight = actionRows.length > 0 ? 2 : 0;
+      const bottomSectionHeight = footerSectionHeight + actionSectionHeight;
+      const bodyInnerRows = inner - bottomSectionHeight;
+      const bodyLines = renderBody(contentWidth, bodyInnerRows);
+
+      const dirtyDot = isBuffered && isDirty() ? ` ${args.theme.fg("accent", "● Unsaved")}` : "";
+      const title = options.title ? `${options.title}${dirtyDot}` : options.title;
+
+      const frameLines = frame(bodyLines, width, args.theme, {
+        title,
+        fixedInnerRows: bodyInnerRows,
+      });
+
+      // Replace the bottom padding + border with the fixed sections
+      const bottomBorder = frameLines.pop()!;
+      const bottomPadding = frameLines.pop()!;
+      const borderAccent = (s: string) => args.theme.fg("borderAccent", s);
+
+      // Footer hint line
+      const footDiv = `${borderAccent("│")}  ${args.theme.fg("dim", "─".repeat(Math.max(1, contentWidth)))}  ${borderAccent("│")}`;
+      frameLines.push(footDiv);
+      for (const line of footerRows) {
+        const paddedLine = `  ${line}`;
+        frameLines.push(
+          `${borderAccent("│")}${pad(paddedLine, contentWidth + 4)}${borderAccent("│")}`,
+        );
+      }
+
+      // Action buttons — side by side on one line, styled like tabs.
+      // Tab/Shift+Tab cycles through them as individual stops.
+      if (actionRows.length > 0) {
+        const actDiv = `${borderAccent("│")}  ${args.theme.fg("dim", "─".repeat(Math.max(1, contentWidth)))}  ${borderAccent("│")}`;
+        frameLines.push(actDiv);
+
+        const cells: string[] = [];
+        for (let ai = 0; ai < actionRows.length; ai++) {
+          const isFocused = tabActionFocus >= tabs.length && tabActionFocus - tabs.length === ai;
+          const keyHint = ai === 0 ? " [ctrl+shift+r]" : " [ctrl+shift+d]";
+          const padded = ` ${actionRows[ai]!.label}${keyHint} `;
+          if (isFocused) {
+            cells.push(args.theme.fg("accent", args.theme.inverse(args.theme.bold(padded))));
+          } else {
+            cells.push(args.theme.bg("selectedBg", args.theme.fg("accent", padded)));
+          }
+        }
+        const line = pad(cells.join(" "), contentWidth);
+        frameLines.push(`${borderAccent("│")}  ${line}  ${borderAccent("│")}`);
+      }
+
+      // Restore bottom padding and border
+      frameLines.push(bottomPadding);
+      frameLines.push(bottomBorder);
+
+      return frameLines;
+    },
+    invalidate(): void {
+      submenu?.invalidate();
+    },
+    handleInput,
+  };
+}
+
+function submenuTitle(key: string | undefined): string | undefined {
+  return key ? `${key} →` : undefined;
+}
+
+function notifyError(ctx: ExtensionContext, err: unknown): void {
+  const message = err instanceof Error ? err.message : String(err);
+  try {
+    ctx.ui.notify(message, "error");
+  } catch {
+    // Defensive: never let a bad notify call break the modal loop.
+  }
+}
+
+function extractInitialValue(field: Field): unknown {
+  if (field.type === "action") return undefined;
+  return (field as { value: unknown }).value;
+}
+
+function getNestedValue(obj: unknown, path: string): unknown {
+  const parts = path.split(".");
+  let current = obj;
+  for (const part of parts) {
+    if (current === null || current === undefined || typeof current !== "object") {
+      return undefined;
+    }
+    current = (current as Record<string, unknown>)[part];
+  }
+  return current;
+}

--- a/src/pi-base/settings/body.ts
+++ b/src/pi-base/settings/body.ts
@@ -30,7 +30,6 @@ import type {
   Field,
   FieldKeyHint,
   FieldRenderContext,
-  NumberField,
   SettingsModalOptions,
   Tab,
   VisibilityContext,
@@ -261,7 +260,7 @@ export function createSettingsModalBody<F extends Field>(
   // and search filtering loops.
   let cachedVisibleIndices: number[] = [];
 
-  function buildVisibilityContext(field: Field, scope: string): VisibilityContext {
+  function buildVisibilityContext(_field: Field, scope: string): VisibilityContext {
     return {
       get: (key: string) => {
         const r = rows.find((rr) => rr.field.key === key);
@@ -333,14 +332,6 @@ export function createSettingsModalBody<F extends Field>(
   function focusedRow(): InternalRow | undefined {
     const idx = focusedIndex();
     return idx === undefined ? undefined : rows[idx];
-  }
-
-  function focusedAction(): (typeof actionRows)[number] | undefined {
-    if (tabActionFocus >= tabs.length) {
-      const actionIdx = tabActionFocus - tabs.length;
-      return actionRows[actionIdx] ?? undefined;
-    }
-    return undefined;
   }
 
   function isDirty(): boolean {
@@ -607,7 +598,7 @@ export function createSettingsModalBody<F extends Field>(
     }
   }
 
-  function renderConfirmSubmenu(width: number): string[] {
+  function renderConfirmSubmenu(_width: number): string[] {
     const lines: string[] = [];
     lines.push("");
     lines.push("  You have unsaved changes:");
@@ -678,7 +669,7 @@ export function createSettingsModalBody<F extends Field>(
     ];
   }
 
-  function renderScopeActionConfirm(width: number): string[] {
+  function renderScopeActionConfirm(_width: number): string[] {
     const lines: string[] = [];
     const isReset = scopeActionConfirm!.action === "reset";
     const options = getScopeActionOptions(scopeActionConfirm!.action);
@@ -1019,17 +1010,6 @@ export function createSettingsModalBody<F extends Field>(
     args.tui.requestRender();
   }
 
-  function cycleTab(delta: number): void {
-    if (tabs.length === 0) return;
-    const idx = tabs.findIndex((t) => t.id === activeTabId);
-    const nextIdx = ((idx === -1 ? 0 : idx) + delta + tabs.length) % tabs.length;
-    activeTabId = tabs[nextIdx]!.id;
-    fieldSelected = 0;
-    scroll = 0;
-    tabActionFocus = -1;
-    updateVisibleIndices();
-    args.tui.requestRender();
-  }
 
   function renderTabBar(width: number): string {
     if (tabs.length === 0) return "";
@@ -1078,7 +1058,7 @@ export function createSettingsModalBody<F extends Field>(
     return args.theme.bg("toolPendingBg", pad(text, width));
   }
 
-  function renderFooter(width: number): string[] {
+  function renderFooter(_width: number): string[] {
     const row = focusedRow();
     let rowHints: FieldKeyHint[] = [];
     if (row) {

--- a/src/pi-base/settings/fields/action.ts
+++ b/src/pi-base/settings/fields/action.ts
@@ -1,0 +1,39 @@
+/**
+ * Renderer for `type: "action"` rows. Non-storing — Enter triggers the
+ * caller-supplied `onActivate(ctx)` and never changes a value.
+ */
+
+import { matchesKey } from "@earendil-works/pi-tui";
+import type { ActionField, FieldRenderer } from "../types";
+
+export const actionRenderer: FieldRenderer<ActionField, void> = {
+  type: "action",
+  renderValue(row, { selected, ctx }) {
+    const text = row.field.display ?? "(run)";
+    if (row.field.disabled) {
+      return ctx.theme.fg("muted", text);
+    }
+    return ctx.theme.fg(selected ? "accent" : "muted", text);
+  },
+  hints(row) {
+    if (row.field.disabled) return [];
+    return [{ key: "enter", label: "run" }];
+  },
+  handleKey(row, data, { ctx }) {
+    if (row.field.disabled) return {};
+    if (matchesKey(data, "enter") || matchesKey(data, "return") || data === " ") {
+      // Fire and forget — actions are deliberately fire-and-go so the
+      // modal stays responsive even when `onActivate` is async.
+      try {
+        const ret = row.field.onActivate(ctx.ctx);
+        if (ret && typeof (ret as Promise<void>).then === "function") {
+          (ret as Promise<void>).catch(() => {});
+        }
+      } catch {
+        // Swallow — actions must never break the modal loop.
+      }
+      return { consumed: true };
+    }
+    return {};
+  },
+};

--- a/src/pi-base/settings/fields/boolean.ts
+++ b/src/pi-base/settings/fields/boolean.ts
@@ -1,0 +1,40 @@
+/**
+ * Renderer for `type: "boolean"` rows. Enter / Space toggles between
+ * `on` and `off`; the value is committed immediately.
+ */
+
+import { matchesKey } from "@earendil-works/pi-tui";
+import type { BooleanField, FieldRenderer } from "../types";
+
+export const booleanRenderer: FieldRenderer<BooleanField, boolean> = {
+  type: "boolean",
+  renderValue(row, { selected, ctx }) {
+    const text = row.value ? "on" : "off";
+    if (row.field.disabled) {
+      return ctx.theme.fg("muted", text);
+    }
+    return ctx.theme.fg(selected ? "accent" : row.value ? "success" : "muted", text);
+  },
+  hints(row) {
+    if (row.field.disabled) return [];
+    return [
+      { key: "enter/space", label: row.value ? "turn off" : "turn on" },
+      { key: "←/→", label: "toggle" },
+    ];
+  },
+  handleKey(row, data) {
+    if (row.field.disabled) return {};
+    if (matchesKey(data, "enter") || matchesKey(data, "return") || data === " ") {
+      return { consumed: true, commit: !row.value };
+    }
+    if (matchesKey(data, "left")) {
+      if (row.value === false) return { consumed: true };
+      return { consumed: true, commit: false };
+    }
+    if (matchesKey(data, "right")) {
+      if (row.value === true) return { consumed: true };
+      return { consumed: true, commit: true };
+    }
+    return {};
+  },
+};

--- a/src/pi-base/settings/fields/custom.ts
+++ b/src/pi-base/settings/fields/custom.ts
@@ -1,0 +1,68 @@
+/**
+ * Renderer for `type: "custom"` rows. The caller supplies:
+ *
+ *   - `render(args)` — returns the right-hand value cell as a string.
+ *   - `handleInput?(data, args)` — optional inline-edit handler; return
+ *     true to consume the key.
+ *   - `openSubmenu?(args)` — optional submenu mounted on Enter; the
+ *     factory receives a `done(value?)` callback the modal supplies.
+ *
+ * Anything more exotic than the built-in `model` widget belongs here.
+ */
+
+import { matchesKey } from "@earendil-works/pi-tui";
+import type { CustomField, FieldRenderer, SubmenuFactory } from "../types";
+
+export const customRenderer: FieldRenderer<CustomField, unknown> = {
+  type: "custom",
+  renderValue(row, args) {
+    const text = row.field.render({
+      value: row.value,
+      width: args.width,
+      selected: args.selected && !row.field.disabled,
+      theme: args.ctx.theme,
+    });
+    if (row.field.disabled) {
+      return args.ctx.theme.fg("muted", text);
+    }
+    return text;
+  },
+  hints(row) {
+    if (row.field.disabled) return [];
+    // Caller-supplied override wins outright — useful when
+    // `handleInput` consumes a specific key (e.g. space) but Enter
+    // is a no-op, in which case the default "enter edit" heuristic
+    // would be misleading.
+    if (row.field.hints) return row.field.hints;
+    if (row.field.openSubmenu) return [{ key: "enter", label: "open" }];
+    if (row.field.handleInput) return [{ key: "enter", label: "edit" }];
+    return [];
+  },
+  handleKey(row, data, args) {
+    if (row.field.disabled) return {};
+    // Caller-supplied inline-edit handler runs first so it can intercept
+    // arrow keys etc. before we treat Enter as "open submenu".
+    if (row.field.handleInput) {
+      const consumed = row.field.handleInput(data, {
+        value: row.value,
+        width: 0,
+        selected: true,
+        theme: args.ctx.theme,
+      });
+      if (consumed) return { consumed: true };
+    }
+    if (matchesKey(data, "enter") || matchesKey(data, "return") || data === " ") {
+      if (row.field.openSubmenu) {
+        const factory: SubmenuFactory<unknown> = (done) =>
+          row.field.openSubmenu!({
+            value: row.value,
+            theme: args.ctx.theme,
+            tui: args.ctx.tui,
+            done,
+          });
+        return { consumed: true, submenu: factory };
+      }
+    }
+    return {};
+  },
+};

--- a/src/pi-base/settings/fields/enum.ts
+++ b/src/pi-base/settings/fields/enum.ts
@@ -1,0 +1,282 @@
+/**
+ * Renderer for `type: "enum"` rows.
+ *
+ * Short option lists (≤ `cycleThreshold`, default 4) cycle in place via
+ * Enter / Space; longer lists open a `SelectList` submenu so users
+ * don't have to mash Enter to scroll through 20+ entries.
+ */
+
+import { getSelectListTheme } from "@earendil-works/pi-coding-agent";
+import {
+  matchesKey,
+  SelectList,
+  truncateToWidth,
+  type Component,
+  type SelectItem,
+} from "@earendil-works/pi-tui";
+import { formatHintLine } from "../frame";
+import type { EnumField, FieldRenderContext, FieldRenderer, SubmenuFactory } from "../types";
+
+const DEFAULT_CYCLE_THRESHOLD = 4;
+const MAX_VISIBLE_ROWS = 12;
+
+function labelFor(field: EnumField, value: string): string {
+  return field.optionLabels?.[value] ?? value;
+}
+
+function nextCycleValue(field: EnumField, current: string): string {
+  if (field.options.length === 0) return current;
+  const idx = field.options.indexOf(current as never);
+  const nextIdx = (idx + 1 + field.options.length) % field.options.length;
+  return field.options[nextIdx]!;
+}
+
+function prevCycleValue(field: EnumField, current: string): string {
+  if (field.options.length === 0) return current;
+  const idx = field.options.indexOf(current as never);
+  const prevIdx = (idx - 1 + field.options.length) % field.options.length;
+  return field.options[prevIdx]!;
+}
+
+/** Build a submenu factory the modal can mount with its own `done`. */
+function makeEnumSubmenu(
+  field: EnumField,
+  current: string,
+  ctx: FieldRenderContext,
+): SubmenuFactory<string> {
+  if (field.search) {
+    return makeSearchableEnumSubmenu(field, current, ctx);
+  }
+
+  return (done) => {
+    const items: SelectItem[] = field.options.map((value, idx) => ({
+      value,
+      label: `${idx + 1}. ${labelFor(field, value)}`,
+    }));
+    const list = new SelectList(
+      items,
+      Math.min(items.length, MAX_VISIBLE_ROWS),
+      getSelectListTheme(),
+    );
+    const idx = field.options.indexOf(current);
+    list.setSelectedIndex(idx >= 0 ? idx : 0);
+    list.onSelect = (item) => done(item.value);
+    list.onCancel = () => done();
+
+    const component: Component = {
+      render(width: number): string[] {
+        const lines = [...list.render(width)];
+        lines.push("");
+        const hints = [
+          { key: "↑↓", label: "select" },
+          ...(items.length > 1 ? [{ key: `1-${Math.min(9, items.length)}`, label: "choose" }] : []),
+          { key: "enter", label: "save" },
+          { key: "esc", label: "cancel" },
+        ];
+        const hintText = `  ${formatHintLine(hints, ctx.theme)}`;
+        lines.push(truncateToWidth(hintText, width, "…", true));
+        return lines;
+      },
+      invalidate(): void {
+        list.invalidate();
+      },
+      handleInput(data: string): void {
+        const num = parseInt(data, 10);
+        if (data.length === 1 && !isNaN(num) && num >= 1 && num <= Math.min(9, items.length)) {
+          const item = items[num - 1];
+          if (item) {
+            done(item.value);
+            return;
+          }
+        }
+        list.handleInput(data);
+        ctx.tui.requestRender();
+      },
+    };
+    return component;
+  };
+}
+
+/**
+ * Build a searchable enum submenu with a filter bar at the top.
+ * Used when `field.search === true`.
+ */
+function makeSearchableEnumSubmenu(
+  field: EnumField,
+  current: string,
+  ctx: FieldRenderContext,
+): SubmenuFactory<string> {
+  return (done) => {
+    const allItems: SelectItem[] = field.options.map((value) => ({
+      value,
+      label: labelFor(field, value),
+    }));
+
+    let search = "";
+    let selected = 0;
+
+    function filteredItems(): SelectItem[] {
+      if (!search.trim()) return allItems;
+      const q = search.toLowerCase();
+      return allItems.filter(
+        (item) => item.label.toLowerCase().includes(q) || item.value.toLowerCase().includes(q),
+      );
+    }
+
+    function clampSelected(): void {
+      const items = filteredItems();
+      if (selected >= items.length) selected = Math.max(0, items.length - 1);
+    }
+
+    const component: Component = {
+      render(width: number): string[] {
+        const lines: string[] = [];
+        const items = filteredItems();
+        const searchPrompt = `Search: ${search}${ctx.theme.inverse(" ")}`;
+        lines.push(ctx.theme.bg("toolPendingBg", truncateToWidth(searchPrompt, width, "…", true)));
+        lines.push("");
+
+        if (items.length === 0) {
+          lines.push(ctx.theme.fg("muted", "  No matching options."));
+        } else {
+          const maxVisible = MAX_VISIBLE_ROWS;
+          const scroll = Math.max(
+            0,
+            Math.min(selected - Math.floor(maxVisible / 2), Math.max(0, items.length - maxVisible)),
+          );
+          const slice = items.slice(scroll, scroll + maxVisible);
+          for (let i = 0; i < slice.length; i++) {
+            const isSelected = scroll + i === selected;
+            const prefix = isSelected ? ctx.theme.fg("accent", "▌ ") : "  ";
+            const display = isSelected
+              ? ctx.theme.fg("accent", slice[i]!.label)
+              : ctx.theme.fg("muted", slice[i]!.label);
+            const line = `${prefix}${display}`;
+            lines.push(
+              isSelected
+                ? ctx.theme.bg("selectedBg", truncateToWidth(line, width, "…", true))
+                : truncateToWidth(line, width, "…", true),
+            );
+          }
+        }
+
+        lines.push("");
+        const hints = [
+          { key: "↑↓", label: "select" },
+          { key: "enter", label: "save" },
+          { key: "esc", label: "cancel" },
+        ];
+        if (search) hints.unshift({ key: "type", label: "to filter" });
+        lines.push(`  ${formatHintLine(hints, ctx.theme)}`);
+        return lines;
+      },
+      invalidate(): void {
+        // no external state to invalidate
+      },
+      handleInput(data: string): void {
+        if (matchesKey(data, "up")) {
+          selected = Math.max(0, selected - 1);
+          ctx.tui.requestRender();
+          return;
+        }
+        if (matchesKey(data, "down")) {
+          const items = filteredItems();
+          selected = Math.min(selected + 1, Math.max(0, items.length - 1));
+          ctx.tui.requestRender();
+          return;
+        }
+        if (matchesKey(data, "enter") || matchesKey(data, "return")) {
+          const items = filteredItems();
+          if (items.length > 0) {
+            done(items[Math.min(selected, items.length - 1)]!.value);
+          }
+          return;
+        }
+        if (matchesKey(data, "escape")) {
+          done();
+          return;
+        }
+        if (matchesKey(data, "backspace") || matchesKey(data, "ctrl+h")) {
+          search = search.slice(0, -1);
+          selected = 0;
+          ctx.tui.requestRender();
+          return;
+        }
+        if (data.length === 1 && data >= " " && data !== "\x7f") {
+          search += data;
+          selected = 0;
+          ctx.tui.requestRender();
+        }
+      },
+    };
+    return component;
+  };
+}
+
+export const enumRenderer: FieldRenderer<EnumField, string> = {
+  type: "enum",
+  renderValue(row, { selected, ctx }) {
+    const text = labelFor(row.field, row.value);
+    if (row.field.disabled) {
+      return ctx.theme.fg("muted", text);
+    }
+    return ctx.theme.fg(selected ? "accent" : "muted", text);
+  },
+  hints(row) {
+    if (row.field.disabled) return [];
+    // Searchable enums always open a list submenu
+    if (row.field.search) {
+      return [{ key: "enter", label: "open list" }];
+    }
+    const threshold = row.field.cycleThreshold ?? DEFAULT_CYCLE_THRESHOLD;
+    if (row.field.options.length > threshold) {
+      return [{ key: "enter", label: "open list" }];
+    }
+    return [
+      { key: "enter/space", label: "cycle" },
+      { key: "←/→", label: "prev/next" },
+    ];
+  },
+  handleKey(row, data, { ctx }) {
+    if (row.field.disabled) return {};
+    // Searchable enums always open a submenu on Enter/Space
+    if (row.field.search) {
+      if (matchesKey(data, "enter") || matchesKey(data, "return") || data === " ") {
+        return {
+          consumed: true,
+          submenu: makeEnumSubmenu(row.field, row.value, ctx),
+        };
+      }
+      // No cycling for searchable enums — all navigation is in the submenu
+      return {};
+    }
+
+    const threshold = row.field.cycleThreshold ?? DEFAULT_CYCLE_THRESHOLD;
+    const isLongList = row.field.options.length > threshold;
+
+    if (matchesKey(data, "enter") || matchesKey(data, "return") || data === " ") {
+      if (isLongList) {
+        return {
+          consumed: true,
+          submenu: makeEnumSubmenu(row.field, row.value, ctx),
+        };
+      }
+      return { consumed: true, commit: nextCycleValue(row.field, row.value) };
+    }
+
+    if (!isLongList) {
+      if (matchesKey(data, "left")) {
+        const prev = prevCycleValue(row.field, row.value);
+        if (prev === row.value) return { consumed: true };
+        return { consumed: true, commit: prev };
+      }
+      if (matchesKey(data, "right")) {
+        const next = nextCycleValue(row.field, row.value);
+        if (next === row.value) return { consumed: true };
+        return { consumed: true, commit: next };
+      }
+    }
+
+    return {};
+  },
+};

--- a/src/pi-base/settings/fields/enum.ts
+++ b/src/pi-base/settings/fields/enum.ts
@@ -103,7 +103,7 @@ function makeEnumSubmenu(
  */
 function makeSearchableEnumSubmenu(
   field: EnumField,
-  current: string,
+  _current: string,
   ctx: FieldRenderContext,
 ): SubmenuFactory<string> {
   return (done) => {
@@ -121,11 +121,6 @@ function makeSearchableEnumSubmenu(
       return allItems.filter(
         (item) => item.label.toLowerCase().includes(q) || item.value.toLowerCase().includes(q),
       );
-    }
-
-    function clampSelected(): void {
-      const items = filteredItems();
-      if (selected >= items.length) selected = Math.max(0, items.length - 1);
     }
 
     const component: Component = {

--- a/src/pi-base/settings/fields/index.ts
+++ b/src/pi-base/settings/fields/index.ts
@@ -1,0 +1,42 @@
+/**
+ * Built-in field renderers. The modal's `RENDERERS` lookup is
+ * constructed from these so user-supplied `type: "custom"` fields can
+ * coexist with built-ins without any registration ceremony.
+ */
+
+import type { Field, FieldRenderer } from "../types";
+import { actionRenderer } from "./action";
+import { booleanRenderer } from "./boolean";
+import { customRenderer } from "./custom";
+import { enumRenderer } from "./enum";
+import { modelRenderer } from "./model";
+import { numberRenderer, pathRenderer, secretRenderer, stringRenderer } from "./string";
+import { textRenderer } from "./text";
+
+export {
+  actionRenderer,
+  booleanRenderer,
+  customRenderer,
+  enumRenderer,
+  modelRenderer,
+  numberRenderer,
+  pathRenderer,
+  secretRenderer,
+  stringRenderer,
+  textRenderer,
+};
+
+/** Map of field discriminator → renderer. */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const RENDERERS: Record<Field["type"], FieldRenderer<any, any>> = {
+  boolean: booleanRenderer,
+  enum: enumRenderer,
+  string: stringRenderer,
+  number: numberRenderer,
+  secret: secretRenderer,
+  path: pathRenderer,
+  text: textRenderer,
+  action: actionRenderer,
+  model: modelRenderer,
+  custom: customRenderer,
+};

--- a/src/pi-base/settings/fields/model.ts
+++ b/src/pi-base/settings/fields/model.ts
@@ -1,0 +1,401 @@
+/**
+ * Renderer for `type: "model"` — the two-axis "model + reasoning
+ * effort" widget that voice and web both reinvented before this
+ * package existed.
+ *
+ * UX:
+ *   - Row collapsed: `<model>  ·  <effort>` (or just `<model>` when
+ *     `hideEffort` is set).
+ *   - Enter opens a submenu with:
+ *       · a typeable filter row at the top — printable keystrokes
+ *         narrow the model list by name (case-insensitive substring);
+ *       · `↑/↓` over a `SelectList` of models;
+ *       · `←/→` over the supported effort ladder for the highlighted
+ *         model (skipped entirely when `hideEffort` is set).
+ *     Enter saves both axes atomically; Esc abandons.
+ *   - Discovery: by default, models come from
+ *     `pi.modelRegistry.getAvailable()` (filtered to entries the user
+ *     has authed, matching voice's old behaviour). The caller can
+ *     narrow with `filter` or replace the list entirely with `models`.
+ *
+ * The submenu's footer reuses `formatHintLine` so the hot-keys are
+ * highlighted with the same accent colour as the main modal's footer
+ * — no second-class colour scheme inside submenus.
+ */
+
+import { getSelectListTheme } from "@earendil-works/pi-coding-agent";
+import type { Api, Model, ModelThinkingLevel, ThinkingLevelMap } from "@earendil-works/pi-ai";
+import {
+  matchesKey,
+  SelectList,
+  truncateToWidth,
+  type Component,
+  type SelectItem,
+  type TUI,
+} from "@earendil-works/pi-tui";
+import { formatHintLine, type KeyHint } from "../frame";
+import { handleInlineEditInput, type InlineEditState } from "../inline-edit";
+import type {
+  FieldRenderContext,
+  FieldRenderer,
+  ModelField,
+  ModelOption,
+  ModelValue,
+  SubmenuFactory,
+} from "../types";
+
+const ALL_THINKING_LEVELS: ModelThinkingLevel[] = [
+  "off",
+  "minimal",
+  "low",
+  "medium",
+  "high",
+  "xhigh",
+  "max",
+];
+
+/** Short display labels for pi's internal thinking levels — used as a
+ *  fallback when the model's `thinkingLevelMap` doesn't override one.
+ *  Mirrors `THINK_LABELS` in `packages/statusline/index.ts` so the
+ *  picker and statusline never disagree on what `medium` looks like. */
+const LEVEL_FALLBACK_LABELS: Record<ModelThinkingLevel, string> = {
+  off: "off",
+  minimal: "min",
+  low: "low",
+  medium: "med",
+  high: "high",
+  xhigh: "xhigh",
+  max: "max",
+};
+
+const DEFAULT_SESSION_LABEL = "(session model)";
+const MAX_VISIBLE_MODELS = 12;
+
+/**
+ * Resolve the human-readable label for a thinking level.
+ *
+ * Models may override per-level display strings via
+ * `thinkingLevelMap` (e.g. Anthropic models map `xhigh` to a token
+ * budget like `"60000"`); we honour those overrides exactly the
+ * same way `packages/statusline/index.ts` does. Missing keys and
+ * non-string values fall back to the short label. Pure presentation
+ * — callers still pass / store the canonical level name (`"xhigh"`).
+ */
+function effortDisplayLabel(
+  level: ModelThinkingLevel,
+  thinkingLevelMap: ThinkingLevelMap | undefined,
+): string {
+  const mapped = thinkingLevelMap?.[level];
+  if (typeof mapped === "string" && mapped.length > 0) return mapped;
+  return LEVEL_FALLBACK_LABELS[level] ?? level;
+}
+
+function listModelOptions(field: ModelField, ctx: FieldRenderContext): ModelOption[] {
+  if (field.models) return field.models;
+  const sessionLabel = field.sessionLabel ?? DEFAULT_SESSION_LABEL;
+  const available = ctx.ctx.modelRegistry.getAvailable();
+  const filtered = field.filter ? available.filter(field.filter) : available;
+  const live: ModelOption[] = filtered.map((m) => ({
+    value: `${m.provider}/${m.id}`,
+    label: `${m.name}  [${m.provider}]`,
+    model: m,
+  }));
+  return field.hideSession ? live : [{ value: "", label: sessionLabel }, ...live];
+}
+
+/**
+ * Find the live `Model<Api>` for a stored value.
+ *
+ * Looks at the caller-provided `field.models` first (so `web` and
+ * other extensions that pre-build their option list still get rich
+ * label resolution), then falls back to the host model registry.
+ * Returns undefined for the `(session model)` sentinel and for any
+ * value that no longer matches a registered model.
+ */
+function resolveModelForValue(
+  field: ModelField,
+  value: ModelValue,
+  ctx: FieldRenderContext,
+): Model<Api> | undefined {
+  if (!value.id) return undefined;
+  if (field.models) {
+    const opt = field.models.find((o) => o.value === value.id);
+    if (opt?.model) return opt.model;
+    // Pre-built option without a backing `Model<Api>` — we can't
+    // resolve thinkingLevelMap from here. Fall through to the registry.
+  }
+  const slash = value.id.indexOf("/");
+  if (slash <= 0) return undefined;
+  const provider = value.id.slice(0, slash);
+  const id = value.id.slice(slash + 1);
+  return ctx.ctx.modelRegistry.find(provider, id);
+}
+
+function supportedEfforts(model: Model<Api> | undefined): ModelThinkingLevel[] {
+  if (!model || !model.thinkingLevelMap) return ALL_THINKING_LEVELS;
+  const map = model.thinkingLevelMap;
+  return ALL_THINKING_LEVELS.filter((lvl) => !(lvl in map && map[lvl] === null));
+}
+
+function clampEffort(
+  desired: ModelThinkingLevel | undefined,
+  supported: ModelThinkingLevel[],
+): ModelThinkingLevel {
+  if (desired && supported.includes(desired)) return desired;
+  return supported.includes("medium") ? "medium" : (supported[0] ?? "off");
+}
+
+function modelDisplay(field: ModelField, value: ModelValue): string {
+  if (value.id === "") return field.sessionLabel ?? DEFAULT_SESSION_LABEL;
+  return value.id;
+}
+
+function rowLabel(field: ModelField, value: ModelValue, ctx: FieldRenderContext): string {
+  const left = modelDisplay(field, value);
+  if (field.hideEffort) return left;
+  if (!value.thinking) return left;
+  // Honour the model's `thinkingLevelMap` overrides so the row
+  // displays the same label statusline shows (e.g. token-budget
+  // numbers for Anthropic) instead of pi's internal level name.
+  const model = resolveModelForValue(field, value, ctx);
+  const label = effortDisplayLabel(value.thinking, model?.thinkingLevelMap);
+  return `${left}  ·  ${label}`;
+}
+
+/**
+ * Build the submenu component. The submenu owns three pieces of state:
+ *
+ *   1. `filter`     — the typeable name-filter buffer.
+ *   2. `effortIndex` / `supported` — current effort axis (only when
+ *      `hideEffort` is unset).
+ *   3. The currently-mounted SelectList. We rebuild it whenever the
+ *      filter changes so SelectList's internal selectedIndex stays
+ *      coherent with the visible items.
+ */
+function makeSubmenu(
+  field: ModelField,
+  current: ModelValue,
+  ctx: FieldRenderContext,
+): SubmenuFactory<ModelValue> {
+  return (done) => {
+    const allOptions = listModelOptions(field, ctx);
+    const showEffort = !field.hideEffort;
+
+    const filter: InlineEditState = { buffer: "", cursor: 0 };
+
+    let list!: SelectList;
+    let visibleOptions: ModelOption[] = [];
+
+    let effortIndex = 0;
+    let supported: ModelThinkingLevel[] = [];
+
+    const refreshEffort = (preferred: ModelThinkingLevel | undefined): void => {
+      if (!showEffort) return;
+      const item = list.getSelectedItem();
+      const opt = visibleOptions.find((m) => m.value === item?.value);
+      supported = supportedEfforts(opt?.model);
+      if (supported.length === 0) supported = ["off"];
+      const clamped = clampEffort(preferred, supported);
+      effortIndex = Math.max(0, supported.indexOf(clamped));
+    };
+
+    /** Build / rebuild the SelectList from the current filter. Tries
+     *  to keep the highlight on `preserveValue` when possible so
+     *  cursor focus doesn't jump around on every keystroke. */
+    const buildList = (preserveValue: string | undefined): void => {
+      const query = filter.buffer.trim().toLowerCase();
+      visibleOptions = query
+        ? allOptions.filter(
+            (o) => o.label.toLowerCase().includes(query) || o.value.toLowerCase().includes(query),
+          )
+        : allOptions;
+
+      const items: SelectItem[] = visibleOptions.map((m) => ({
+        value: m.value,
+        label: m.label,
+        description: m.value || undefined,
+      }));
+      list = new SelectList(
+        items,
+        Math.min(Math.max(items.length, 1), MAX_VISIBLE_MODELS),
+        getSelectListTheme(),
+      );
+      const idx =
+        preserveValue !== undefined ? items.findIndex((i) => i.value === preserveValue) : -1;
+      list.setSelectedIndex(idx >= 0 ? idx : 0);
+
+      list.onSelect = (item) => {
+        if (showEffort) {
+          const effort = supported[effortIndex] ?? "off";
+          done({ id: item.value, thinking: effort });
+        } else {
+          done({ id: item.value });
+        }
+      };
+      list.onCancel = () => done();
+      list.onSelectionChange = () => {
+        if (showEffort) {
+          const previous = supported[effortIndex];
+          refreshEffort(previous);
+        }
+        ctx.tui.requestRender();
+      };
+    };
+
+    buildList(current.id);
+    refreshEffort(current.thinking);
+
+    const renderEffortRow = (width: number): string => {
+      const currentLevel = supported[effortIndex] ?? "off";
+      // Resolve the override label from the highlighted model's
+      // thinkingLevelMap so the user sees what statusline shows
+      // (token budget for Anthropic, etc.) rather than pi's
+      // internal level name.
+      const item = list.getSelectedItem();
+      const opt = visibleOptions.find((m) => m.value === item?.value);
+      const displayLabel = effortDisplayLabel(currentLevel, opt?.model?.thinkingLevelMap);
+      const left = effortIndex > 0 ? ctx.theme.fg("accent", "‹") : ctx.theme.fg("dim", "‹");
+      const right =
+        effortIndex < supported.length - 1 ? ctx.theme.fg("accent", "›") : ctx.theme.fg("dim", "›");
+      const label = ctx.theme.fg("muted", "  effort: ");
+      // Show the canonical level name in dim parentheses next to the
+      // override so power-users still know which pi level they're
+      // selecting (e.g. `60000 (xhigh)`).
+      const valueText =
+        displayLabel === currentLevel
+          ? displayLabel
+          : `${displayLabel} ${ctx.theme.fg("dim", `(${currentLevel})`)}`;
+      const value = ctx.theme.fg("accent", ctx.theme.bold(valueText));
+      const counter = ctx.theme.fg("dim", `  (${effortIndex + 1}/${supported.length})`);
+      return truncateToWidth(`${label}${left} ${value} ${right}${counter}`, width, "…", true);
+    };
+
+    const renderFilterRow = (width: number): string => {
+      const cursorBlock = ctx.theme.inverse(" ");
+      const buf = filter.buffer;
+      const before = buf.slice(0, filter.cursor);
+      const after = buf.slice(filter.cursor);
+      const placeholder = !buf ? ctx.theme.fg("dim", "  type to filter…") : "";
+      const hasMatches = visibleOptions.length > 0;
+      const colorKey = hasMatches ? "accent" : "warning";
+      const text = buf
+        ? `  ${ctx.theme.fg("muted", "filter:")} ${ctx.theme.fg(colorKey, before)}${cursorBlock}${ctx.theme.fg(colorKey, after)}`
+        : `  ${ctx.theme.fg("muted", "filter:")} ${cursorBlock}${placeholder}`;
+      return truncateToWidth(text, width, "…", true);
+    };
+
+    const renderHints = (width: number): string => {
+      const hints: KeyHint[] = [{ key: "↑↓", label: "model" }];
+      if (showEffort) hints.push({ key: "←→", label: "effort" });
+      hints.push({ key: "type", label: "filter" }, { key: "enter", label: "save" });
+      if (filter.buffer !== "") {
+        hints.push({ key: "esc", label: "clear filter" });
+      } else {
+        hints.push({ key: "esc", label: "cancel" });
+      }
+      return truncateToWidth(`  ${formatHintLine(hints, ctx.theme)}`, width, "…", true);
+    };
+
+    return {
+      render(width: number): string[] {
+        const lines: string[] = [];
+        lines.push(renderFilterRow(width));
+        lines.push("");
+        if (visibleOptions.length === 0) {
+          lines.push(ctx.theme.fg("muted", "  No matching models. (press esc to clear)"));
+        } else {
+          for (const line of list.render(width)) lines.push(line);
+        }
+        lines.push("");
+        if (showEffort) {
+          lines.push(renderEffortRow(width));
+          lines.push("");
+        }
+        lines.push(renderHints(width));
+        return lines;
+      },
+      invalidate(): void {
+        list.invalidate();
+      },
+      handleInput(data: string): void {
+        // Effort axis (only when not hidden) — must run before the
+        // filter handler so ←/→ aren't typed into the search buffer.
+        if (showEffort) {
+          if (matchesKey(data, "left")) {
+            if (effortIndex > 0) {
+              effortIndex -= 1;
+              ctx.tui.requestRender();
+            }
+            return;
+          }
+          if (matchesKey(data, "right")) {
+            if (effortIndex < supported.length - 1) {
+              effortIndex += 1;
+              ctx.tui.requestRender();
+            }
+            return;
+          }
+        }
+        // Intercept escape key to clear filter first
+        if (matchesKey(data, "escape") && filter.buffer !== "") {
+          const previousValue = list.getSelectedItem()?.value;
+          filter.buffer = "";
+          filter.cursor = 0;
+          buildList(previousValue);
+          refreshEffort(supported[effortIndex]);
+          ctx.tui.requestRender();
+          return;
+        }
+        // Up / Down / Enter / Esc go to the SelectList first so the
+        // user can still drive the list while typing.
+        if (
+          matchesKey(data, "up") ||
+          matchesKey(data, "down") ||
+          matchesKey(data, "enter") ||
+          matchesKey(data, "return") ||
+          matchesKey(data, "escape") ||
+          matchesKey(data, "ctrl+c")
+        ) {
+          list.handleInput(data);
+          ctx.tui.requestRender();
+          return;
+        }
+        // Everything else (printable chars, backspace, ctrl+u, …) is
+        // routed to the inline-edit state machine.
+        const previousValue = list.getSelectedItem()?.value;
+        const consumed = handleInlineEditInput(filter, data);
+        if (consumed) {
+          buildList(previousValue);
+          refreshEffort(supported[effortIndex]);
+          ctx.tui.requestRender();
+        }
+      },
+    };
+  };
+}
+
+export const modelRenderer: FieldRenderer<ModelField, ModelValue> = {
+  type: "model",
+  renderValue(row, { selected, ctx }) {
+    const text = rowLabel(row.field, row.value, ctx);
+    if (row.field.disabled) {
+      return ctx.theme.fg("muted", text);
+    }
+    return ctx.theme.fg(selected ? "accent" : "muted", text);
+  },
+  hints(row) {
+    if (row.field.disabled) return [];
+    // The main-window hint advertises only what the row itself does
+    // there: opening the submenu. `↑↓` and `←→` only fire **inside**
+    // the submenu — emitting them at row level would mislead the
+    // user about what the keys do. The submenu has its own footer.
+    return [{ key: "enter", label: "open" }];
+  },
+  handleKey(row, data, { ctx }) {
+    if (row.field.disabled) return {};
+    if (matchesKey(data, "enter") || matchesKey(data, "return") || data === " ") {
+      return { consumed: true, submenu: makeSubmenu(row.field, row.value, ctx) };
+    }
+    return {};
+  },
+};

--- a/src/pi-base/settings/fields/model.ts
+++ b/src/pi-base/settings/fields/model.ts
@@ -28,10 +28,8 @@ import type { Api, Model, ModelThinkingLevel, ThinkingLevelMap } from "@earendil
 import {
   matchesKey,
   SelectList,
+  SelectItem,
   truncateToWidth,
-  type Component,
-  type SelectItem,
-  type TUI,
 } from "@earendil-works/pi-tui";
 import { formatHintLine, type KeyHint } from "../frame";
 import { handleInlineEditInput, type InlineEditState } from "../inline-edit";

--- a/src/pi-base/settings/fields/string.ts
+++ b/src/pi-base/settings/fields/string.ts
@@ -1,0 +1,419 @@
+/**
+ * Renderer for inline-edit text fields: `string`, `number`, `secret`,
+ * `path`. They share a single state machine — the only differences are:
+ *
+ *   - `number`  parses + validates in `commitFromBuffer`.
+ *   - `secret`  masks the displayed value when not editing.
+ *   - `path`    is identical to `string` today (kept distinct so future
+ *               completion / validation can hang off the type without
+ *               another flag).
+ *
+ * Editing flow:
+ *   1. User presses Enter on the row → `setEditing(true)` and seed the
+ *      buffer from the current value.
+ *   2. Subsequent keystrokes are routed to `handleInlineEditInput`.
+ *   3. Enter commits, Esc cancels, both call `setEditing(false)`.
+ *   4. The modal re-reads the buffer on every render, so the user sees
+ *      live feedback as they type.
+ *
+ * The buffer state is stored on the modal side (one InlineEditState per
+ * row keyed by `field.key`) so renderers stay stateless.
+ */
+
+import { matchesKey, type Component, type SelectItem } from "@earendil-works/pi-tui";
+import { SelectList } from "@earendil-works/pi-tui";
+import { getSelectListTheme } from "@earendil-works/pi-coding-agent";
+import { handleInlineEditInput, renderInlineEditValue, type InlineEditState } from "../inline-edit";
+import { formatHintLine } from "../frame";
+import type {
+  FieldKeyResult,
+  FieldRenderer,
+  FieldRenderContext,
+  NumberField,
+  PathField,
+  SecretField,
+  StringField,
+  SubmenuFactory,
+} from "../types";
+
+/**
+ * The modal stores one InlineEditState per editable row. Renderers
+ * access it through this lookup, set by the modal in `FieldRenderContext`.
+ *
+ * We intentionally don't bake the lookup into `FieldRenderContext` to
+ * keep the public type surface clean — instead, the modal mutates a
+ * weak-keyed registry passed via `(ctx as any).editStates`. The
+ * renderers below pull it out in a single helper to keep the cast
+ * isolated.
+ */
+function getEditState(args: { ctx: unknown }, key: string): InlineEditState | undefined {
+  const registry = (args.ctx as { editStates?: Map<string, InlineEditState> }).editStates;
+  return registry?.get(key);
+}
+
+function setEditState(
+  args: { ctx: unknown },
+  key: string,
+  state: InlineEditState | undefined,
+): void {
+  const registry = (args.ctx as { editStates?: Map<string, InlineEditState> }).editStates;
+  if (!registry) return;
+  if (state === undefined) registry.delete(key);
+  else registry.set(key, state);
+}
+
+function maskedSecret(value: string): string {
+  if (!value) return "(unset)";
+  return "••••••";
+}
+
+function placeholderOrEmpty(
+  field: StringField | PathField,
+  value: string,
+  dim: (s: string) => string,
+): string {
+  if (value) return value;
+  const placeholder = (field as StringField).placeholder;
+  if (placeholder) return dim(placeholder);
+  return dim("(unset)");
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// String
+// ─────────────────────────────────────────────────────────────────────
+
+export const stringRenderer: FieldRenderer<StringField, string> = {
+  type: "string",
+  renderValue(row, args) {
+    const dim = (s: string) => args.ctx.theme.fg("dim", s);
+    if (row.field.disabled) {
+      const text = placeholderOrEmpty(row.field, row.value, dim);
+      return args.ctx.theme.fg("muted", text);
+    }
+    if (args.isEditing) {
+      const state = getEditState(args, row.field.key);
+      if (state) {
+        return args.ctx.theme.fg("accent", renderInlineEditValue(state));
+      }
+    }
+    const text = placeholderOrEmpty(row.field, row.value, dim);
+    return args.selected ? args.ctx.theme.fg("text", text) : args.ctx.theme.fg("muted", text);
+  },
+  hints(row, { isEditing }) {
+    if (row.field.disabled) return [];
+    if (isEditing) {
+      return [
+        { key: "enter", label: "save" },
+        { key: "esc", label: "cancel" },
+        { key: "←/→", label: "move" },
+      ];
+    }
+    return [{ key: "enter", label: "edit" }];
+  },
+  handleKey(row, data, args) {
+    if (row.field.disabled) return {};
+    return handleStringLikeKey<string>(row.field.key, row.value, data, args, (buf) => buf);
+  },
+};
+
+// ─────────────────────────────────────────────────────────────────────
+// Path
+// ─────────────────────────────────────────────────────────────────────
+
+export const pathRenderer: FieldRenderer<PathField, string> = {
+  type: "path",
+  renderValue(row, args) {
+    // Reuse the string renderer's body — `StringField` and `PathField`
+    // share identical render shape today; we cross the variant boundary
+    // via an `unknown` cast to satisfy TS's nominal discriminator.
+    return (
+      stringRenderer.renderValue as unknown as FieldRenderer<PathField, string>["renderValue"]
+    )(row, args);
+  },
+  hints(row, args) {
+    return (stringRenderer.hints as unknown as FieldRenderer<PathField, string>["hints"])(
+      row,
+      args,
+    );
+  },
+  handleKey(row, data, args) {
+    if (row.field.disabled) return {};
+    return handleStringLikeKey<string>(row.field.key, row.value, data, args, (buf) => buf);
+  },
+};
+
+// ─────────────────────────────────────────────────────────────────────
+// Secret
+// ─────────────────────────────────────────────────────────────────────
+
+export const secretRenderer: FieldRenderer<SecretField, string> = {
+  type: "secret",
+  renderValue(row, args) {
+    if (row.field.disabled) {
+      const display = maskedSecret(row.value);
+      return args.ctx.theme.fg("muted", display);
+    }
+    if (args.isEditing) {
+      const state = getEditState(args, row.field.key);
+      if (state) {
+        // Mask in place: render the buffer through the cursor block but
+        // replace every non-cursor char with `•` so over-the-shoulder
+        // viewers can't see the secret as it's being typed.
+        const masked = "•".repeat(state.buffer.length);
+        const view: { buffer: string; cursor: number } = {
+          buffer: masked,
+          cursor: state.cursor,
+        };
+        return args.ctx.theme.fg("accent", renderInlineEditValue(view as InlineEditState));
+      }
+    }
+    const display = maskedSecret(row.value);
+    return args.selected
+      ? args.ctx.theme.fg("text", display)
+      : args.ctx.theme.fg(row.value ? "success" : "muted", display);
+  },
+  hints(row, args) {
+    return (stringRenderer.hints as unknown as FieldRenderer<SecretField, string>["hints"])(
+      row,
+      args,
+    );
+  },
+  handleKey(row, data, args) {
+    if (row.field.disabled) return {};
+    return handleStringLikeKey<string>(row.field.key, row.value, data, args, (buf) => buf);
+  },
+};
+
+// ─────────────────────────────────────────────────────────────────────
+// Number — helpers
+// ─────────────────────────────────────────────────────────────────────
+
+function nextValue(values: readonly number[], current: number): number {
+  if (values.length === 0) return current;
+  const idx = values.indexOf(current);
+  return values[(idx + 1 + values.length) % values.length]!;
+}
+
+function prevValue(values: readonly number[], current: number): number {
+  if (values.length === 0) return current;
+  const idx = values.indexOf(current);
+  return values[(idx - 1 + values.length) % values.length]!;
+}
+
+function stepUp(value: number, step: number, min?: number, max?: number): number {
+  const next = value + step;
+  if (max !== undefined && next > max) return min ?? value;
+  return next;
+}
+
+function stepDown(value: number, step: number, min?: number, max?: number): number {
+  const prev = value - step;
+  if (min !== undefined && prev < min) return max ?? value;
+  return prev;
+}
+
+function getValueDesc(field: NumberField): string | undefined {
+  return field.valueDescriptions?.[String(field.value)];
+}
+
+function makeNumberValuesSubmenu(
+  values: readonly number[],
+  current: number,
+  _valueDesc: string | undefined,
+  ctx: FieldRenderContext,
+): SubmenuFactory<number> {
+  return (done) => {
+    const items: SelectItem[] = values.map((v) => ({
+      value: String(v),
+      label: String(v),
+    }));
+    const list = new SelectList(items, Math.min(items.length, 12), getSelectListTheme());
+    const idx = items.findIndex((i) => Number(i.value) === current);
+    list.setSelectedIndex(idx >= 0 ? idx : 0);
+    list.onSelect = (item) => done(Number(item.value));
+    list.onCancel = () => done();
+
+    const component: Component = {
+      render(width: number): string[] {
+        const lines = [...list.render(width)];
+        lines.push("");
+        const hints = [
+          { key: "↑↓", label: "select" },
+          { key: "enter", label: "save" },
+          { key: "esc", label: "cancel" },
+        ];
+        const hintText = `  ${formatHintLine(hints, ctx.theme)}`;
+        return lines;
+      },
+      invalidate(): void {
+        list.invalidate();
+      },
+      handleInput(data: string): void {
+        list.handleInput(data);
+        ctx.tui.requestRender();
+      },
+    };
+    return component;
+  };
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Number
+// ─────────────────────────────────────────────────────────────────────
+
+export const numberRenderer: FieldRenderer<NumberField, number> = {
+  type: "number",
+  renderValue(row, args) {
+    if (row.field.disabled) {
+      const text = String(row.value);
+      return args.ctx.theme.fg("muted", text);
+    }
+    if (args.isEditing) {
+      const state = getEditState(args, row.field.key);
+      if (state) {
+        return args.ctx.theme.fg("accent", renderInlineEditValue(state));
+      }
+    }
+    const text = String(row.value);
+    return args.selected ? args.ctx.theme.fg("text", text) : args.ctx.theme.fg("muted", text);
+  },
+  hints(row, args) {
+    if (row.field.disabled) return [];
+    const { values, step } = row.field;
+    if (values && values.length > 4) return [{ key: "enter", label: "open list" }];
+    if (values || step !== undefined) {
+      return [
+        { key: "enter/space", label: "cycle" },
+        { key: "←/→", label: "prev/next" },
+      ];
+    }
+    return (stringRenderer.hints as unknown as FieldRenderer<NumberField, number>["hints"])(
+      row,
+      args,
+    );
+  },
+  handleKey(row, data, args) {
+    if (row.field.disabled) return {};
+    const { values, step } = row.field;
+
+    // Discrete values: cycle through (like enum) or open submenu
+    if (values && values.length > 0) {
+      if (matchesKey(data, "enter") || matchesKey(data, "return") || data === " ") {
+        if (values.length > 4) {
+          return {
+            consumed: true,
+            submenu: makeNumberValuesSubmenu(values, row.value, getValueDesc(row.field), args.ctx),
+          };
+        }
+        return { consumed: true, commit: nextValue(values, row.value) };
+      }
+      if (matchesKey(data, "left")) {
+        return { consumed: true, commit: prevValue(values, row.value) };
+      }
+      if (matchesKey(data, "right")) {
+        return { consumed: true, commit: nextValue(values, row.value) };
+      }
+      return {};
+    }
+
+    // Step-based: Enter/Space steps by step within [min, max], wrapping
+    if (step !== undefined) {
+      if (matchesKey(data, "enter") || matchesKey(data, "return") || data === " ") {
+        return { consumed: true, commit: stepUp(row.value, step, row.field.min, row.field.max) };
+      }
+      if (matchesKey(data, "left")) {
+        return { consumed: true, commit: stepDown(row.value, step, row.field.min, row.field.max) };
+      }
+      if (matchesKey(data, "right")) {
+        return { consumed: true, commit: stepUp(row.value, step, row.field.min, row.field.max) };
+      }
+      return {};
+    }
+
+    // Plain number: inline edit (current behavior)
+    return handleStringLikeKey<number>(row.field.key, String(row.value), data, args, (buffer) => {
+      const trimmed = buffer.trim();
+      if (trimmed === "") throw new Error("Expected a number");
+      const parsed = Number(trimmed);
+      if (!Number.isFinite(parsed)) throw new Error(`Not a number: '${buffer}'`);
+      if (row.field.integer && !Number.isInteger(parsed)) throw new Error("Expected an integer");
+      if (typeof row.field.min === "number" && parsed < row.field.min)
+        throw new Error(`Must be ≥ ${row.field.min}`);
+      if (typeof row.field.max === "number" && parsed > row.field.max)
+        throw new Error(`Must be ≤ ${row.field.max}`);
+      if (values && !values.includes(parsed))
+        throw new Error(`Must be one of: ${values.join(", ")}`);
+      return parsed;
+    });
+  },
+};
+
+// ─────────────────────────────────────────────────────────────────────
+// Shared edit-key state machine
+// ─────────────────────────────────────────────────────────────────────
+
+interface StringLikeArgs {
+  isEditing: boolean;
+  ctx: unknown;
+  setEditing: (v: boolean) => void;
+}
+
+function handleStringLikeKey<V>(
+  key: string,
+  initialBuffer: string,
+  data: string,
+  args: StringLikeArgs,
+  parse: (buffer: string) => V,
+): FieldKeyResult<V> {
+  // Defensive coercion: the caller may pass a non-string value (e.g. an
+  // array from config with configFilename + scope tabs). We coerce here
+  // so cursor/buffer arithmetic always works on a plain string.
+  const initialStr = String(initialBuffer);
+
+  if (!args.isEditing) {
+    if (matchesKey(data, "enter") || matchesKey(data, "return")) {
+      // Begin editing — seed the buffer from the current value.
+      setEditState(args, key, { buffer: initialStr, cursor: initialStr.length });
+      args.setEditing(true);
+      return { consumed: true };
+    }
+    return {};
+  }
+
+  // Editing mode: Enter commits, Esc cancels.
+  if (matchesKey(data, "enter") || matchesKey(data, "return")) {
+    const state = getEditState(args, key);
+    if (!state) {
+      args.setEditing(false);
+      return { consumed: true };
+    }
+    try {
+      const value = parse(state.buffer);
+      setEditState(args, key, undefined);
+      args.setEditing(false);
+      return { consumed: true, commit: value };
+    } catch (error) {
+      // Re-throw so the modal can surface via ctx.ui.notify; keep
+      // editing mode active so the user can correct the value.
+      throw error;
+    }
+  }
+  if (matchesKey(data, "escape")) {
+    setEditState(args, key, undefined);
+    args.setEditing(false);
+    return { consumed: true };
+  }
+
+  const state = getEditState(args, key);
+  if (!state) {
+    // Defensive: if the registry got out of sync, fall back to a
+    // fresh buffer so the user isn't stuck in editing mode with no
+    // way to type.
+    setEditState(args, key, { buffer: initialStr, cursor: initialStr.length });
+    return { consumed: true };
+  }
+  if (handleInlineEditInput(state, data)) {
+    return { consumed: true };
+  }
+  return { consumed: true }; // swallow stray keys while editing
+}

--- a/src/pi-base/settings/fields/string.ts
+++ b/src/pi-base/settings/fields/string.ts
@@ -24,7 +24,6 @@ import { matchesKey, type Component, type SelectItem } from "@earendil-works/pi-
 import { SelectList } from "@earendil-works/pi-tui";
 import { getSelectListTheme } from "@earendil-works/pi-coding-agent";
 import { handleInlineEditInput, renderInlineEditValue, type InlineEditState } from "../inline-edit";
-import { formatHintLine } from "../frame";
 import type {
   FieldKeyResult,
   FieldRenderer,
@@ -237,12 +236,6 @@ function makeNumberValuesSubmenu(
       render(width: number): string[] {
         const lines = [...list.render(width)];
         lines.push("");
-        const hints = [
-          { key: "↑↓", label: "select" },
-          { key: "enter", label: "save" },
-          { key: "esc", label: "cancel" },
-        ];
-        const hintText = `  ${formatHintLine(hints, ctx.theme)}`;
         return lines;
       },
       invalidate(): void {

--- a/src/pi-base/settings/fields/text.ts
+++ b/src/pi-base/settings/fields/text.ts
@@ -1,0 +1,112 @@
+/**
+ * Renderer for `type: "text"` rows — multiline string values.
+ *
+ * Editing opens a submenu with a full multiline `Editor`.
+ * - Ctrl+S saves and closes.
+ * - Escape cancels and closes.
+ * - All other input (Enter, Shift+Enter, arrows, typing) is handled by
+ *   the Editor directly.
+ */
+
+import { Editor, type Component } from "@earendil-works/pi-tui";
+import { getSelectListTheme } from "@earendil-works/pi-coding-agent";
+import type { EditorTheme } from "@earendil-works/pi-tui";
+import { truncateToWidth } from "@earendil-works/pi-tui";
+import type {
+  FieldRenderer,
+  SubmenuFactory,
+  TextField,
+  FieldRenderContext,
+  FieldKeyHint,
+} from "../types";
+import { formatHintLine } from "../frame";
+
+export const textRenderer: FieldRenderer<TextField, string> = {
+  type: "text",
+  renderValue(row, { selected, ctx }) {
+    const display = formatTextPreview(row.value);
+    if (row.field.disabled) {
+      return ctx.theme.fg("muted", display);
+    }
+    return ctx.theme.fg(selected ? "accent" : "muted", display);
+  },
+  hints(row): FieldKeyHint[] {
+    if (row.field.disabled) return [];
+    return [{ key: "enter", label: "open editor" }];
+  },
+  handleKey(row, data, { ctx }) {
+    if (row.field.disabled) return {};
+    if (data === "\r" || data === "\n") {
+      return {
+        consumed: true,
+        submenu: makeTextSubmenu(row.value, ctx),
+      };
+    }
+    return {};
+  },
+};
+
+function formatTextPreview(value: string): string {
+  const lineCount = value.split("\n").length;
+  const preview = value.replace(/\s+/g, " ").trim();
+  const quoted = preview ? JSON.stringify(preview) : '""';
+  const suffix = lineCount > 1 ? ` (${lineCount} lines)` : "";
+  return `${truncateToWidth(quoted, 48, "...")}${suffix}`;
+}
+
+function makeTextSubmenu(current: string, ctx: FieldRenderContext): SubmenuFactory<string> {
+  return (done) => {
+    const editor = new Editor(
+      ctx.tui,
+      {
+        borderColor: (s: string) => ctx.theme.fg("muted", s),
+        selectList: getSelectListTheme(),
+      } as EditorTheme,
+      {
+        paddingX: 0,
+      },
+    );
+    editor.setText(current);
+    editor.focused = true;
+    editor.disableSubmit = true;
+    editor.onChange = () => ctx.tui.requestRender();
+
+    const component: Component = {
+      render(_width: number): string[] {
+        const lines = editor.render(80);
+        lines.push("");
+        lines.push(
+          ctx.theme.fg(
+            "dim",
+            formatHintLine(
+              [
+                { key: "ctrl+s", label: "save" },
+                { key: "esc", label: "cancel" },
+              ],
+              ctx.theme,
+            ),
+          ),
+        );
+        return lines;
+      },
+      invalidate(): void {
+        editor.invalidate();
+      },
+      handleInput(data: string): void {
+        if (data === "\x13") {
+          // Ctrl+S
+          done(editor.getExpandedText());
+          return;
+        }
+        if (data === "\x1b") {
+          // Escape
+          done();
+          return;
+        }
+        editor.handleInput(data);
+        ctx.tui.requestRender();
+      },
+    };
+    return component;
+  };
+}

--- a/src/pi-base/settings/frame.ts
+++ b/src/pi-base/settings/frame.ts
@@ -1,0 +1,183 @@
+/**
+ * Rounded-light frame helpers for the settings modal — and for any
+ * future overlay in this package that wants the same look.
+ *
+ * Visual:
+ *
+ *     ╭── Title ──────────────────────╮
+ *     │                                │
+ *     │   Muted              off       │
+ *     │   Voice              Umbriel   │
+ *     │                                │
+ *     ╰────────────────────────────────╯
+ *
+ * The frame draws:
+ *   - A single-line top border with an inline title pill (`╭── Title ──╮`).
+ *     Title text is coloured via the host theme's `accent` foreground.
+ *   - A bottom border closing with `╰─╯`.
+ *   - Vertical sides as `│` separators.
+ *   - `paddingY` blank rows above and below the body, plus `paddingX`
+ *     spaces left and right of every body row.
+ *   - Optional row-count cap (`fixedInnerRows`) so a too-tall body is
+ *     truncated with a `↓ N more line(s)` indicator instead of overflowing
+ *     the popup.
+ *
+ * All helpers are width-aware: every output line is right-truncated to
+ * `width` columns using pi-tui's `truncateToWidth` so they never escape
+ * the overlay rectangle.
+ */
+
+import type { Theme } from "@earendil-works/pi-coding-agent";
+import { truncateToWidth, visibleWidth, wrapTextWithAnsi } from "@earendil-works/pi-tui";
+
+/** Default horizontal padding inside the frame, in columns. */
+export const DEFAULT_PADDING_X = 2;
+/** Default vertical padding inside the frame, in rows. */
+export const DEFAULT_PADDING_Y = 1;
+/** Total vertical rows consumed by the frame chrome (top + bottom + 2× padY). */
+export const FRAME_VERTICAL_CHROME = 2 + DEFAULT_PADDING_Y * 2;
+
+export interface FrameOptions {
+  /** Inline title in the top border. Truncated with `…` when too wide. */
+  title?: string;
+  /** Inner padding columns (left and right). Defaults to {@link DEFAULT_PADDING_X}. */
+  paddingX?: number;
+  /** Inner padding rows (top and bottom). Defaults to {@link DEFAULT_PADDING_Y}. */
+  paddingY?: number;
+  /**
+   * If set, the body is forced to exactly this many inner rows. Excess
+   * lines are replaced with a `↓ N more` indicator at the bottom; missing
+   * lines are padded with blank rows so the overlay never visually shrinks
+   * mid-session.
+   */
+  fixedInnerRows?: number;
+}
+
+/** Width available to body content, given a frame's outer `width`. */
+export function frameContentWidth(width: number, paddingX: number = DEFAULT_PADDING_X): number {
+  return Math.max(1, width - 2 - paddingX * 2);
+}
+
+/** Right-pad a (possibly ANSI-coloured) string to exactly `width` columns. */
+export function pad(text: string, width: number): string {
+  const truncated = truncateToWidth(text, width, "");
+  return `${truncated}${" ".repeat(Math.max(0, width - visibleWidth(truncated)))}`;
+}
+
+/**
+ * Wrap `line` to fit `width` columns. Hard newlines split the line first;
+ * each segment is then word-wrapped (ANSI-aware via pi-tui's helper) and
+ * finally truncated as a defence-in-depth against pathological cases.
+ */
+export function wrapLine(line: string, width: number): string[] {
+  const safeWidth = Math.max(1, width);
+  const normalized = String(line ?? "").replace(/\t/g, "  ");
+  const wrapped = normalized.split(/\r?\n/).flatMap((part) => {
+    const rows = wrapTextWithAnsi(part, safeWidth);
+    return rows.length > 0 ? rows : [""];
+  });
+  return wrapped.map((part) => truncateToWidth(part, safeWidth, ""));
+}
+
+/** Render a single horizontal divider line, themed in `dim`. */
+export function divider(width: number, theme: Theme): string {
+  return theme.fg("dim", "─".repeat(Math.max(1, width)));
+}
+
+/** One key-hint pair as rendered in the modal's footer. */
+export interface KeyHint {
+  key: string;
+  label: string;
+}
+
+/**
+ * Format a list of key hints as a single line: each `key` rendered in
+ * the host theme's `accent` colour and each `label` in `dim`, joined
+ * by a dim middle-dot (`·`). Used by both the main settings modal
+ * footer and any submenu that wants matching highlighting.
+ *
+ * Returns the raw composed string — caller is responsible for
+ * truncating / wrapping if needed.
+ */
+export function formatHintLine(hints: KeyHint[], theme: Theme): string {
+  return hints
+    .map((h) => `${theme.fg("accent", h.key)} ${theme.fg("dim", h.label)}`)
+    .join(theme.fg("dim", " · "));
+}
+
+/**
+ * Wrap `lines` in a rounded-light frame. The top border embeds an
+ * optional title pill rendered in the host theme's `accent` colour; the
+ * border itself is themed in `borderAccent` so it stands out from chat
+ * but blends with the user's chosen palette.
+ *
+ * The output is exactly the right shape to hand to `ctx.ui.custom`'s
+ * overlay component — every line is exactly `width` columns wide.
+ */
+export function frame(
+  lines: string[],
+  width: number,
+  theme: Theme,
+  options: FrameOptions = {},
+): string[] {
+  const paddingX = options.paddingX ?? DEFAULT_PADDING_X;
+  const paddingY = options.paddingY ?? DEFAULT_PADDING_Y;
+  const inner = Math.max(1, width - 2);
+  const contentWidth = frameContentWidth(width, paddingX);
+  const border = (s: string) => theme.fg("borderAccent", s);
+
+  let body = lines;
+  if (options.fixedInnerRows !== undefined && body.length > options.fixedInnerRows) {
+    const hidden = body.length - options.fixedInnerRows + 1;
+    body = [
+      ...body.slice(0, Math.max(0, options.fixedInnerRows - 1)),
+      theme.fg("dim", `↓ ${hidden} more line(s)`),
+    ].slice(0, options.fixedInnerRows);
+  }
+
+  const blank = `${border("│")}${" ".repeat(inner)}${border("│")}`;
+  const top = (): string => {
+    if (!options.title) return `${border("╭")}${border("─".repeat(inner))}${border("╮")}`;
+    // Title pill: `── <title> ──`, truncated to fit; surrounded by border
+    // dashes on both sides so the pill always reaches the corners.
+    const titlePlain = ` ${truncateToWidth(options.title, Math.max(1, inner - 4), "…")} `;
+    const titleVisible = visibleWidth(titlePlain);
+    const leftDash = 2;
+    const rightDash = Math.max(1, inner - leftDash - titleVisible);
+    return (
+      `${border("╭")}${border("─".repeat(leftDash))}` +
+      `${theme.fg("accent", theme.bold(titlePlain))}` +
+      `${border("─".repeat(rightDash))}${border("╮")}`
+    );
+  };
+
+  const out: string[] = [top()];
+  for (let i = 0; i < paddingY; i += 1) out.push(blank);
+  for (const line of body) {
+    out.push(
+      `${border("│")}${" ".repeat(paddingX)}${pad(line, contentWidth)}${" ".repeat(paddingX)}${border("│")}`,
+    );
+  }
+  for (let i = 0; i < paddingY; i += 1) out.push(blank);
+  out.push(`${border("╰")}${border("─".repeat(inner))}${border("╯")}`);
+  return out.map((line) => truncateToWidth(line, width, ""));
+}
+
+/**
+ * Compute a sensible inner-row count given the terminal height and a
+ * preferred maximum. Mirrors the `responsiveInnerRows` math from
+ * `extension-manager.ts` so popups shrink gracefully on short terminals
+ * instead of clipping past the bottom edge.
+ */
+export function responsiveInnerRows(
+  terminalRows: number,
+  preferred: number,
+  minimum = 12,
+  ratio = 0.85,
+): number {
+  const available = Math.max(
+    minimum + FRAME_VERTICAL_CHROME,
+    Math.floor(Math.max(1, terminalRows) * ratio),
+  );
+  return Math.max(minimum, Math.min(preferred, available - FRAME_VERTICAL_CHROME));
+}

--- a/src/pi-base/settings/index.ts
+++ b/src/pi-base/settings/index.ts
@@ -1,0 +1,75 @@
+/**
+ * @k0valik/pi-base/settings — public entry point for the settings
+ * modal feature (vendored from wierdbytes/pi-common/settings).
+ *
+ * High-level: `openSettingsModal(ctx, opts)` opens a centered popup,
+ * persists changes via `opts.onChange`, and resolves on close.
+ *
+ * Mid-level: `createSettingsModal(ctx, opts)` returns a `ctx.ui.custom`
+ * factory for callers that manage their own overlay lifecycle.
+ *
+ * Low-level: `createSettingsModalBody`, `frame`, `inline-edit` helpers,
+ * built-in `RENDERERS` map, and the full `Field` discriminated union
+ * are all exported for callers building bespoke layouts on top of the
+ * same primitives.
+ */
+
+export { createSettingsModal, openSettingsModal } from "./modal";
+
+export { createSettingsModalBody } from "./body";
+
+export {
+  divider,
+  formatHintLine,
+  frame,
+  frameContentWidth,
+  pad,
+  responsiveInnerRows,
+  wrapLine,
+  type FrameOptions,
+  type KeyHint,
+} from "./frame";
+
+export {
+  clampInlineCursor,
+  deleteWordBackward,
+  handleInlineEditInput,
+  insertInlineText,
+  renderInlineEditValue,
+  type InlineEditState,
+} from "./inline-edit";
+
+export { RENDERERS } from "./fields/index";
+
+export { validateFieldValue } from "./validate-field";
+
+export type {
+  ActionField,
+  BooleanField,
+  CustomField,
+  CustomFieldRenderArgs,
+  CustomFieldSubmenuArgs,
+  EnumField,
+  Field,
+  FieldBase,
+  FieldKeyHint,
+  FieldKeyResult,
+  FieldRenderContext,
+  FieldRenderer,
+  FieldRow,
+  ModelField,
+  ModelOption,
+  ModelValue,
+  NumberField,
+  PathField,
+  SecretField,
+  SettingsModalFactory,
+  SettingsModalOptions,
+  SettingsTheme,
+  StringField,
+  SubmenuFactory,
+  Tab,
+  TextField,
+  ValueOfField,
+  VisibilityContext,
+} from "./types";

--- a/src/pi-base/settings/inline-edit.ts
+++ b/src/pi-base/settings/inline-edit.ts
@@ -24,7 +24,7 @@
  * input would be the wrong kind of input to this editor anyway.
  */
 
-import { matchesKey } from "@earendil-works/pi-tui";
+import { matchesKey, decodeKittyPrintable } from "@earendil-works/pi-tui";
 
 /** Shared yank buffer for storing killed text. */
 let yankBuffer = "";
@@ -153,7 +153,8 @@ export function deleteInlineRange(editing: InlineEditState, start: number, end: 
 
 /** Heuristic: is `data` a single, plain printable input character? */
 export function isPlainSearchInput(data: string): boolean {
-  return data.length === 1 && data >= " " && data !== "\x7f";
+  const decoded = decodeKittyPrintable(data) ?? data;
+  return decoded.length === 1 && decoded >= " " && decoded !== "\x7f";
 }
 
 /**

--- a/src/pi-base/settings/inline-edit.ts
+++ b/src/pi-base/settings/inline-edit.ts
@@ -1,0 +1,282 @@
+/**
+ * Inline string-editor state machine for single-line value editing inside
+ * settings rows.
+ *
+ * Ported from the helpers in vstack's `extension-manager.ts`. This file is
+ * **pure logic** — no terminal access, no theme, no rendering — so it can
+ * be exercised in `bun test` / `vitest` without a TUI.
+ *
+ * Key shape: a tiny `{ buffer, cursor }` struct mutated in place by the
+ * helper functions. `cursor` is a **code-unit** index into `buffer` (so
+ * `buffer.slice(0, cursor)` is always safe), but every cursor-moving
+ * helper internally walks **code points** so multi-unit characters
+ * (CJK, emoji, regional indicators) move atomically — pressing `←` once
+ * over a 🌍 jumps two code units, not one.
+ *
+ * Word-jump uses the same three-class scheme as most readline-derived
+ * editors:
+ *   - `space`: `\s` (whitespace);
+ *   - `word`:  `[A-Za-z0-9_]` (identifier-ish);
+ *   - `punct`: everything else.
+ *
+ * Tabs / hard-newlines are intentionally not special-cased — settings
+ * values are single-line strings, and any `\n` arriving from terminal
+ * input would be the wrong kind of input to this editor anyway.
+ */
+
+import { matchesKey } from "@earendil-works/pi-tui";
+
+/** Shared yank buffer for storing killed text. */
+let yankBuffer = "";
+
+/** Retrieve the current content of the yank buffer. */
+export function getInlineYankBuffer(): string {
+  return yankBuffer;
+}
+
+/** Set the content of the yank buffer. */
+export function setInlineYankBuffer(val: string): void {
+  yankBuffer = val;
+}
+
+/** Mutable cursor state. `cursor` is a code-unit offset into `buffer`. */
+export interface InlineEditState {
+  buffer: string;
+  cursor: number;
+}
+
+interface InlineEditChar {
+  ch: string;
+  /** Inclusive code-unit start of this char in the source buffer. */
+  start: number;
+  /** Exclusive code-unit end (==start of the next char). */
+  end: number;
+}
+
+/** Decompose `text` into its sequence of code-point chars with their
+ *  code-unit ranges. Used to keep the cursor on a code-point boundary. */
+export function inlineEditChars(text: string): InlineEditChar[] {
+  const out: InlineEditChar[] = [];
+  let offset = 0;
+  for (const ch of text) {
+    const start = offset;
+    offset += ch.length;
+    out.push({ ch, start, end: offset });
+  }
+  return out;
+}
+
+/** Force `cursor` back into `[0, buffer.length]` after a buffer mutation. */
+export function clampInlineCursor(editing: InlineEditState): void {
+  editing.cursor = Math.max(0, Math.min(editing.cursor, editing.buffer.length));
+}
+
+/**
+ * Convert a code-unit offset into the index of the char immediately to
+ * the right of the cursor. A cursor sitting on a char boundary returns
+ * the index of the char it is just before. A cursor past the end returns
+ * `chars.length`.
+ */
+export function codeUnitToCharIndex(chars: InlineEditChar[], cursor: number): number {
+  let index = 0;
+  while (index < chars.length && chars[index]!.end <= cursor) index += 1;
+  return index;
+}
+
+/** Inverse of `codeUnitToCharIndex`. */
+export function charIndexToCodeUnit(
+  chars: InlineEditChar[],
+  index: number,
+  textLength: number,
+): number {
+  if (index <= 0) return 0;
+  if (index >= chars.length) return textLength;
+  return chars[index]!.start;
+}
+
+/** Three-class word/word-boundary classifier used by word-jump helpers. */
+export function inlineCharKind(ch: string): "space" | "word" | "punct" {
+  if (/\s/u.test(ch)) return "space";
+  if (/[A-Za-z0-9_]/.test(ch)) return "word";
+  return "punct";
+}
+
+/** Move the cursor by `delta` code-points (negative = left). */
+export function moveInlineCursorByChars(editing: InlineEditState, delta: number): void {
+  const chars = inlineEditChars(editing.buffer);
+  const index = codeUnitToCharIndex(chars, editing.cursor);
+  editing.cursor = charIndexToCodeUnit(chars, index + delta, editing.buffer.length);
+}
+
+/** Skip whitespace then a contiguous run of the same char-kind to the left. */
+export function moveInlineCursorWordLeft(editing: InlineEditState): void {
+  const chars = inlineEditChars(editing.buffer);
+  let index = codeUnitToCharIndex(chars, editing.cursor);
+  while (index > 0 && inlineCharKind(chars[index - 1]!.ch) === "space") index -= 1;
+  if (index <= 0) {
+    editing.cursor = 0;
+    return;
+  }
+  const kind = inlineCharKind(chars[index - 1]!.ch);
+  while (index > 0 && inlineCharKind(chars[index - 1]!.ch) === kind) index -= 1;
+  editing.cursor = charIndexToCodeUnit(chars, index, editing.buffer.length);
+}
+
+/** Skip whitespace then a contiguous run of the same char-kind to the right. */
+export function moveInlineCursorWordRight(editing: InlineEditState): void {
+  const chars = inlineEditChars(editing.buffer);
+  let index = codeUnitToCharIndex(chars, editing.cursor);
+  while (index < chars.length && inlineCharKind(chars[index]!.ch) === "space") index += 1;
+  if (index >= chars.length) {
+    editing.cursor = editing.buffer.length;
+    return;
+  }
+  const kind = inlineCharKind(chars[index]!.ch);
+  while (index < chars.length && inlineCharKind(chars[index]!.ch) === kind) index += 1;
+  editing.cursor = charIndexToCodeUnit(chars, index, editing.buffer.length);
+}
+
+/** Insert `text` at the cursor and advance past it. */
+export function insertInlineText(editing: InlineEditState, text: string): void {
+  clampInlineCursor(editing);
+  editing.buffer = `${editing.buffer.slice(0, editing.cursor)}${text}${editing.buffer.slice(editing.cursor)}`;
+  editing.cursor += text.length;
+}
+
+/** Delete the half-open `[start, end)` code-unit range; cursor lands at `start`. */
+export function deleteInlineRange(editing: InlineEditState, start: number, end: number): void {
+  const safeStart = Math.max(0, Math.min(start, editing.buffer.length));
+  const safeEnd = Math.max(safeStart, Math.min(end, editing.buffer.length));
+  editing.buffer = `${editing.buffer.slice(0, safeStart)}${editing.buffer.slice(safeEnd)}`;
+  editing.cursor = safeStart;
+}
+
+/** Heuristic: is `data` a single, plain printable input character? */
+export function isPlainSearchInput(data: string): boolean {
+  return data.length === 1 && data >= " " && data !== "\x7f";
+}
+
+/**
+ * Dispatch a raw terminal input string to the editor. Returns true when
+ * the input was consumed (caller should re-render); false when it didn't
+ * match any inline-edit shortcut (caller may handle it as a hot-key).
+ */
+export function handleInlineEditInput(editing: InlineEditState, data: string): boolean {
+  clampInlineCursor(editing);
+  if (matchesKey(data, "left") || matchesKey(data, "ctrl+b")) {
+    moveInlineCursorByChars(editing, -1);
+    return true;
+  }
+  if (matchesKey(data, "right") || matchesKey(data, "ctrl+f")) {
+    moveInlineCursorByChars(editing, 1);
+    return true;
+  }
+  if (matchesKey(data, "alt+left") || matchesKey(data, "ctrl+left") || matchesKey(data, "alt+b")) {
+    moveInlineCursorWordLeft(editing);
+    return true;
+  }
+  if (
+    matchesKey(data, "alt+right") ||
+    matchesKey(data, "ctrl+right") ||
+    matchesKey(data, "alt+f")
+  ) {
+    moveInlineCursorWordRight(editing);
+    return true;
+  }
+  if (matchesKey(data, "home") || matchesKey(data, "ctrl+a")) {
+    editing.cursor = 0;
+    return true;
+  }
+  if (matchesKey(data, "end") || matchesKey(data, "ctrl+e")) {
+    editing.cursor = editing.buffer.length;
+    return true;
+  }
+  if (matchesKey(data, "backspace") || matchesKey(data, "ctrl+h")) {
+    const before = editing.cursor;
+    moveInlineCursorByChars(editing, -1);
+    deleteInlineRange(editing, editing.cursor, before);
+    return true;
+  }
+  if (matchesKey(data, "delete") || matchesKey(data, "ctrl+d")) {
+    const start = editing.cursor;
+    moveInlineCursorByChars(editing, 1);
+    deleteInlineRange(editing, start, editing.cursor);
+    return true;
+  }
+  if (matchesKey(data, "ctrl+u")) {
+    editing.buffer = "";
+    editing.cursor = 0;
+    return true;
+  }
+  if (matchesKey(data, "ctrl+w")) {
+    const current = editing.cursor;
+    moveInlineCursorWordLeft(editing);
+    const target = editing.cursor;
+    const killedText = editing.buffer.slice(target, current);
+    if (killedText) {
+      yankBuffer = killedText;
+    }
+    deleteInlineRange(editing, target, current);
+    return true;
+  }
+  if (matchesKey(data, "alt+d")) {
+    const current = editing.cursor;
+    moveInlineCursorWordRight(editing);
+    const target = editing.cursor;
+    const killedText = editing.buffer.slice(current, target);
+    if (killedText) {
+      yankBuffer = killedText;
+    }
+    deleteInlineRange(editing, current, target);
+    return true;
+  }
+  if (matchesKey(data, "ctrl+k")) {
+    const killedText = editing.buffer.slice(editing.cursor);
+    if (killedText) {
+      yankBuffer = killedText;
+    }
+    deleteInlineRange(editing, editing.cursor, editing.buffer.length);
+    return true;
+  }
+  if (matchesKey(data, "ctrl+y")) {
+    if (yankBuffer) {
+      insertInlineText(editing, yankBuffer);
+    }
+    return true;
+  }
+  if (isPlainSearchInput(data)) {
+    insertInlineText(editing, data);
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Render the buffer with a `█` block at the cursor position. Suitable
+ * for embedding in a one-line settings row.
+ */
+export function renderInlineEditValue(editing: InlineEditState): string {
+  clampInlineCursor(editing);
+  return `${editing.buffer.slice(0, editing.cursor)}█${editing.buffer.slice(editing.cursor)}`;
+}
+
+/**
+ * Word-deletion helper to delete a word backward from the end of a string.
+ */
+export function deleteWordBackward(text: string): string {
+  let i = text.length;
+  while (i > 0 && /\s/.test(text[i - 1]!)) {
+    i--;
+  }
+  if (i === 0) return "";
+  const charKind = (ch: string) => {
+    if (/\s/.test(ch)) return "space";
+    if (/[A-Za-z0-9_]/.test(ch)) return "word";
+    return "punct";
+  };
+  const kind = charKind(text[i - 1]!);
+  while (i > 0 && charKind(text[i - 1]!) === kind) {
+    i--;
+  }
+  return text.slice(0, i);
+}

--- a/src/pi-base/settings/modal.ts
+++ b/src/pi-base/settings/modal.ts
@@ -1,0 +1,129 @@
+/**
+ * `createSettingsModal` and `openSettingsModal` — the public modal
+ * entry points. Both wrap `createSettingsModalBody` and shape it for
+ * `ctx.ui.custom`.
+ */
+
+import { join } from "node:path";
+import type { ExtensionContext, Theme } from "@earendil-works/pi-coding-agent";
+import type { Component, KeybindingsManager, OverlayOptions, TUI } from "@earendil-works/pi-tui";
+import { createSettingsModalBody } from "./body";
+import { getExtensionsDir, readConfig, writeConfig, deleteConfig } from "../config.ts";
+import type { Field, SettingsModalFactory, SettingsModalOptions } from "./types";
+
+const DEFAULT_OVERLAY: OverlayOptions = {
+  anchor: "center",
+  width: "92%",
+  maxHeight: "85%",
+};
+
+// Singleton guard: track one open modal per ExtensionContext.
+// WeakMap so entries are GC'd when the context is no longer referenced.
+const openModals = new WeakMap<ExtensionContext, (result: void) => void>();
+
+/**
+ * Build a `ctx.ui.custom`-compatible factory for the settings modal.
+ * Useful for callers that already manage their own overlay lifecycle.
+ *
+ * The returned factory captures `ctx` from `openSettingsModal`'s call
+ * site — when used standalone, the caller is expected to invoke it via
+ * `ctx.ui.custom(createSettingsModal(opts), …)`, and pi will pass the
+ * tui/theme/keybindings/done arguments at mount time.
+ */
+export function createSettingsModal<F extends Field>(
+  ctx: ExtensionContext,
+  options: SettingsModalOptions<F>,
+): SettingsModalFactory<void> {
+  return (
+    tui: TUI,
+    theme: Theme,
+    _keybindings: KeybindingsManager,
+    done: (result: void) => void,
+  ): Component => {
+    const close = (): void => {
+      try {
+        options.onClose?.();
+      } catch {
+        // Caller-supplied onClose must not break the modal teardown.
+      }
+      openModals.delete(ctx);
+      done();
+    };
+
+    // Singleton guard: if a modal is already open on this ctx, close
+    // it before opening the new one. This prevents two in-memory
+    // buffers racing to write.
+    const existing = openModals.get(ctx);
+    if (existing) {
+      try {
+        existing(void 0);
+      } catch {
+        // Defensive: existing modal's close must not break the new one.
+      }
+    }
+    openModals.set(ctx, close);
+
+    // Auto-inject default scope action handlers when configFilename is
+    // set but the callbacks are absent. This ensures that any modal using
+    // scope tabs always has reset/delete actions without requiring every
+    // caller to supply them explicitly.
+    if (options.configFilename) {
+      if (!options.onResetScope) {
+        options.onResetScope = async (scope: "global" | "project") => {
+          const dir = scope === "project" ? join(ctx.cwd, ".pi") : (options.globalConfigDir ?? getExtensionsDir());
+          const knownKeys = new Set(Object.keys(options.defaults ?? {}));
+          const existing = readConfig<Record<string, unknown>>(options.configFilename!, dir);
+          const unknownKeys: Record<string, unknown> = {};
+          if (existing && typeof existing === "object") {
+            for (const [key, val] of Object.entries(existing)) {
+              if (!knownKeys.has(key)) unknownKeys[key] = val;
+            }
+          }
+          if (Object.keys(unknownKeys).length > 0) {
+            writeConfig(options.configFilename!, unknownKeys, dir);
+          } else {
+            deleteConfig(options.configFilename!, dir);
+          }
+        };
+      }
+      if (!options.onDeleteScope) {
+        options.onDeleteScope = async (scope: "global" | "project") => {
+          const dir = scope === "project" ? join(ctx.cwd, ".pi") : (options.globalConfigDir ?? getExtensionsDir());
+          deleteConfig(options.configFilename!, dir);
+        };
+      }
+    }
+
+    return createSettingsModalBody<F>(options, { tui, theme, ctx, close });
+  };
+}
+
+/**
+ * Convenience: open a settings modal as a centered overlay and resolve
+ * when the user closes it. This is the **happy-path** entry point most
+ * callers want.
+ *
+ * Defaults: anchor center, width 92%, maxHeight 85%. Override via
+ * `options.overlayOptions`.
+ *
+ * @example
+ * ```ts
+ * await openSettingsModal(ctx, {
+ *   title: "@k0valik/pi-voice",
+ *   fields: [
+ *     { key: "muted", type: "boolean", label: "Muted", value: cfg.muted },
+ *   ],
+ *   onChange: (key, value) => { cfg[key] = value; saveConfig(cfg); },
+ * });
+ * ```
+ */
+export async function openSettingsModal<F extends Field>(
+  ctx: ExtensionContext,
+  options: SettingsModalOptions<F>,
+): Promise<void> {
+  const overlayOptions = options.overlayOptions ?? DEFAULT_OVERLAY;
+  await ctx.ui.custom<void>(createSettingsModal(ctx, options), {
+    overlay: true,
+    overlayOptions,
+  });
+}

--- a/src/pi-base/settings/types.ts
+++ b/src/pi-base/settings/types.ts
@@ -1,0 +1,478 @@
+/**
+ * Public types for the `@k0valik/pi-base` settings modal (vendored from wierdbytes/pi-common).
+ *
+ * The modal accepts a flat array of `Field`s (or, when `tabs` is set,
+ * one such array per tab) and a single `onChange` callback. Every
+ * built-in field is a discriminated-union variant of `Field`. Callers
+ * needing more exotic widgets can drop down to the `custom` variant and
+ * implement a `FieldRenderer` directly.
+ *
+ * Persistence is intentionally out of scope here — the caller passes
+ * each field's current value at open time and decides what to do in
+ * `onChange`. Re-opening the modal re-reads the values.
+ */
+
+import type { ExtensionContext, Theme } from "@earendil-works/pi-coding-agent";
+import type { Api, Model, ModelThinkingLevel } from "@earendil-works/pi-ai";
+import type { Component, KeybindingsManager, OverlayOptions, TUI } from "@earendil-works/pi-tui";
+
+// ─────────────────────────────────────────────────────────────────────
+// Visibility context for visibleWhen
+// ─────────────────────────────────────────────────────────────────────
+
+export interface VisibilityContext {
+  get(key: string): unknown;
+  getScoped(key: string, scope?: string): unknown;
+  scope: string;
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Field discriminated union
+// ─────────────────────────────────────────────────────────────────────
+
+/** Common shape for every field variant. */
+export interface FieldBase {
+  /** Stable id; passed back as the first argument to `onChange`. */
+  key: string;
+  /** Left-hand label shown in the row. */
+  label: string;
+  /** Optional help text rendered under the row when it's focused. */
+  description?: string;
+  /** Optional tab id this field belongs to (when the modal uses tabs). */
+  tab?: string;
+  /** Disable interactions; the row still renders but Enter is a no-op. */
+  disabled?: boolean;
+  /** Optional default value used when resetting the field. */
+  default?: unknown;
+  /**
+   * Opt-in to alt+↑ / alt+↓ reorder. When set, the modal swaps this
+   * row with the immediate neighbour (in `visibleRowIndices` order)
+   * if and only if that neighbour is also reorderable. The caller's
+   * `SettingsModalOptions.onReorder` is invoked after the swap so it
+   * can mirror the change into persistent state. Non-reorderable
+   * neighbours block the move (no skip-and-swap), so callers should
+   * group reorderable rows contiguously inside a tab.
+   */
+  reorderable?: boolean;
+  /**
+   * Visual nesting level. Rows with `depth > 0` are indented by
+   * `depth * 2` spaces. Useful for grouping related fields under a
+   * parent concept without a nested schema.
+   */
+  depth?: number;
+  /**
+   * Conditionally hide this field in the settings editor. The callback
+   * receives a context object that allows reading sibling values and
+   * the current scope.
+   *
+   * Hidden values persist in the config file until explicitly cleared
+   * — this is purely a UI affordance, not a data filter.
+   */
+  visibleWhen?: (ctx: VisibilityContext) => boolean;
+  /**
+   * Override the row's label color. The default behaviour is
+   * `selected ? "text" : "muted"` — fields opt-in here to express
+   * "this row is active" (always rendered with the bright `text`
+   * color) or "this row is disabled" (always muted, even when
+   * focused) regardless of focus state.
+   *
+   * Accepts a boolean (`true` ⇒ muted, `false` ⇒ active) or a
+   * thunk re-evaluated on every render so the color can track live
+   * external state (e.g. a per-block visibility toggle that updates
+   * via `onChange`).
+   *
+   * Unset means "follow default".
+   */
+  dim?: boolean | (() => boolean);
+  /**
+   * When true, changes to this field require the user to run `/reload`
+   * for the new value to take effect. The modal aggregates dirty
+   * `requiresReload` fields and shows a hint in the confirm prompt.
+   */
+  requiresReload?: boolean;
+}
+
+export interface BooleanField extends FieldBase {
+  type: "boolean";
+  value: boolean;
+  default?: boolean;
+  /** Per-value help text, keyed by "on" or "off". */
+  valueDescriptions?: Partial<Record<"on" | "off", string>>;
+}
+
+export interface EnumField<T extends string = string> extends FieldBase {
+  type: "enum";
+  value: T;
+  options: readonly T[];
+  /** Long label shown in the cycle / submenu (defaults to `value`). */
+  optionLabels?: Partial<Record<T, string>>;
+  /**
+   * When `options.length` is greater than this, Enter opens a
+   * `SelectList` submenu instead of cycling. Default `4`.
+   */
+  cycleThreshold?: number;
+  /**
+   * Per-value help text shown in the description area when this
+   * row is focused. Keyed by option value.
+   */
+  valueDescriptions?: Partial<Record<T, string>>;
+  /**
+   * When true, Enter always opens a filterable list submenu (even
+   * for short option lists). The user can type to fuzzy-search
+   * options instead of cycling through them one by one.
+   * Default `false`.
+   */
+  search?: boolean;
+  default?: T;
+}
+
+export interface StringField extends FieldBase {
+  type: "string";
+  value: string;
+  /** Optional placeholder shown when the value is empty. */
+  placeholder?: string;
+  default?: string;
+}
+
+export interface TextField extends FieldBase {
+  type: "text";
+  value: string;
+  /** Optional placeholder shown when the value is empty. */
+  placeholder?: string;
+  default?: string;
+}
+
+export interface NumberField extends FieldBase {
+  type: "number";
+  value: number;
+  /** Inclusive bounds; values outside are rejected with a notify(). */
+  min?: number;
+  max?: number;
+  /** When true, rejects non-integers. */
+  integer?: boolean;
+  /**
+   * Step size for arrow-key cycling within the range.
+   * When set, up-arrow / down-arrow increment/decrement the value by `step`
+   * clamped to `[min, max]`. Mutually exclusive with `values`.
+   */
+  step?: number;
+  /** Discrete list of valid values (mutually exclusive with min/max/integer/step). */
+  values?: readonly number[];
+  /** Per-value help text, keyed by stringified number. */
+  valueDescriptions?: Record<string, string>;
+  default?: number;
+}
+
+export interface SecretField extends FieldBase {
+  type: "secret";
+  value: string;
+  default?: string;
+}
+
+export interface PathField extends FieldBase {
+  type: "path";
+  value: string;
+  default?: string;
+}
+
+export interface ActionField extends FieldBase {
+  type: "action";
+  /** Right-hand display value (defaults to `(run)`). */
+  display?: string;
+  /** Fired on Enter. */
+  onActivate: (ctx: ExtensionContext) => void | Promise<void>;
+}
+
+/** Composite value for a model + reasoning-effort field. */
+export interface ModelValue {
+  /** Canonical `<provider>/<id>` string, or `""` for "session model". */
+  id: string;
+  /** One of pi-ai's six levels (`off|minimal|low|medium|high|xhigh`). */
+  thinking?: ModelThinkingLevel;
+}
+
+/** Pre-resolved model option (skips registry discovery when provided). */
+export interface ModelOption {
+  /** Canonical `<provider>/<id>`, or `""` for the "session model" sentinel. */
+  value: string;
+  /** Human-readable label shown in the SelectList. */
+  label: string;
+  /** Optional concrete model — used to compute supported effort levels. */
+  model?: Model<Api>;
+}
+
+export interface ModelField extends FieldBase {
+  type: "model";
+  value: ModelValue;
+  /** Default sentinel label. Defaults to `"(session model)"`. */
+  sessionLabel?: string;
+  /** Override the auto-discovered list of models. */
+  models?: ModelOption[];
+  /** Filter the auto-discovered list (ignored when `models` is set). */
+  filter?: (model: Model<Api>) => boolean;
+  /** Hide the `(session model)` sentinel. Defaults to `false`. */
+  hideSession?: boolean;
+  /**
+   * Hide the reasoning-effort axis. Useful for tools that don't have
+   * a thinking concept at all (e.g. Anthropic server-side `web_search`,
+   * which only takes a model id). When `true`:
+   *   - the submenu only renders the model `SelectList` (no effort row);
+   *   - `←/→` are not consumed;
+   *   - the saved value's `thinking` is always `undefined`;
+   *   - the row label drops the `· effort` suffix.
+   * Defaults to `false`.
+   */
+  hideEffort?: boolean;
+  default?: ModelValue;
+}
+
+/**
+ * Escape hatch for arbitrary widgets. The modal calls `render(args)` to
+ * draw the row; `handleInput(data, args)` consumes terminal input when
+ * the row is focused. If `openSubmenu` is provided, Enter on the row
+ * mounts the returned component full-screen-inside-the-frame; the
+ * submenu calls `done(value)` to commit (or `done()` to cancel).
+ */
+export interface CustomField<T = unknown> extends FieldBase {
+  type: "custom";
+  value: T;
+  /** Render the row's right-hand value cell (left part is the label). */
+  render: (args: CustomFieldRenderArgs<T>) => string;
+  /** Optional inline-edit input handler. Return true to consume. */
+  handleInput?: (data: string, args: CustomFieldRenderArgs<T>) => boolean;
+  /**
+   * Optional submenu mounted on Enter. The factory receives a `done`
+   * callback that commits (`done(value)`) or cancels (`done()`).
+   */
+  openSubmenu?: (args: CustomFieldSubmenuArgs<T>) => Component;
+  /**
+   * Override the auto-generated footer hints for this row. The default
+   * heuristic in `customRenderer.hints` shows `enter open` when an
+   * `openSubmenu` is provided and `enter edit` when only `handleInput`
+   * is. Set this to advertise a different set (e.g. `space toggle`
+   * when `handleInput` consumes space but Enter is a no-op) without
+   * sub-classing the field renderer.
+   */
+  hints?: FieldKeyHint[];
+}
+
+export interface CustomFieldRenderArgs<T> {
+  value: T;
+  width: number;
+  selected: boolean;
+  theme: Theme;
+}
+
+export interface CustomFieldSubmenuArgs<T> {
+  value: T;
+  theme: Theme;
+  tui: TUI;
+  done: (newValue?: T) => void;
+}
+
+/** Discriminated union of every field variant. */
+export type Field =
+  | BooleanField
+  | EnumField
+  | StringField
+  | TextField
+  | NumberField
+  | SecretField
+  | PathField
+  | ActionField
+  | ModelField
+  | CustomField;
+
+// ─────────────────────────────────────────────────────────────────────
+// Renderer interface (internal, but exported for advanced callers)
+// ─────────────────────────────────────────────────────────────────────
+
+export interface FieldRenderContext {
+  theme: Theme;
+  tui: TUI;
+  ctx: ExtensionContext;
+  requestRender: () => void;
+}
+
+export interface FieldKeyHint {
+  key: string;
+  label: string;
+}
+
+/** Live state of a row — passed to renderers and input handlers. */
+export interface FieldRow<F extends Field = Field, V = unknown> {
+  field: F;
+  /** Current displayed value (may be ahead of disk if onChange is async). */
+  value: V;
+}
+
+/**
+ * A `FieldRenderer` knows how to draw, focus, and edit one variant of
+ * `Field`. Built-in renderers live in `./fields/*.ts`; custom callers
+ * should use `type: "custom"` instead of implementing this interface
+ * directly.
+ */
+export interface FieldRenderer<F extends Field = Field, V = unknown> {
+  /** The discriminator this renderer handles. */
+  type: F["type"];
+  /** Render the right-hand value cell for one row. */
+  renderValue(
+    row: FieldRow<F, V>,
+    args: { width: number; selected: boolean; isEditing: boolean; ctx: FieldRenderContext },
+  ): string;
+  /** Footer-hint pieces shown when this row is focused. */
+  hints(row: FieldRow<F, V>, args: { isEditing: boolean }): FieldKeyHint[];
+  /**
+   * Handle a key event. Return `consumed` to suppress default handling
+   * (navigation, esc-close); return a `commit` value to persist; return
+   * a `submenu` to mount one. Called only when the row is focused.
+   */
+  handleKey(
+    row: FieldRow<F, V>,
+    data: string,
+    args: { isEditing: boolean; ctx: FieldRenderContext; setEditing: (v: boolean) => void },
+  ): FieldKeyResult<V>;
+}
+
+/**
+ * Submenu factory passed back from a renderer's `handleKey`. The modal
+ * supplies the `done` callback when mounting; calling `done(value)`
+ * commits and unmounts, calling `done()` cancels and unmounts.
+ */
+export type SubmenuFactory<V> = (done: (value?: V) => void) => Component;
+
+export interface FieldKeyResult<V> {
+  consumed?: boolean;
+  /** A new value to commit (modal calls onChange). */
+  commit?: V;
+  /** Submenu factory to mount; modal supplies the `done` callback. */
+  submenu?: SubmenuFactory<V>;
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Tabs and modal options
+// ─────────────────────────────────────────────────────────────────────
+
+export interface Tab {
+  /** Stable id; `field.tab` matches against this. */
+  id: string;
+  /** Pill label shown in the tab strip. */
+  label: string;
+}
+
+export interface SettingsTheme {
+  /** Override the default frame title colour. Optional. */
+  titleColor?: (text: string) => string;
+  /** Override the focused-row background. Optional. */
+  rowSelected?: (text: string) => string;
+  /** Override the inline-edit value colour. Optional. */
+  editingValue?: (text: string) => string;
+}
+
+export interface SettingsModalOptions<F extends Field = Field> {
+  /** Title rendered in the frame's top border (e.g. `"@k0valik/pi-voice"`). */
+  title?: string;
+  /** Field rows. May span multiple tabs via each field's optional `tab` id. */
+  fields: F[];
+  /** Optional tab strip; rendered only when length ≥ 1. */
+  tabs?: Tab[];
+  /** Optional config filename to enable tabulated global vs project local views. */
+  configFilename?: string;
+  /** Optional defaults for the configuration to fallback to when loading. */
+  defaults?: Record<string, unknown>;
+  /** Initial tab id (defaults to the first tab). */
+  initialTab?: string;
+  /** Show a fuzzy-search bar above the list. */
+  enableSearch?: boolean;
+  /** Theme overrides (mostly used for callers with fixed-palette aesthetics). */
+  theme?: SettingsTheme;
+  /** Override the overlay positioning (defaults: anchor center, 92% × 85%). */
+  overlayOptions?: OverlayOptions | (() => OverlayOptions);
+  /** Override the global config directory used for scope-tab loading. Defaults to `getExtensionsDir()`. */
+  globalConfigDir?: string;
+  /**
+   * Called whenever a field's value changes. The modal calls this
+   * synchronously after updating its own row state, so any throw here
+   * is surfaced via `ctx.ui.notify` and does NOT roll back the row.
+   */
+  onChange?: <K extends F["key"]>(
+    key: K,
+    value: ValueOfField<F, K>,
+    field: F,
+  ) => void | Promise<void>;
+  /**
+   * Buffered mode: persist all edits at once on explicit save.
+   * When `mode` is `"buffered"`, the modal holds edits in memory and
+   * calls `onSave` only when the user confirms. `onChange` is optional
+   * and serves only live preview; dirty detection is modal-owned.
+   */
+  mode?: "immediate" | "buffered";
+  /**
+   * Called when the user confirms a buffered save. Receives the
+   * full buffer (all field values, including untouched defaults) and
+   * the chosen scope. May be async.
+   */
+  onSave?: (values: Record<string, unknown>, scope: "global" | "project") => void | Promise<void>;
+  /**
+   * Called when the user discards buffered edits. The modal closes
+   * immediately after.
+   */
+  onCancel?: () => void;
+  /**
+   * Called when the user presses alt+↑ / alt+↓ on a `reorderable: true`
+   * row. The modal has already swapped its internal `rows` array and
+   * moved focus to follow the row by the time this fires; the caller
+   * just needs to mirror the change into persistent state.
+   *
+   * Indices are 0-based positions **within the active tab's visible
+   * rows** (so they map directly to e.g. `layout.order` positions for
+   * statusline-style use cases). Both `fromIndex` and `toIndex` count
+   * only `reorderable: true` peers — non-reorderable rows interleaved
+   * with the reorderable ones do NOT participate and do NOT shift the
+   * peer index.
+   */
+  onReorder?: (info: { fieldKey: string; fromIndex: number; toIndex: number }) => void;
+  /**
+   * Called once when the modal closes. Useful for fire-and-forget
+   * cleanup (e.g. saving a debounced config).
+   */
+  onClose?: () => void;
+  /**
+   * Infer the default scope for the confirm prompt. Called once at
+   * modal mount. Return "project" if a project-local config file
+   * exists, "global" otherwise. Optional — defaults to "global".
+   *
+   * This keeps the modal framework independent of any specific
+   * config library (pi-base, custom fs, etc.) — the extension
+   * decides what "project-local" means for its own config system.
+   */
+  inferDefaultScope?: () => "global" | "project";
+  /**
+   * Called when the user activates "Reset scope to defaults" from
+   * the bottom of a scope tab. The callback should delete the
+   * scope's config file or otherwise clear all overrides so the
+   * next load falls back to defaults entirely.
+   *
+   * After this callback completes, the modal re-reads configs and
+   * updates all rows with their default values.
+   */
+  onResetScope?: (scope: "global" | "project") => void | Promise<void>;
+  /**
+   * Called when the user activates "Delete config" from the bottom of
+   * a scope tab. The callback should delete the scope's config file
+   * entirely (not just reset it).
+   */
+  onDeleteScope?: (scope: "global" | "project") => void | Promise<void>;
+}
+
+/** Value type of the field with key `K` inside a union `F`. */
+export type ValueOfField<F extends Field, K extends string> =
+  Extract<F, { key: K }> extends { value: infer V } ? V : never;
+
+/** Component factory shape required by `ctx.ui.custom`. */
+export type SettingsModalFactory<T = void> = (
+  tui: TUI,
+  theme: Theme,
+  keybindings: KeybindingsManager,
+  done: (result: T) => void,
+) => Component;

--- a/src/pi-base/settings/validate-field.ts
+++ b/src/pi-base/settings/validate-field.ts
@@ -1,0 +1,100 @@
+/**
+ * Field value validation utilities.
+ *
+ * Each `validateFieldValue` call checks a single value against the
+ * field's type-specific constraints (enum membership, boolean type,
+ * string no-newlines, number range / integer / values / step) and
+ * returns either `undefined` (valid) or a warning message string.
+ *
+ * The primary consumer is the settings modal (body.ts), which shows
+ * per-field warnings in the focused-row description area. Callers
+ * can also use this in ConfigManager to skip invalid values during
+ * save, or to repair loaded configs.
+ */
+
+import type { Field } from "./types";
+
+/**
+ * Validate a field value against the field's type-specific constraints.
+ *
+ * @param field - The field definition
+ * @param value - The value to validate
+ * @returns A warning message if invalid, `undefined` if valid
+ */
+export function validateFieldValue(field: Field, value: unknown): string | undefined {
+  if (value === undefined || value === null) return undefined;
+
+  switch (field.type) {
+    case "enum": {
+      if (typeof value !== "string") return `Must be a string, got ${typeof value}`;
+      if (!field.options.includes(value as never))
+        return `Must be one of: ${field.options.join(", ")}`;
+      return undefined;
+    }
+
+    case "boolean": {
+      if (typeof value !== "boolean") return `Must be a boolean, got ${typeof value}`;
+      return undefined;
+    }
+
+    case "string": {
+      if (typeof value !== "string") return `Must be a string, got ${typeof value}`;
+      if (value.includes("\n") || value.includes("\r"))
+        return "Must be a single-line string (no newlines)";
+      return undefined;
+    }
+
+    case "text": {
+      if (typeof value !== "string") return `Must be a string, got ${typeof value}`;
+      return undefined;
+    }
+
+    case "number": {
+      if (typeof value !== "number" || !Number.isFinite(value))
+        return `Must be a finite number, got ${typeof value === "number" ? String(value) : typeof value}`;
+      if (field.integer && !Number.isInteger(value)) return "Must be an integer";
+      if (field.values !== undefined && field.values.length > 0) {
+        if (!field.values.includes(value)) return `Must be one of: ${field.values.join(", ")}`;
+      }
+      if (typeof field.min === "number" && value < field.min)
+        return `Must be at least ${field.min}`;
+      if (typeof field.max === "number" && value > field.max) return `Must be at most ${field.max}`;
+      if (field.step !== undefined && field.step > 0) {
+        // Check alignment to step within floating-point tolerance
+        const min = field.min ?? 0;
+        const offset = value - min;
+        const rem = offset % field.step;
+        if (rem > 1e-9 && field.step - rem > 1e-9) {
+          return `Must be aligned to step ${field.step}`;
+        }
+      }
+      return undefined;
+    }
+
+    case "secret": {
+      if (typeof value !== "string") return `Must be a string, got ${typeof value}`;
+      return undefined;
+    }
+
+    case "path": {
+      if (typeof value !== "string") return `Must be a string, got ${typeof value}`;
+      return undefined;
+    }
+
+    case "model": {
+      if (typeof value !== "object" || value === null)
+        return `Must be an object with id, got ${typeof value}`;
+      const v = value as { id?: unknown };
+      if (typeof v.id !== "string") return `Must have a string id, got ${typeof v.id}`;
+      return undefined;
+    }
+
+    case "action":
+    case "custom":
+      // Custom types can't be validated generically
+      return undefined;
+
+    default:
+      return undefined;
+  }
+}

--- a/tests/blackhole-command.test.ts
+++ b/tests/blackhole-command.test.ts
@@ -6,7 +6,12 @@ import { mkdirSync, rmSync, writeFileSync, readFileSync, existsSync } from "node
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 
-const testRoot = join(tmpdir(), `pi-blackhole-cmd-test-${process.pid}-${Date.now()}`);
+const { testRoot } = vi.hoisted(() => {
+	// Use require() to avoid import-hoisting issues with vi.mock
+	const { join } = require("node:path");
+	const { tmpdir } = require("node:os");
+	return { testRoot: join(tmpdir(), `pi-blackhole-cmd-test-${process.pid}-${Date.now()}`) };
+});
 
 // Mock the pi SDK before importing our module
 vi.mock("@earendil-works/pi-coding-agent", () => ({

--- a/tests/manual-mode-migration.test.ts
+++ b/tests/manual-mode-migration.test.ts
@@ -1,0 +1,182 @@
+/**
+ * Manual mode migration — verifies the noAutoCompact → compaction:"manual" parity fix.
+ *
+ * Tests cover:
+ *   - isManualMode() helper correctness (new exported function)
+ *   - Config migration preserves manual mode behavior after noAutoCompact is removed
+ *   - Consolidation pending-state loading uses isManualMode gate
+ *   - Memory command shows manual mode labels via isManualMode
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdirSync, writeFileSync, rmSync, existsSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { tmpdir } from "node:os";
+import { randomUUID } from "node:crypto";
+import { __setTestConfigDir } from "../src/core/unified-config.js";
+
+// ── isManualMode tests ───────────────────────────────────────────────────────
+
+describe("isManualMode", () => {
+	it("returns true for compaction:'manual'", async () => {
+		const { isManualMode } = await import("../src/core/unified-config.js");
+		expect(isManualMode({ compaction: "manual" })).toBe(true);
+	});
+
+	it("returns true for legacy noAutoCompact:true", async () => {
+		const { isManualMode } = await import("../src/core/unified-config.js");
+		expect(isManualMode({ noAutoCompact: true })).toBe(true);
+	});
+
+	it("returns true when both keys are set", async () => {
+		const { isManualMode } = await import("../src/core/unified-config.js");
+		expect(isManualMode({ compaction: "manual", noAutoCompact: true })).toBe(true);
+	});
+
+	it("returns false for compaction:'auto'", async () => {
+		const { isManualMode } = await import("../src/core/unified-config.js");
+		expect(isManualMode({ compaction: "auto" })).toBe(false);
+	});
+
+	it("returns false for compaction:'off'", async () => {
+		const { isManualMode } = await import("../src/core/unified-config.js");
+		expect(isManualMode({ compaction: "off" })).toBe(false);
+	});
+
+	it("returns false for empty config", async () => {
+		const { isManualMode } = await import("../src/core/unified-config.js");
+		expect(isManualMode({})).toBe(false);
+	});
+
+	it("returns false for noAutoCompact:false", async () => {
+		const { isManualMode } = await import("../src/core/unified-config.js");
+		expect(isManualMode({ noAutoCompact: false })).toBe(false);
+	});
+});
+
+// ── Config migration + isManualMode parity ───────────────────────────────────
+
+describe("Config migration — manual mode parity", () => {
+	const testDir = join(tmpdir(), `pi-blackhole-manual-parity-${randomUUID().slice(0, 8)}`);
+
+	beforeEach(() => {
+		__setTestConfigDir(testDir);
+		mkdirSync(testDir, { recursive: true });
+	});
+
+	afterEach(() => {
+		__setTestConfigDir(undefined);
+		try { rmSync(testDir, { recursive: true, force: true }); } catch {}
+	});
+
+	it("migrated config (noAutoCompact removed, compaction:'manual') passes isManualMode", async () => {
+		const { loadUnifiedConfig, isManualMode } = await import("../src/core/unified-config.js");
+
+		const configPath = join(testDir, "pi-blackhole", "pi-blackhole-config.json");
+		mkdirSync(dirname(configPath), { recursive: true });
+		// Simulate post-migration config (old key removed, new key present)
+		writeFileSync(configPath, JSON.stringify({ compaction: "manual" }));
+
+		const config = loadUnifiedConfig(testDir);
+		expect(config.compaction).toBe("manual");
+		expect(config.noAutoCompact).toBeUndefined();
+		expect(isManualMode(config)).toBe(true);
+	});
+
+	it("auto mode config has noAutoCompact undefined and isManualMode false", async () => {
+		const { loadUnifiedConfig, isManualMode } = await import("../src/core/unified-config.js");
+
+		const configPath = join(testDir, "pi-blackhole", "pi-blackhole-config.json");
+		mkdirSync(dirname(configPath), { recursive: true });
+		writeFileSync(configPath, JSON.stringify({ compaction: "auto" }));
+
+		const config = loadUnifiedConfig(testDir);
+		expect(config.compaction).toBe("auto");
+		expect(config.noAutoCompact).toBeUndefined();
+		expect(isManualMode(config)).toBe(false);
+	});
+
+	it("legacy config (noAutoCompact:true, no new keys) passes isManualMode before migration", async () => {
+		const { loadUnifiedConfig, isManualMode } = await import("../src/core/unified-config.js");
+
+		const configPath = join(testDir, "pi-blackhole", "pi-blackhole-config.json");
+		mkdirSync(dirname(configPath), { recursive: true });
+		writeFileSync(configPath, JSON.stringify({ noAutoCompact: true }));
+
+		const config = loadUnifiedConfig(testDir);
+		// After load, migration runs: noAutoCompact removed, compaction set to "manual"
+		expect(config.compaction).toBe("manual");
+		expect(config.noAutoCompact).toBeUndefined();
+		expect(isManualMode(config)).toBe(true);
+	});
+});
+
+// ── Consolidation pending-state loading gate ─────────────────────────────────
+
+describe("Consolidation — pending state loading uses isManualMode", () => {
+	it("anyStageDue receives pending state in manual mode and uses it for reflector checks", async () => {
+		// Verify that the consolidation module reads pending state when in manual mode.
+		// We check this via anyStageDue, which receives the pending parameter
+		// that maybeLaunchConsolidation passes when isManualMode(config) is true.
+		const { Runtime } = await import("../src/om/runtime.js");
+		const { anyStageDue } = await import("../src/om/consolidation.js");
+		const { isManualMode } = await import("../src/core/unified-config.js");
+
+		const runtime = new Runtime();
+		runtime.config.compaction = "manual";
+		runtime.config.observeAfterTokens = 100000;
+		runtime.config.reflectAfterTokens = 1;
+		runtime.config.observationsPoolMaxTokens = 100_000;
+		runtime.config.dropperPressureThreshold = 0.70;
+		runtime.config.reflectorInputMaxTokens = 500;
+
+		// Pending batch with coversUpToId AFTER the cursor → triggers reflector
+		const pending = {
+			observationBatches: [{ coversUpToId: "entry-2", data: { observations: [{ id: "o1", content: "test", tokenCount: 4 }] } }],
+			reflectionBatches: [],
+			droppedBatches: [],
+			observation: { coversUpToId: "entry-2", data: {} },
+			reflection: undefined,
+			dropped: undefined,
+		};
+
+		const entries = [
+			{ type: "message", id: "entry-1", message: { role: "user", content: [{ type: "text", text: "hello" }] } },
+			{ type: "message", id: "entry-2", message: { role: "assistant", content: [{ type: "text", text: "world" }] } },
+		];
+
+		// With pending observation batches after cursor, reflector should be due
+		runtime.advanceCursor("reflector", "entry-1", "recorded");
+		expect(isManualMode(runtime.config)).toBe(true);
+		expect(anyStageDue(entries, runtime, pending)).toBe(true);
+	});
+
+	it("anyStageDue ignores pending in auto mode", async () => {
+		const { Runtime } = await import("../src/om/runtime.js");
+		const { anyStageDue } = await import("../src/om/consolidation.js");
+		const { isManualMode } = await import("../src/core/unified-config.js");
+
+		const runtime = new Runtime();
+		runtime.config.compaction = "auto";
+		runtime.config.observeAfterTokens = 100000;
+		runtime.config.reflectAfterTokens = 10;
+		runtime.config.observationsPoolMaxTokens = 100_000;
+		runtime.config.dropperPressureThreshold = 0.70;
+		runtime.config.reflectorInputMaxTokens = 500;
+
+		const pending = {
+			observationBatches: [{ coversUpToId: "entry-1", data: { observations: [{ id: "o1", content: "test", tokenCount: 4 }] } }],
+			reflectionBatches: [],
+			droppedBatches: [],
+		};
+
+		const entries = [
+			{ type: "message", id: "entry-1", message: { role: "user", content: [{ type: "text", text: "hello" }] } },
+		];
+
+		// In auto mode, pending is ignored — no OM markers on branch, no new data
+		runtime.advanceCursor("reflector", "entry-1", "recorded");
+		expect(isManualMode(runtime.config)).toBe(false);
+		expect(anyStageDue(entries, runtime, pending)).toBe(false);
+	});
+});

--- a/tests/memory-command.test.ts
+++ b/tests/memory-command.test.ts
@@ -286,9 +286,9 @@ describe("/blackhole-memory command", () => {
 		expect(msg).toContain("Usage:");
 	});
 
-	it("noAutoCompact shows auto-disabled marker and preamble cap info", async () => {
+	it("manual mode shows manual marker and preamble cap info", async () => {
 		const { pi, runtime, handlerMap } = createMockEnvironment();
-		runtime.config.noAutoCompact = true;
+		runtime.config.compaction = "manual";
 		registerMemoryCommand(pi as any, runtime as any);
 
 		const ui = { notify: vi.fn() };
@@ -303,7 +303,7 @@ describe("/blackhole-memory command", () => {
 		});
 
 		const msg = (ui.notify as any).mock.calls[0][0] as string;
-		expect(msg).toContain("auto-disabled");
+		expect(msg).toContain("[manual]");
 		// Pending section and Preamble cap only show when pending data exists on disk
 	});
 });


### PR DESCRIPTION
## Summary

Migrates the blackhole configuration UI from a hand-rolled overlay to pi-base's ConfigManager + settings modal, and completes the `noAutoCompact` → `compaction:'manual'` migration.

## Changes

### 1. Complete `noAutoCompact` → `compaction:'manual'` migration
The migration in a prior commit converted `noAutoCompact:true` to `compaction:'manual'` in-memory, but the save gates in `consolidation.ts` still checked the deleted `noAutoCompact` key. After migration, `runtime.config.noAutoCompact` was `undefined`, so observations fell through to `appendEntry()` (JSONL) instead of `savePendingObservation()` (pending file). This caused pending JSON files to contain only cursors, not actual observation/reflection/dropper payloads.

**Fix:** introduce `isManualMode()` helper in `unified-config.ts` that checks both `compaction==='manual'` and legacy `noAutoCompact===true`. Replace all ~12 save gates, pending-loading gates, and display labels across `consolidation.ts`, `memory.ts`, `before-compact.ts`, `compaction-trigger.ts`, and comments.

### 2. Migrate `/blackhole configure` to pi-base modal overlay
- Vendored pi-base settings modal code into `src/pi-base/`
- Replaced hand-rolled `configure-overlay.ts` with `openSettingsModal`
- Added `saveUnifiedConfigScoped` for global/project scope writes
- Global config now lives at `PI_CODING_AGENT_DIR/pi-blackhole/`
- Project config overlays `<cwd>/.pi/pi-blackhole-config.json`
- `/blackhole configure` now opens scope-aware modal instead of inline overlay

### 3. ConfigManager migration + `PI_CODING_AGENT_DIR` respect
- Migrate blackhole settings to ConfigManager with full env-map, validators, and field definitions (replaces hand-rolled configure-overlay)
- Respect `PI_CODING_AGENT_DIR` everywhere via `getAgentDir()` wrapper in `unified-config.ts`; pass `GLOBAL_CONFIG_DIR` to all config.load/save calls so global config resolves to `<agentDir>/pi-blackhole/` not `extensions/`
- Restore `PI_BLACKHOLE_COMPACTION` and `PI_BLACKHOLE_COMPACTION_ENGINE` env overrides in `loadUnifiedConfig` (ConfigManager.validate also handles them)

## Test plan

- All 831 tests pass
- Manual verification: `/blackhole configure` opens scope-aware modal with existing global config loaded from `~/.pi/agent/pi-blackhole/`

Fixes pending JSON files in manual mode to again contain full observation/reflection/dropper data alongside cursors, restoring crash-safe mid-run interruption recovery and `/blackhole flush` parity.