### PR TITLE
feat: compactAfterPercent — threshold as a fraction of the model's context window

### DIFF
--- a/src/core/config-env.ts
+++ b/src/core/config-env.ts
@@ -89,6 +89,17 @@ export const DECLARATIVE_ENV_OVERRIDES: Record<string, EnvOverride> = {
   fullFoldAlways: "PI_BLACKHOLE_FULL_FOLD_ALWAYS",
   // Positive integers
   compactAfterTokens: "PI_BLACKHOLE_COMPACT_AFTER_TOKENS",
+  // Fractional (0, 1] — custom parser: no default exists (optional field), so
+  // the type-inferred paths above would not apply.
+  compactAfterPercent: {
+    var: "PI_BLACKHOLE_COMPACT_AFTER_PERCENT",
+    parse: (raw: string, current: unknown) => {
+      const parsed = Number.parseFloat(raw);
+      return Number.isFinite(parsed) && parsed > 0 && parsed <= 1
+        ? parsed
+        : current;
+    },
+  },
   observeAfterTokens: "PI_BLACKHOLE_OBSERVE_AFTER_TOKENS",
   reflectAfterTokens: "PI_BLACKHOLE_REFLECT_AFTER_TOKENS",
   observationsPoolMaxTokens: "PI_BLACKHOLE_OBSERVATIONS_POOL_MAX_TOKENS",

--- a/src/core/unified-config.ts
+++ b/src/core/unified-config.ts
@@ -102,6 +102,12 @@ export interface UnifiedConfig {
   reflectAfterTokens: number;
   /** Token threshold for proactive auto-compaction. */
   compactAfterTokens: number;
+  /** Fraction of the active model's context window at which to auto-compact,
+   *  in (0, 1]. When set and the model's context window is known, this takes
+   *  precedence over compactAfterTokens; compactAfterTokens remains the
+   *  fallback (and the threshold for OM-agent contexts without a model).
+   *  Optional; unset preserves absolute-token behavior. */
+  compactAfterPercent?: number;
   /** Observation pool token pressure for full fold. */
   observationsPoolMaxTokens: number;
   /** Treat every compaction as a full-fold boundary so early reflections/drops
@@ -325,6 +331,16 @@ function parseConfig(raw: Record<string, unknown>): Partial<UnifiedConfig> {
     "observerPreambleMaxTokens",
     "agentMaxTurns",
   ] as const;
+
+  // compactAfterPercent: fractional, must be in (0, 1]
+  if (
+    typeof raw.compactAfterPercent === "number" &&
+    Number.isFinite(raw.compactAfterPercent) &&
+    raw.compactAfterPercent > 0 &&
+    raw.compactAfterPercent <= 1
+  ) {
+    c.compactAfterPercent = raw.compactAfterPercent;
+  }
 
   // dropperPressureThreshold: fractional, must be in (0, 1]
   if (

--- a/src/om/compaction-trigger.ts
+++ b/src/om/compaction-trigger.ts
@@ -3,6 +3,7 @@ import { rawTokensSinceLastCompaction, type Entry } from "./ledger/index.js";
 import type { Runtime } from "./runtime.js";
 import { debugLog } from "./debug-log.js";
 import { RETRYABLE_ERROR_RE } from "./retryable-error.js";
+import { effectiveContextWindow } from "./model-budget.js";
 
 function getErrorMessage(error: unknown): string {
   if (error instanceof Error) return error.message;
@@ -43,6 +44,30 @@ export const MID_RUN_RESUME_CUSTOM_TYPE = "blackhole-resume";
 export const MID_RUN_RESUME_MESSAGE =
   "Context was auto-compacted mid-task to stay under the token threshold. " +
   "The summary above preserves prior progress. Continue the task from where you left off.";
+
+/**
+ * Resolve the auto-compaction threshold in tokens.
+ *
+ * When compactAfterPercent is configured and the active model's context
+ * window is known, the threshold is percent × contextWindow — so one config
+ * value adapts across models with very different windows. Otherwise the
+ * absolute compactAfterTokens applies unchanged.
+ */
+export function resolveCompactThreshold(
+  runtime: Runtime,
+  model: { contextWindow?: unknown } | undefined,
+): number {
+  const percent = runtime.config.compactAfterPercent;
+  if (
+    percent !== undefined &&
+    model &&
+    typeof model.contextWindow === "number" &&
+    model.contextWindow > 0
+  ) {
+    return Math.floor(effectiveContextWindow(model as any) * percent);
+  }
+  return runtime.config.compactAfterTokens;
+}
 
 /**
  * Shared config gating for auto-compaction (agent_end and turn_end paths).
@@ -133,7 +158,8 @@ function handleTurnEnd(ctx: any, runtime: Runtime, pi: ExtensionAPI): void {
 
   const entries = ctx.sessionManager.getBranch() as Entry[];
   const tokens = rawTokensSinceLastCompaction(entries);
-  if (tokens < runtime.config.compactAfterTokens) {
+  const threshold = resolveCompactThreshold(runtime, ctx.model);
+  if (tokens < threshold) {
     // Pressure relieved (a compaction ran) — lift any failure suspension.
     runtime.midRunCompactionSuspended = false;
     return;
@@ -153,7 +179,7 @@ function handleTurnEnd(ctx: any, runtime: Runtime, pi: ExtensionAPI): void {
   const ui = ctx.ui;
   dbg("compaction_trigger.turn_end.threshold_reached", {
     tokens,
-    threshold: runtime.config.compactAfterTokens,
+    threshold,
     mode,
   });
   runtime.tryEmitInfo(
@@ -247,6 +273,7 @@ function handleAgentEnd(event: any, ctx: any, runtime: Runtime): void {
     overrideDefaultCompaction: runtime.config.overrideDefaultCompaction,
     compactInFlight: runtime.compactInFlight,
     compactAfterTokens: runtime.config.compactAfterTokens,
+    compactAfterPercent: runtime.config.compactAfterPercent,
   });
 
   // Unified + legacy compaction guards (shared with the turn_end path)
@@ -287,16 +314,17 @@ function handleAgentEnd(event: any, ctx: any, runtime: Runtime): void {
   });
 
   const tokens = rawTokensSinceLastCompaction(entries);
+  const threshold = resolveCompactThreshold(runtime, ctx.model);
   dbg("compaction_trigger.tokens", {
     tokens,
-    compactAfterTokens: runtime.config.compactAfterTokens,
+    threshold,
     branchLength: entries.length,
   });
-  if (tokens < runtime.config.compactAfterTokens) {
+  if (tokens < threshold) {
     dbg("compaction_trigger.skip", {
       reason: "below_threshold",
       tokens,
-      threshold: runtime.config.compactAfterTokens,
+      threshold,
     });
     return;
   }
@@ -411,16 +439,16 @@ function handleAgentEnd(event: any, ctx: any, runtime: Runtime): void {
       const currentTokens = rawTokensSinceLastCompaction(currentEntries);
       dbg("compaction_trigger.microtask.recheck_tokens", {
         currentTokens,
-        threshold: runtime.config.compactAfterTokens,
-        ok: currentTokens >= runtime.config.compactAfterTokens,
+        threshold,
+        ok: currentTokens >= threshold,
       });
-      if (currentTokens < runtime.config.compactAfterTokens) {
+      if (currentTokens < threshold) {
         runtime.compactInFlight = false;
         runtime.autoCompactionController = null;
         dbg("compaction_trigger.microtask.bail", {
           reason: "pressure_relieved",
           currentTokens,
-          threshold: runtime.config.compactAfterTokens,
+          threshold,
         });
         runtime.tryEmitInfo(
           hasUI,

--- a/tests/compaction-trigger.test.ts
+++ b/tests/compaction-trigger.test.ts
@@ -10,7 +10,10 @@
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { registerCompactionTrigger } from "../src/om/compaction-trigger.js";
+import {
+  registerCompactionTrigger,
+  resolveCompactThreshold,
+} from "../src/om/compaction-trigger.js";
 import {
   compactionEntry,
   textCustomMessage,
@@ -43,6 +46,7 @@ function captureHandler(
   args: {
     overrideDefaultCompaction?: boolean;
     compactAfterTokens?: number;
+    compactAfterPercent?: number;
     passive?: boolean;
     compactInFlight?: boolean;
     noAutoCompact?: boolean;
@@ -81,6 +85,7 @@ function captureHandler(
     config: {
       overrideDefaultCompaction: args.overrideDefaultCompaction ?? true,
       compactAfterTokens: args.compactAfterTokens ?? 3,
+      compactAfterPercent: args.compactAfterPercent,
       passive: args.passive ?? false,
       noAutoCompact: args.noAutoCompact ?? false,
       memory: args.memory ?? true,
@@ -788,5 +793,88 @@ describe("mid-run compaction cancellation resilience", () => {
     ctx.compact.mock.calls[0][0].onError({ message: "Compaction cancelled" });
 
     expect(pi.sendMessage).not.toHaveBeenCalled();
+  });
+});
+
+describe("compactAfterPercent (context-window-relative threshold)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("resolveCompactThreshold uses percent x contextWindow when both known", () => {
+    const runtime = {
+      config: { compactAfterTokens: 81_000, compactAfterPercent: 0.75 },
+    } as any;
+    expect(resolveCompactThreshold(runtime, { contextWindow: 1_000_000 })).toBe(
+      750_000,
+    );
+    expect(resolveCompactThreshold(runtime, { contextWindow: 272_000 })).toBe(
+      204_000,
+    );
+  });
+
+  it("resolveCompactThreshold falls back to compactAfterTokens without a usable window", () => {
+    const runtime = {
+      config: { compactAfterTokens: 81_000, compactAfterPercent: 0.75 },
+    } as any;
+    expect(resolveCompactThreshold(runtime, undefined)).toBe(81_000);
+    expect(resolveCompactThreshold(runtime, {})).toBe(81_000);
+    expect(resolveCompactThreshold(runtime, { contextWindow: 0 })).toBe(81_000);
+  });
+
+  it("resolveCompactThreshold ignores percent when unset", () => {
+    const runtime = { config: { compactAfterTokens: 81_000 } } as any;
+    expect(resolveCompactThreshold(runtime, { contextWindow: 1_000_000 })).toBe(
+      81_000,
+    );
+  });
+
+  it("percent threshold wins over a huge compactAfterTokens (agent_end)", async () => {
+    const { handler, runtime } = captureHandler({
+      compactAfterTokens: 999_999,
+      compactAfterPercent: 0.5,
+    });
+    // window 4 x 0.5 = threshold 2; dueBranch has ~3 tokens
+    const ctx = fakeCtx([dueBranch], { model: { contextWindow: 4 } });
+
+    handler(agentEnd(), ctx);
+    expect(runtime.compactInFlight).toBe(true);
+    await flushAll();
+
+    expect(ctx.compact).toHaveBeenCalledTimes(1);
+  });
+
+  it("stays below a percent threshold larger than accumulated tokens (agent_end)", async () => {
+    const { handler, runtime } = captureHandler({
+      compactAfterTokens: 1,
+      compactAfterPercent: 0.5,
+    });
+    // window 100 x 0.5 = threshold 50; dueBranch has ~3 tokens.
+    // compactAfterTokens=1 alone would have fired - percent must take precedence.
+    const ctx = fakeCtx([dueBranch], { model: { contextWindow: 100 } });
+
+    handler(agentEnd(), ctx);
+    await flushAll();
+
+    expect(runtime.compactInFlight).toBe(false);
+    expect(ctx.compact).not.toHaveBeenCalled();
+  });
+
+  it("applies the percent threshold on the turn_end (mid-run) path", async () => {
+    const { turnHandler, runtime } = captureHandler({
+      compactAfterTokens: 999_999,
+      compactAfterPercent: 0.5,
+      midRunCompaction: "pause",
+    });
+    const ctx = fakeCtx([dueBranch], { model: { contextWindow: 4 } });
+
+    turnHandler(turnEnd(), ctx);
+
+    expect(runtime.compactInFlight).toBe(true);
+    expect(ctx.compact).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## Problem

The absolute `compactAfterTokens` default (81k) means very different things across models: ~65% of a 128k window, but only **8%** of a 1M-window model (claude/gpt-5.x class), where sessions compact far earlier than needed.

The README already says:

> `compactAfterTokens` should be significantly below your model's total context window — aim for ~60-70%.

This PR mechanizes that guidance so one config value adapts per model — same pattern oh-my-pi uses (`compaction.thresholdPercent`).

## Change

- **unified-config**: optional `compactAfterPercent` in (0,1], validated like `dropperPressureThreshold`. Unset preserves existing behavior exactly.
- **config-env**: `PI_BLACKHOLE_COMPACT_AFTER_PERCENT` (custom parser — the field has no default, so the type-inferred env paths don't apply).
- **compaction-trigger**: exported `resolveCompactThreshold(runtime, model)` — `percent × contextWindow` when `ctx.model` has a usable window, else `compactAfterTokens` fallback. Used by `agent_end`, `turn_end`, and the deferred idle-wait recheck (threshold captured once — no stale-ctx access in the closure).
- **tests**: 6 new cases — unit resolution, both trigger paths, precedence in both directions. Full suite 1113/1113.

## Live validation

Real pi session (deepseek, 1M window), `compactAfterPercent: 0.10` + `compactAfterTokens: 999999`:

- `debug.ndjson`: `compaction_trigger.skip {tokens: 88316, threshold: 100000}` — percent-derived threshold, absolute ignored
- after crossing: `compaction_trigger.threshold_reached {tokens: 174357}` → blackhole recap rendered in the TUI

## Design notes

- Percent applies only with a *known* window (`model.contextWindow > 0`) — unknown window falls back to `compactAfterTokens` rather than the 128k `effectiveContextWindow` default, so behavior without registry data is unchanged.
- Settings/status overlays intentionally untouched to keep the diff minimal; happy to wire the knob into the configure overlay if you want it surfaced there.