### PR TITLE
feat: provider-aware engine coordination via skipForProviders

### DIFF
--- a/src/core/config-env.ts
+++ b/src/core/config-env.ts
@@ -114,4 +114,13 @@ export const DECLARATIVE_ENV_OVERRIDES: Record<string, EnvOverride> = {
       return Number.isFinite(n) && n > 0 && n <= 1 ? n : undefined;
     },
   },
+  // Comma-separated provider skip list ("provider" or "provider:api")
+  skipForProviders: {
+    var: "PI_BLACKHOLE_SKIP_PROVIDERS",
+    parse: (raw: string) =>
+      raw
+        .split(",")
+        .map((s) => s.trim())
+        .filter((s) => s.length > 0),
+  },
 };

--- a/src/core/provider-skip.ts
+++ b/src/core/provider-skip.ts
@@ -1,0 +1,38 @@
+/**
+ * Provider-aware engine coordination.
+ *
+ * Extensions like pi-codex-compaction own compaction for specific providers
+ * (OpenAI Codex native remote compaction, preserving opaque checkpoints).
+ * When the active model's provider is listed in `skipForProviders`, blackhole
+ * steps aside entirely — no compaction, no observational-memory
+ * consolidation — so exactly one compaction engine acts per turn, regardless
+ * of extension registration order.
+ */
+
+/** True when the active model's provider (or provider:api) is in skipForProviders. */
+export function matchesSkippedProvider(
+  config: { skipForProviders?: string[] },
+  model: unknown,
+): boolean {
+  const list = config.skipForProviders;
+  if (
+    !list ||
+    list.length === 0 ||
+    model === null ||
+    typeof model !== "object"
+  ) {
+    return false;
+  }
+  const { provider, api } = model as { provider?: unknown; api?: unknown };
+  if (typeof provider !== "string" || provider.length === 0) return false;
+  for (const entry of list) {
+    const trimmed = entry.trim();
+    if (trimmed.length === 0) continue;
+    const [entryProvider, entryApi] = trimmed.split(":", 2);
+    if (entryProvider !== provider) continue;
+    // Bare provider entry skips any api of that provider; "provider:api"
+    // skips only that exact api (e.g. "openai-codex:openai-codex-responses").
+    if (entryApi === undefined || entryApi === api) return true;
+  }
+  return false;
+}

--- a/src/core/provider-skip.ts
+++ b/src/core/provider-skip.ts
@@ -9,30 +9,42 @@
  * of extension registration order.
  */
 
+type ProviderModel = { provider: string; api?: unknown };
+
+function isProviderModel(model: unknown): model is ProviderModel {
+  if (model === null || typeof model !== "object" || !("provider" in model)) {
+    return false;
+  }
+
+  const { provider } = model;
+  return typeof provider === "string" && provider.length > 0;
+}
+
+export function getModelProvider(model: unknown): string | undefined {
+  return isProviderModel(model) ? model.provider : undefined;
+}
+
 /** True when the active model's provider (or provider:api) is in skipForProviders. */
 export function matchesSkippedProvider(
   config: { skipForProviders?: string[] },
   model: unknown,
 ): boolean {
   const list = config.skipForProviders;
-  if (
-    !list ||
-    list.length === 0 ||
-    model === null ||
-    typeof model !== "object"
-  ) {
-    return false;
-  }
-  const { provider, api } = model as { provider?: unknown; api?: unknown };
-  if (typeof provider !== "string" || provider.length === 0) return false;
+  if (!list || list.length === 0 || !isProviderModel(model)) return false;
+
   for (const entry of list) {
     const trimmed = entry.trim();
     if (trimmed.length === 0) continue;
     const [entryProvider, entryApi] = trimmed.split(":", 2);
-    if (entryProvider !== provider) continue;
-    // Bare provider entry skips any api of that provider; "provider:api"
-    // skips only that exact api (e.g. "openai-codex:openai-codex-responses").
-    if (entryApi === undefined || entryApi === api) return true;
+    if (entryProvider !== model.provider) continue;
+    // Bare provider entry skips any api. "provider:" targets models with no
+    // api, while "provider:api" matches that exact api.
+    if (
+      entryApi === undefined ||
+      (entryApi === "" ? model.api === undefined : entryApi === model.api)
+    ) {
+      return true;
+    }
   }
   return false;
 }

