### PR TITLE
Add isolated provider idle timeout

### DIFF
--- a/src/core/unified-config.ts
+++ b/src/core/unified-config.ts
@@ -139,6 +139,8 @@ export interface UnifiedConfig {
   observerPreambleMaxTokens: number;
   /** Shared turn cap for background memory agents. */
   agentMaxTurns: number;
+  /** Body-idle timeout for background provider streams. Uses 5 minutes when unset. */
+  providerIdleTimeoutMs?: number;
 
   /** Base model override for all memory workers. */
   model?: OmModelConfig;
@@ -324,6 +326,7 @@ function parseConfig(raw: Record<string, unknown>): Partial<UnifiedConfig> {
     "observerChunkMaxTokens",
     "observerPreambleMaxTokens",
     "agentMaxTurns",
+    "providerIdleTimeoutMs",
   ] as const;
 
   // dropperPressureThreshold: fractional, must be in (0, 1]

--- a/src/om/agents/dropper/agent.ts
+++ b/src/om/agents/dropper/agent.ts
@@ -12,7 +12,11 @@ import {
   type AgentTool,
 } from "@earendil-works/pi-agent-core";
 import type { Message, Model, ModelThinkingLevel } from "@earendil-works/pi-ai";
-import { createBridgeStreamFn } from "../../provider-stream.js";
+import {
+  createBridgeStreamFn,
+  createProviderFetch,
+  type ProviderFetchOption,
+} from "../../provider-stream.js";
 import { streamSimple } from "@earendil-works/pi-ai/compat";
 import { Type } from "typebox";
 import type { Static } from "typebox";
@@ -53,6 +57,7 @@ interface RunDropperArgs {
   streamFn?: (model: any, context: any, options: any) => any;
   maxTurns?: number;
   thinkingLevel?: ModelThinkingLevel;
+  providerIdleTimeoutMs?: number;
 }
 
 const DROP_SKIP_FULLNESS = 0.1;
@@ -369,10 +374,11 @@ export async function runDropper(
   const effectiveMaxTurns =
     args.maxTurns && args.maxTurns > 0 ? args.maxTurns : undefined;
   let turnCount = 0;
-  const config: AgentLoopConfig = {
+  const config: AgentLoopConfig & ProviderFetchOption = {
     model,
     apiKey,
     headers,
+    fetch: createProviderFetch(args.providerIdleTimeoutMs),
     maxTokens: boundedMaxTokens(model, AGENT_LOOP_MAX_TOKENS),
     convertToLlm: (msgs) => msgs as Message[],
     toolExecution: "sequential",

--- a/src/om/agents/observer/agent.ts
+++ b/src/om/agents/observer/agent.ts
@@ -13,7 +13,11 @@ import {
   type AgentTool,
 } from "@earendil-works/pi-agent-core";
 import type { Message, Model, ModelThinkingLevel } from "@earendil-works/pi-ai";
-import { createBridgeStreamFn } from "../../provider-stream.js";
+import {
+  createBridgeStreamFn,
+  createProviderFetch,
+  type ProviderFetchOption,
+} from "../../provider-stream.js";
 import { streamSimple } from "@earendil-works/pi-ai/compat";
 import { Type } from "typebox";
 import type { Static } from "typebox";
@@ -40,6 +44,7 @@ interface RunObserverArgs {
   streamFn?: (model: any, context: any, options: any) => any;
   maxTurns?: number;
   thinkingLevel?: ModelThinkingLevel;
+  providerIdleTimeoutMs?: number;
 }
 
 const RelevanceSchema = Type.Union([
@@ -241,10 +246,11 @@ ${conversation}`;
   const effectiveMaxTurns =
     args.maxTurns && args.maxTurns > 0 ? args.maxTurns : undefined;
   let turnCount = 0;
-  const config: AgentLoopConfig = {
+  const config: AgentLoopConfig & ProviderFetchOption = {
     model,
     apiKey,
     headers,
+    fetch: createProviderFetch(args.providerIdleTimeoutMs),
     maxTokens: boundedMaxTokens(model, AGENT_LOOP_MAX_TOKENS),
     convertToLlm: (msgs) => msgs as Message[],
     toolExecution: "sequential",

--- a/src/om/agents/reflector/agent.ts
+++ b/src/om/agents/reflector/agent.ts
@@ -12,7 +12,11 @@ import {
   type AgentTool,
 } from "@earendil-works/pi-agent-core";
 import type { Message, Model, ModelThinkingLevel } from "@earendil-works/pi-ai";
-import { createBridgeStreamFn } from "../../provider-stream.js";
+import {
+  createBridgeStreamFn,
+  createProviderFetch,
+  type ProviderFetchOption,
+} from "../../provider-stream.js";
 import { streamSimple } from "@earendil-works/pi-ai/compat";
 import { Type } from "typebox";
 import type { Static } from "typebox";
@@ -47,6 +51,7 @@ interface RunReflectorArgs {
   streamFn?: (model: any, context: any, options: any) => any;
   maxTurns?: number;
   thinkingLevel?: ModelThinkingLevel;
+  providerIdleTimeoutMs?: number;
 }
 
 const RecordReflectionsSchema = Type.Object({
@@ -180,10 +185,11 @@ export async function runReflector(
   const effectiveMaxTurns =
     args.maxTurns && args.maxTurns > 0 ? args.maxTurns : undefined;
   let turnCount = 0;
-  const config: AgentLoopConfig = {
+  const config: AgentLoopConfig & ProviderFetchOption = {
     model,
     apiKey,
     headers,
+    fetch: createProviderFetch(args.providerIdleTimeoutMs),
     maxTokens: boundedMaxTokens(model, AGENT_LOOP_MAX_TOKENS),
     convertToLlm: (msgs) => msgs as Message[],
     toolExecution: "sequential",

--- a/src/om/consolidation.ts
+++ b/src/om/consolidation.ts
@@ -876,6 +876,7 @@ async function runObserverStage(
           "observer",
           stageModelForThinking,
         ),
+        providerIdleTimeoutMs: runtime.config.providerIdleTimeoutMs,
       });
 
       if (result.observations && result.observations.length > 0) {
@@ -1214,6 +1215,7 @@ async function runReflectorStage(
           "reflector",
           stageModelForThinking,
         ),
+        providerIdleTimeoutMs: runtime.config.providerIdleTimeoutMs,
       });
 
       if (!reflections || reflections.length === 0) {
@@ -1512,6 +1514,7 @@ async function runDropperStage(
           "dropper",
           stageModelForThinking,
         ),
+        providerIdleTimeoutMs: runtime.config.providerIdleTimeoutMs,
       });
       const latestReflectionCoverageId = isManualMode(runtime.config)
         ? pending?.reflection?.coversUpToId

--- a/src/om/provider-stream.ts
+++ b/src/om/provider-stream.ts
@@ -47,6 +47,48 @@ export function captureRegisteredProviderStreams(
   });
 }
 
+/** Pi 0.81 forwards fetch at runtime but omits it from AgentLoopConfig types. */
+export type ProviderFetchOption = { fetch: typeof fetch };
+
+interface Dispatcher {
+  dispatch(options: Record<string, unknown>, handler: unknown): unknown;
+}
+
+const DEFAULT_PROVIDER_IDLE_TIMEOUT_MS = 300_000;
+const GLOBAL_DISPATCHER_SYMBOLS = [
+  Symbol.for("undici.globalDispatcher.2"),
+  Symbol.for("undici.globalDispatcher.1"),
+];
+
+function getGlobalDispatcher(): Dispatcher {
+  for (const symbol of GLOBAL_DISPATCHER_SYMBOLS) {
+    const dispatcher = (globalThis as Record<symbol, unknown>)[symbol];
+    if (
+      dispatcher &&
+      typeof (dispatcher as Dispatcher).dispatch === "function"
+    ) {
+      return dispatcher as Dispatcher;
+    }
+  }
+  throw new Error(
+    "Blackhole provider idle timeout requires Pi's Undici dispatcher",
+  );
+}
+
+export function createProviderFetch(
+  timeoutMs = DEFAULT_PROVIDER_IDLE_TIMEOUT_MS,
+): typeof fetch {
+  const dispatcher: Dispatcher = {
+    dispatch(options, handler) {
+      return getGlobalDispatcher().dispatch(
+        { ...options, bodyTimeout: timeoutMs },
+        handler,
+      );
+    },
+  };
+  return (input, init) => fetch(input, { ...init, dispatcher } as RequestInit);
+}
+
 export function createBridgeStreamFn(streamSimple: any) {
   const PROVIDER_STREAMS_KEY = Symbol.for("pi-blackhole:provider-streams");
   return (model: any, ctx: any, opts: any) => {

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -69,6 +69,25 @@ describe("Config defaults", () => {
   });
 });
 
+describe("providerIdleTimeoutMs", () => {
+  it("uses the provider default when omitted", async () => {
+    const { loadUnifiedConfig } = await import("../src/core/unified-config.js");
+    expect(loadUnifiedConfig(testDir).providerIdleTimeoutMs).toBeUndefined();
+  });
+
+  it("accepts a positive timeout", async () => {
+    const { loadUnifiedConfig } = await import("../src/core/unified-config.js");
+    writeConfig({ providerIdleTimeoutMs: 120_000 });
+    expect(loadUnifiedConfig(testDir).providerIdleTimeoutMs).toBe(120_000);
+  });
+
+  it("ignores invalid timeouts", async () => {
+    const { loadUnifiedConfig } = await import("../src/core/unified-config.js");
+    writeConfig({ providerIdleTimeoutMs: 0 });
+    expect(loadUnifiedConfig(testDir).providerIdleTimeoutMs).toBeUndefined();
+  });
+});
+
 describe("dropperPressureThreshold", () => {
   it("defaults to 0.70 when no config file exists", async () => {
     const { loadUnifiedConfig } = await import("../src/core/unified-config.js");

--- a/tests/observer.test.ts
+++ b/tests/observer.test.ts
@@ -49,6 +49,21 @@ describe("runObserver", () => {
     allowedSourceEntryIds: ["entry-a"],
   };
 
+  it("passes the isolated provider fetch through agent-loop config", async () => {
+    let providerFetch: unknown;
+    const loop = fakeAgentLoop((_prompts, _context, config) => {
+      providerFetch = config.fetch;
+    });
+
+    await runObserver({
+      ...baseArgs,
+      agentLoop: loop,
+      providerIdleTimeoutMs: 120_000,
+    });
+
+    expect(providerFetch).toBeTypeOf("function");
+  });
+
   it("keeps core observer prompt rules", async () => {
     let systemPrompt = "";
     const loop = fakeAgentLoop((_prompts, context) => {

--- a/tests/provider-stream.test.ts
+++ b/tests/provider-stream.test.ts
@@ -3,11 +3,21 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   captureRegisteredProviderStreams,
   createBridgeStreamFn,
+  createProviderFetch,
 } from "../src/om/provider-stream.js";
+
+const dispatcherSymbol = Symbol.for("undici.globalDispatcher.2");
+const originalDispatcher = (globalThis as any)[dispatcherSymbol];
 
 describe("custom provider stream bridge", () => {
   afterEach(() => {
     delete (globalThis as any)[Symbol.for("pi-blackhole:provider-streams")];
+    vi.unstubAllGlobals();
+    if (originalDispatcher === undefined) {
+      delete (globalThis as any)[dispatcherSymbol];
+    } else {
+      (globalThis as any)[dispatcherSymbol] = originalDispatcher;
+    }
   });
 
   it("discovers custom streams through the public model registry API", () => {
@@ -33,10 +43,35 @@ describe("custom provider stream bridge", () => {
     (globalThis as any)[key] = new Map([["custom-api", customStream]]);
     const bridge = createBridgeStreamFn(fallbackStream);
 
-    expect(bridge({ api: "custom-api" }, "context", "options")).toBe(
-      "custom-result",
-    );
+    expect(bridge({ api: "custom-api" }, "context", {})).toBe("custom-result");
     expect(customStream).toHaveBeenCalledOnce();
     expect(fallbackStream).not.toHaveBeenCalled();
+  });
+
+  it("overrides body idle timeout without replacing the global dispatcher", async () => {
+    const dispatch = vi.fn(() => true);
+    (globalThis as any)[dispatcherSymbol] = { dispatch };
+    const fetchMock = vi.fn(async () => new Response());
+    vi.stubGlobal("fetch", fetchMock);
+
+    await createProviderFetch()("https://example.com");
+    const defaultDispatcher = fetchMock.mock.calls[0]?.[1]?.dispatcher;
+    defaultDispatcher.dispatch({ path: "/default" }, "handler");
+
+    await createProviderFetch(120_000)("https://example.com");
+    const configuredDispatcher = fetchMock.mock.calls[1]?.[1]?.dispatcher;
+    configuredDispatcher.dispatch({ path: "/configured" }, "handler");
+
+    expect(dispatch).toHaveBeenNthCalledWith(
+      1,
+      { path: "/default", bodyTimeout: 300_000 },
+      "handler",
+    );
+    expect(dispatch).toHaveBeenNthCalledWith(
+      2,
+      { path: "/configured", bodyTimeout: 120_000 },
+      "handler",
+    );
+    expect((globalThis as any)[dispatcherSymbol]).toEqual({ dispatch });
   });
 });


### PR DESCRIPTION
This change lets background memory jobs tolerate longer silent provider intervals without forcing interactive Pi requests to wait equally long. It applies an optional per-request body-idle timeout through the existing provider transport while preserving Pi's global timeout for normal prompts. The default matches the provider's existing five-minute behavior, and no additional runtime dependency is introduced.