### PR TITLE
fix: discover custom provider streams through model registry

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -16,6 +16,7 @@ import { registerConsolidationTrigger } from "./src/om/consolidation.js";
 import { registerCompactionTrigger } from "./src/om/compaction-trigger.js";
 import { registerRecallTool } from "./src/tools/recall";
 import { Runtime } from "./src/om/runtime.js";
+import { captureRegisteredProviderStreams } from "./src/om/provider-stream.js";
 
 export default (pi: ExtensionAPI) => {
 	// ── Bridge: capture custom provider stream functions for jiti-loaded agents ──
@@ -25,42 +26,13 @@ export default (pi: ExtensionAPI) => {
 	// streamSimple functions in a Symbol.for() global so agents can access them without
 	// going through pi-ai's registry.
 	//
-	// There are two mechanisms:
-	// 1. Wrap pi.registerProvider to capture streamSimple at registration time.
-	//    This handles providers registered AFTER our factory runs.
-	// 2. On agent_start, scan modelRegistry.registeredProviders for any providers
-	//    that registered BEFORE our factory ran (different extension load order).
+	// Capture custom provider streams from Pi's model registry before each run.
+	// This works regardless of extension load order and includes providers added
+	// after startup.
 	const PROVIDER_STREAMS_KEY = Symbol.for("pi-blackhole:provider-streams");
 	const providerStreams: Map<string, Function> = (globalThis as any)[PROVIDER_STREAMS_KEY] ??= new Map();
-
-	const origRegisterProvider = pi.registerProvider.bind(pi);
-	pi.registerProvider = ((name: string, config: any) => {
-		if (config && config.streamSimple && config.api) {
-			providerStreams.set(config.api, config.streamSimple);
-		}
-		origRegisterProvider(name, config);
-	}) as typeof pi.registerProvider;
-
-	// Fallback: on agent_start, capture providers that registered before our wrapper
-	// (handles the case where pi-blackhole loads after another provider extension).
-	// Uses a dedicated flag instead of checking providerStreams.size so the scan
-	// always runs once even if the wrapper already captured some providers.
-	let hasScannedFallback = false;
 	pi.on("agent_start", (_event: unknown, ctx: any) => {
-		if (hasScannedFallback) return;
-		hasScannedFallback = true
-		// modelRegistry.registeredProviders is declared private in TypeScript but is a
-		// regular JS class field at runtime. We access it via bracket notation for
-		// future-proofing against potential #private migration.
-		const registry = (ctx as any)?.modelRegistry;
-		const registered: Map<string, any> | undefined = registry?.["registeredProviders"];
-		if (registered && typeof registered.forEach === "function") {
-			registered.forEach((config: any, _name: string) => {
-				if (config && config.streamSimple && config.api && !providerStreams.has(config.api)) {
-					providerStreams.set(config.api, config.streamSimple);
-				}
-			});
-		}
+		captureRegisteredProviderStreams(ctx.modelRegistry, providerStreams);
 	});
 
 	scaffoldSettings();

--- a/src/om/provider-stream.ts
+++ b/src/om/provider-stream.ts
@@ -6,6 +6,38 @@
  * bridge logic so all OM agents (observer, reflector, dropper) use the same
  * custom-provider resolution instead of each duplicating the 15-line function.
  */
+interface RegisteredProviderConfig {
+	api?: string;
+	streamSimple?: Function;
+}
+
+interface ProviderRegistry {
+	getRegisteredProviderIds?: () => readonly string[];
+	getRegisteredProviderConfig?: (providerId: string) => RegisteredProviderConfig | undefined;
+	registeredProviders?: Map<string, RegisteredProviderConfig>;
+}
+
+export function captureRegisteredProviderStreams(
+	registry: ProviderRegistry,
+	providerStreams: Map<string, Function>,
+): void {
+	if (registry.getRegisteredProviderIds && registry.getRegisteredProviderConfig) {
+		for (const providerId of registry.getRegisteredProviderIds()) {
+			const config = registry.getRegisteredProviderConfig(providerId);
+			if (config?.streamSimple && config.api && !providerStreams.has(config.api)) {
+				providerStreams.set(config.api, config.streamSimple);
+			}
+		}
+		return;
+	}
+
+	registry.registeredProviders?.forEach((config) => {
+		if (config.streamSimple && config.api && !providerStreams.has(config.api)) {
+			providerStreams.set(config.api, config.streamSimple);
+		}
+	});
+}
+
 export function createBridgeStreamFn(streamSimple: any) {
 	const PROVIDER_STREAMS_KEY = Symbol.for("pi-blackhole:provider-streams");
 	return (model: any, ctx: any, opts: any) => {

--- a/tests/provider-stream.test.ts
+++ b/tests/provider-stream.test.ts
@@ -1,0 +1,36 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { captureRegisteredProviderStreams, createBridgeStreamFn } from "../src/om/provider-stream.js";
+
+describe("custom provider stream bridge", () => {
+	afterEach(() => {
+		delete (globalThis as any)[Symbol.for("pi-blackhole:provider-streams")];
+	});
+
+	it("discovers custom streams through the public model registry API", () => {
+		const customStream = vi.fn();
+		const registry = {
+			getRegisteredProviderIds: () => ["custom-provider"],
+			getRegisteredProviderConfig: (providerId: string) => providerId === "custom-provider"
+				? { api: "custom-api", streamSimple: customStream }
+				: undefined,
+		};
+		const providerStreams = new Map<string, Function>();
+
+		captureRegisteredProviderStreams(registry as any, providerStreams);
+
+		expect(providerStreams.get("custom-api")).toBe(customStream);
+	});
+
+	it("uses the discovered stream for a custom API", () => {
+		const fallbackStream = vi.fn();
+		const customStream = vi.fn(() => "custom-result");
+		const key = Symbol.for("pi-blackhole:provider-streams");
+		(globalThis as any)[key] = new Map([["custom-api", customStream]]);
+		const bridge = createBridgeStreamFn(fallbackStream);
+
+		expect(bridge({ api: "custom-api" }, "context", "options")).toBe("custom-result");
+		expect(customStream).toHaveBeenCalledOnce();
+		expect(fallbackStream).not.toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
This change makes background memory workers discover custom provider stream handlers through Pi’s supported model registry interface before each run. Extension registration objects are isolated, and relying on a private registry field can leave the bridge empty regardless of load order. Without a populated bridge, workers fall through to the generic API dispatcher, which cannot resolve a custom API and can terminate the Pi process with an uncaught exception. The legacy discovery path remains available for older Pi releases.