--- a/src/core/unified-config.ts
+++ b/src/core/unified-config.ts
@@ -82,6 +82,14 @@ export interface UnifiedConfig {
    *  "pi-default" — Pi's built-in summarization */
   compactionEngine: "blackhole" | "pi-default";
 
+  /**
+   * Providers for which blackhole steps aside entirely (no compaction, no
+   * observational-memory consolidation) — used for multi-engine coordination
+   * (e.g. OpenAI Codex sessions must use native Codex remote compaction).
+   * Entries are provider ids, optionally "provider:api" for precision.
+   */
+  skipForProviders: string[];
+
   /** Mid-run auto-compaction (turn_end trigger, fires while the agent is still
    *  executing tool loops — agent_end alone never fires during long runs).
    *  "resume" — compact at threshold and inject a resume message so the agent
@@ -179,6 +187,7 @@ export const DEFAULTS: UnifiedConfig = {
   // New config surface
   compaction: "auto",
   compactionEngine: "blackhole",
+  skipForProviders: [],
   tailBehavior: "minimal",
   midRunCompaction: "off",
 
@@ -295,6 +304,15 @@ function parseConfig(raw: Record<string, unknown>): Partial<UnifiedConfig> {
   if (isTailBehavior(raw.tailBehavior)) c.tailBehavior = raw.tailBehavior;
   if (isMidRunCompaction(raw.midRunCompaction))
     c.midRunCompaction = raw.midRunCompaction;
+
+  // Provider-aware skip list (entries: provider or "provider:api")
+  if (Array.isArray(raw.skipForProviders)) {
+    const list = raw.skipForProviders
+      .filter((v): v is string => typeof v === "string")
+      .map((v) => v.trim())
+      .filter((v) => v.length > 0);
+    if (list.length > 0) c.skipForProviders = list;
+  }
 
   // Booleans — pi-vcc
   if (typeof raw.overrideDefaultCompaction === "boolean")

--- a/src/hooks/before-compact.ts
+++ b/src/hooks/before-compact.ts
@@ -11,7 +11,10 @@ import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { convertToLlm } from "@earendil-works/pi-coding-agent";
 import { writeFileSync } from "fs";
 import { compile } from "../core/summarize";
-import { matchesSkippedProvider } from "../core/provider-skip.js";
+import {
+  getModelProvider,
+  matchesSkippedProvider,
+} from "../core/provider-skip.js";
 import type { PiVccCompactionDetails } from "../details";
 import {
   buildCompactionProjection,
@@ -311,8 +314,7 @@ export const registerBeforeCompactHook = (
     // registration order. Applies to auto and explicit (/blackhole) paths.
     if (matchesSkippedProvider(omRuntime.config, ctx.model)) {
       trace("before_compact.provider_skipped", {
-        provider: (ctx.model as { provider?: unknown } | null | undefined)
-          ?.provider,
+        provider: getModelProvider(ctx.model),
         skipForProviders: omRuntime.config.skipForProviders,
       });
       return;

--- a/src/hooks/before-compact.ts
+++ b/src/hooks/before-compact.ts
@@ -11,6 +11,7 @@ import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { convertToLlm } from "@earendil-works/pi-coding-agent";
 import { writeFileSync } from "fs";
 import { compile } from "../core/summarize";
+import { matchesSkippedProvider } from "../core/provider-skip.js";
 import type { PiVccCompactionDetails } from "../details";
 import {
   buildCompactionProjection,
@@ -303,6 +304,19 @@ export const registerBeforeCompactHook = (
     );
     const trace = (ev: string, d?: Record<string, unknown>) =>
       debugLog(ev, d, omRuntime.config.debugLog === true);
+
+    // Provider-aware skip: another engine owns compaction for this provider
+    // (e.g. pi-codex-compaction for OpenAI Codex). Step aside entirely so
+    // exactly one compaction engine acts per turn, regardless of extension
+    // registration order. Applies to auto and explicit (/blackhole) paths.
+    if (matchesSkippedProvider(omRuntime.config, ctx.model)) {
+      trace("before_compact.provider_skipped", {
+        provider: (ctx.model as { provider?: unknown } | null | undefined)
+          ?.provider,
+        skipForProviders: omRuntime.config.skipForProviders,
+      });
+      return;
+    }
 
     trace("before_compact.enter", {
       customInstructions,

--- a/src/om/consolidation.ts
+++ b/src/om/consolidation.ts
@@ -8,6 +8,7 @@
  * - 30s retry gate prevents repeated failed runs (isConsolidationRetryGated).
  */
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { matchesSkippedProvider } from "../core/provider-skip.js";
 import { runDropper } from "./agents/dropper/agent.js";
 import { runObserver } from "./agents/observer/agent.js";
 import { runReflector } from "./agents/reflector/agent.js";
@@ -515,6 +516,11 @@ function maybeLaunchConsolidation(
 ): void {
   runtime.ensureConfig(ctx.cwd, (msg) => ctx.ui?.notify?.(msg, "warning"));
   if (runtime.config.memory === false) return;
+
+  // Provider-aware skip: another engine owns this provider (e.g. Codex native
+  // compaction); blackhole also steps aside from observational-memory
+  // consolidation so it never touches opaque checkpoints.
+  if (matchesSkippedProvider(runtime.config, ctx.model)) return;
 
   // LEGACY: passive check — only applies when new keys are absent (unmigrated config)
   if (

--- a/tests/provider-skip.test.ts
+++ b/tests/provider-skip.test.ts
@@ -40,6 +40,14 @@ describe("matchesSkippedProvider", () => {
     ).toBe(false);
   });
 
+  test("trailing-colon entry skips models without an api", () => {
+    const cfg = { skipForProviders: ["openai-codex:"] };
+    expect(matchesSkippedProvider(cfg, { provider: "openai-codex" })).toBe(
+      true,
+    );
+    expect(matchesSkippedProvider(cfg, codex)).toBe(false);
+  });
+
   test("non-listed providers and non-codex models are not skipped", () => {
     expect(
       matchesSkippedProvider({ skipForProviders: ["openai-codex"] }, other),

--- a/tests/provider-skip.test.ts
+++ b/tests/provider-skip.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Unit tests for provider-aware engine coordination (matchesSkippedProvider).
+ */
+import { describe, test, expect } from "vitest";
+import { matchesSkippedProvider } from "../src/core/provider-skip.js";
+
+const codex = {
+  provider: "openai-codex",
+  api: "openai-codex-responses",
+  id: "gpt-5.5",
+};
+const other = { provider: "anthropic", api: "completions", id: "claude" };
+
+describe("matchesSkippedProvider", () => {
+  test("no skip list → never skips", () => {
+    expect(matchesSkippedProvider({ skipForProviders: undefined }, codex)).toBe(
+      false,
+    );
+    expect(matchesSkippedProvider({ skipForProviders: [] }, codex)).toBe(false);
+    expect(matchesSkippedProvider({}, codex)).toBe(false);
+  });
+
+  test("bare provider entry skips any api of that provider", () => {
+    expect(
+      matchesSkippedProvider({ skipForProviders: ["openai-codex"] }, codex),
+    ).toBe(true);
+    expect(
+      matchesSkippedProvider(
+        { skipForProviders: ["openai-codex"] },
+        { provider: "openai-codex", api: "chat" },
+      ),
+    ).toBe(true);
+  });
+
+  test("provider:api entry skips only that exact api", () => {
+    const cfg = { skipForProviders: ["openai-codex:openai-codex-responses"] };
+    expect(matchesSkippedProvider(cfg, codex)).toBe(true);
+    expect(
+      matchesSkippedProvider(cfg, { provider: "openai-codex", api: "chat" }),
+    ).toBe(false);
+  });
+
+  test("non-listed providers and non-codex models are not skipped", () => {
+    expect(
+      matchesSkippedProvider({ skipForProviders: ["openai-codex"] }, other),
+    ).toBe(false);
+    expect(
+      matchesSkippedProvider({ skipForProviders: ["claude"] }, codex),
+    ).toBe(false);
+  });
+
+  test("malformed input never throws", () => {
+    expect(
+      matchesSkippedProvider({ skipForProviders: ["openai-codex"] }, null),
+    ).toBe(false);
+    expect(
+      matchesSkippedProvider({ skipForProviders: ["openai-codex"] }, undefined),
+    ).toBe(false);
+    expect(
+      matchesSkippedProvider(
+        { skipForProviders: ["openai-codex"] },
+        "openai-codex",
+      ),
+    ).toBe(false);
+    expect(
+      matchesSkippedProvider(
+        { skipForProviders: ["openai-codex"] },
+        { provider: 42 },
+      ),
+    ).toBe(false);
+    expect(
+      matchesSkippedProvider({ skipForProviders: ["openai-codex"] }, {}),
+    ).toBe(false);
+  });
+
+  test("whitespace entries are tolerated", () => {
+    expect(
+      matchesSkippedProvider(
+        { skipForProviders: [" openai-codex ", ""] },
+        codex,
+      ),
+    ).toBe(true);
+  });
+});

--- a/tests/vcc-before-compact-hook.test.ts
+++ b/tests/vcc-before-compact-hook.test.ts
@@ -38,7 +38,10 @@ afterAll(() => {
 });
 
 // Minimal ExtensionAPI stub: capture handler + provide ctx with mocked ui.notify
-function createMockPi(initialConfig?: Record<string, unknown>) {
+function createMockPi(
+  initialConfig?: Record<string, unknown>,
+  ctxModel?: unknown,
+) {
   let handler: ((event: any, ctx: any) => any) | undefined;
   const notifyCalls: Array<{ msg: string; level: string }> = [];
   const config = {
@@ -52,6 +55,7 @@ function createMockPi(initialConfig?: Record<string, unknown>) {
   const ctx = {
     cwd: tmpDir,
     hasUI: true,
+    model: ctxModel,
     ui: {
       notify: (msg: string, level: string) => {
         notifyCalls.push({ msg, level });
@@ -487,5 +491,103 @@ describe("registerBeforeCompactHook: CompactionStats population", () => {
     // compactAll: everything summarized, nothing kept
     expect(omRuntime.compactionStats!.compactAll).toBe(true);
     expect(omRuntime.compactionStats!.keptUserTurns).toBe(0);
+  });
+});
+
+describe("registerBeforeCompactHook: provider-aware skip", () => {
+  const codexModel = {
+    provider: "openai-codex",
+    api: "openai-codex-responses",
+    id: "gpt-5.5",
+  };
+
+  test("listed provider (Codex) → hook steps aside entirely (returns undefined)", () => {
+    const { pi, invoke, omRuntime } = createMockPi(
+      { skipForProviders: ["openai-codex"] },
+      codexModel,
+    );
+    registerBeforeCompactHook(pi, omRuntime);
+    const entries = [
+      msg("m1", "user", "hello"),
+      msg("m2", "assistant", "hi"),
+      msg("m3", "user", "more"),
+      msg("m4", "assistant", "reply"),
+    ];
+    // Even with plenty of live messages (which would normally compact), the
+    // Codex provider must be left to pi-codex-compaction.
+    expect(invoke(makeEvent(entries))).toBeUndefined();
+  });
+
+  test("listed provider:api (Codex responses) → steps aside", () => {
+    const { pi, invoke, omRuntime } = createMockPi(
+      { skipForProviders: ["openai-codex:openai-codex-responses"] },
+      codexModel,
+    );
+    registerBeforeCompactHook(pi, omRuntime);
+    expect(
+      invoke(
+        makeEvent([
+          msg("m1", "user"),
+          msg("m2", "assistant"),
+          msg("m3", "user"),
+          msg("m4", "assistant"),
+        ]),
+      ),
+    ).toBeUndefined();
+  });
+
+  test("explicit /blackhole on a listed provider → still steps aside", () => {
+    const { pi, invoke, omRuntime } = createMockPi(
+      { skipForProviders: ["openai-codex"] },
+      codexModel,
+    );
+    registerBeforeCompactHook(pi, omRuntime);
+    expect(
+      invoke(
+        makeEvent(
+          [
+            msg("m1", "user"),
+            msg("m2", "assistant"),
+            msg("m3", "user"),
+            msg("m4", "assistant"),
+          ],
+          PI_VCC_COMPACT_INSTRUCTION,
+        ),
+      ),
+    ).toBeUndefined();
+  });
+
+  test("non-listed provider (non-Codex) → normal blackhole compaction", () => {
+    const { pi, invoke, omRuntime } = createMockPi(
+      { skipForProviders: ["openai-codex"] },
+      { provider: "anthropic", api: "completions", id: "claude" },
+    );
+    registerBeforeCompactHook(pi, omRuntime);
+    const result = invoke(
+      makeEvent([
+        msg("m1", "user", "a"),
+        msg("m2", "assistant", "b"),
+        msg("m3", "user", "c"),
+        msg("m4", "assistant", "d"),
+      ]),
+    );
+    expect(result.cancel).toBeUndefined();
+    expect(result.compaction).toBeDefined();
+    expect(typeof result.compaction.summary).toBe("string");
+    expect(result.compaction.summary.length).toBeGreaterThan(0);
+  });
+
+  test("no skip list → Codex provider still compacts (existing behavior preserved)", () => {
+    const { pi, invoke, omRuntime } = createMockPi({}, codexModel);
+    registerBeforeCompactHook(pi, omRuntime);
+    const result = invoke(
+      makeEvent([
+        msg("m1", "user", "a"),
+        msg("m2", "assistant", "b"),
+        msg("m3", "user", "c"),
+        msg("m4", "assistant", "d"),
+      ]),
+    );
+    expect(result.compaction).toBeDefined();
   });
 });


### PR DESCRIPTION
# Provider-aware engine coordination via `skipForProviders`

## Problem

Pi's extension runner resolves `session_before_compact` as **last-writer-wins**
with a **cancel short-circuit**: the last non-undefined handler result wins,
and a result with `cancel: true` stops all later handlers immediately. When
two compaction engines are registered (e.g. this package alongside
`pi-codex-compaction`, which owns OpenAI Codex native remote compaction):

- Codex sessions: blackhole's own compaction result can **overwrite** the
  native Codex result (double work — the remote checkpoint is discarded), and
  blackhole's `cancel` (e.g. too-few-live-messages) can **block** the Codex
  native path entirely depending on registration order.
- Non-Codex sessions: blackhole's observational-memory consolidation also runs
  over Codex sessions, touching branches that carry opaque checkpoints.

There is currently no way for blackhole to know which model a turn belongs to
before deciding whether it should compact.

## Change

Add a `skipForProviders` config key (array of provider ids, optionally
`"provider:api"` for precision). When the active model's provider is listed,
blackhole steps aside **entirely**:

- **Compaction** — the `session_before_compact` hook returns early (both auto
  and explicit `/blackhole` paths), so another engine's handler — registered
  before or after blackhole — is never overwritten or short-circuited.
- **Observational-memory consolidation** — the `agent_start`/`turn_end`
  trigger returns early, so observer/reflector/dropper never process sessions
  owned by another engine.

With both engines registered, exactly one compaction engine acts per turn,
regardless of extension registration order.

## Configuration surface

```json
{ "skipForProviders": ["openai-codex"] }
```

- File: `~/.pi/agent/pi-blackhole/pi-blackhole-config.json`
- Env: `PI_BLACKHOLE_SKIP_PROVIDERS=openai-codex` (comma-separated, supports
  `provider:api` entries)
- Default: `[]` (no behavior change for existing users)

## Implementation

- `src/core/provider-skip.ts` — `matchesSkippedProvider(config, model)`
  predicate (bare provider matches any api; `provider:api` matches exactly).
- `src/core/unified-config.ts` — interface field, defaults, parsing.
- `src/core/config-env.ts` — `PI_BLACKHOLE_SKIP_PROVIDERS` env override.
- `src/hooks/before-compact.ts` — early return guard at the top of the hook.
- `src/om/consolidation.ts` — early return guard in `maybeLaunchConsolidation`.

## Tests

- `tests/provider-skip.test.ts` — predicate unit tests (bare/provider:api
  matching, non-listed providers, malformed input, whitespace tolerance).
- `tests/vcc-before-compact-hook.test.ts` — hook integration: listed provider
  steps aside (auto + explicit `/blackhole`), non-listed providers compact
  normally, no skip list preserves existing behavior.

## Motivation

`beautiful-pi` (a Pi meta-package) wires `pi-codex-compaction` and
`pi-blackhole` together and needs provider-aware selection: Codex sessions use
native Codex compaction, all other sessions use blackhole — with no double
compaction and no reliance on extension registration order.
