### PR TITLE
fix: preserve credential-resolved endpoints for OM workers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+### Fixed
+
+- **Credential-resolved provider endpoints are preserved for observational-memory workers.** Observer, reflector, and dropper now use the endpoint selected by Pi's auth resolver, preventing GitHub Copilot Business/Enterprise requests from falling back to the Individual endpoint and returning HTTP 421.
+
 ## [0.4.3] - 2026-08-01
 
 ### Added

--- a/src/om/runtime.ts
+++ b/src/om/runtime.ts
@@ -65,6 +65,48 @@ export interface ResolveCtx {
   stageFallbacks?: ConfiguredModel[];
 }
 
+type AuthWithOptionalEndpoint = {
+  baseUrl?: unknown;
+};
+
+/**
+ * Preserve the endpoint selected by Pi's credential resolver.
+ *
+ * Newer Pi versions expose baseUrl on getApiKeyAndHeaders(). Older versions
+ * keep it on getProviderAuth(), so use that as a backwards-compatible fallback.
+ */
+async function resolveAuthBaseUrl(
+  modelRegistry: any,
+  model: any,
+  auth: AuthWithOptionalEndpoint,
+): Promise<string | undefined> {
+  const directBaseUrl =
+    typeof auth.baseUrl === "string" ? auth.baseUrl.trim() : "";
+  if (directBaseUrl) return directBaseUrl;
+
+  if (typeof modelRegistry.getProviderAuth !== "function") return undefined;
+
+  try {
+    const resolved = await modelRegistry.getProviderAuth(model.provider);
+    const baseUrl = resolved?.auth?.baseUrl;
+    return typeof baseUrl === "string" && baseUrl.trim()
+      ? baseUrl.trim()
+      : undefined;
+  } catch {
+    // Older registries may not expose provider auth resolution.
+    return undefined;
+  }
+}
+
+async function withResolvedAuthEndpoint(
+  modelRegistry: any,
+  model: any,
+  auth: AuthWithOptionalEndpoint,
+): Promise<any> {
+  const baseUrl = await resolveAuthBaseUrl(modelRegistry, model, auth);
+  return baseUrl && baseUrl !== model.baseUrl ? { ...model, baseUrl } : model;
+}
+
 export interface LaunchCtx {
   hasUI: boolean;
   ui?: { notify: Notify };
@@ -250,9 +292,15 @@ export class Runtime {
         continue;
       }
 
+      const resolvedModel = await withResolvedAuthEndpoint(
+        ctx.modelRegistry,
+        configured,
+        auth,
+      );
+
       return {
         ok: true,
-        model: configured,
+        model: resolvedModel,
         apiKey: (auth.apiKey as string) ?? "",
         headers: auth.headers as Record<string, string> | undefined,
         cooldownApplied: false,
@@ -281,9 +329,15 @@ export class Runtime {
         };
       }
 
+      const resolvedModel = await withResolvedAuthEndpoint(
+        ctx.modelRegistry,
+        sessionModel,
+        auth,
+      );
+
       return {
         ok: true,
-        model: sessionModel,
+        model: resolvedModel,
         apiKey: (auth.apiKey as string) ?? "",
         headers: auth.headers as Record<string, string> | undefined,
         cooldownApplied: false,

--- a/tests/runtime.test.ts
+++ b/tests/runtime.test.ts
@@ -63,7 +63,15 @@ function makeModel(
   };
 }
 
-function makeRegistry(models: ReturnType<typeof makeModel>[]) {
+type RegistryOptions = {
+  requestBaseUrl?: string;
+  providerBaseUrl?: string;
+};
+
+function makeRegistry(
+  models: ReturnType<typeof makeModel>[],
+  options: RegistryOptions = {},
+) {
   return {
     models,
     find: vi.fn((p: string, id: string) =>
@@ -74,7 +82,13 @@ function makeRegistry(models: ReturnType<typeof makeModel>[]) {
       ok: true,
       apiKey: "sk-test",
       headers: undefined,
+      ...(options.requestBaseUrl ? { baseUrl: options.requestBaseUrl } : {}),
     })),
+    getProviderAuth: vi.fn(async () =>
+      options.providerBaseUrl
+        ? { auth: { baseUrl: options.providerBaseUrl } }
+        : undefined,
+    ),
   };
 }
 
@@ -117,6 +131,88 @@ describe("Runtime.resolveModel — fallback chain", () => {
     if (result.ok) {
       expect(result.model.id).toBe("primary-model:free");
     }
+  });
+  it("preserves a credential-resolved endpoint from request auth", async () => {
+    writeConfig({
+      observerModel: {
+        provider: "github-copilot",
+        id: "gpt-5.6-luna",
+      },
+    });
+    const model = makeModel("gpt-5.6-luna", "github-copilot", {
+      baseUrl: "https://api.individual.githubcopilot.com",
+    });
+    const registry = makeRegistry([model], {
+      requestBaseUrl: "https://api.enterprise.githubcopilot.com",
+    });
+    const { Runtime } = await import("../src/om/runtime.js");
+    const runtime = new Runtime();
+    runtime.ensureConfig(testDir);
+
+    const result = await runtime.resolveModel({
+      model: undefined,
+      modelRegistry: registry,
+      hasUI: false,
+      stageModel: {
+        provider: "github-copilot",
+        id: "gpt-5.6-luna",
+      },
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.model.baseUrl).toBe(
+        "https://api.enterprise.githubcopilot.com",
+      );
+    }
+    expect(registry.getProviderAuth).not.toHaveBeenCalled();
+  });
+
+  it("falls back to provider auth for registries without request baseUrl", async () => {
+    writeConfig({
+      observerModel: {
+        provider: "github-copilot",
+        id: "cooled-model",
+        cooldownHours: 24,
+      },
+    });
+    const { recordCooldown } = await import("../src/om/cooldown.js");
+    recordCooldown(
+      {
+        provider: "github-copilot",
+        id: "cooled-model",
+        cooldownHours: 24,
+      },
+      "test cooldown",
+      "observer",
+    );
+    const sessionModel = makeModel("session-model", "github-copilot", {
+      baseUrl: "https://api.individual.githubcopilot.com",
+    });
+    const registry = makeRegistry([sessionModel], {
+      providerBaseUrl: "https://api.enterprise.githubcopilot.com",
+    });
+    const { Runtime } = await import("../src/om/runtime.js");
+    const runtime = new Runtime();
+    runtime.ensureConfig(testDir);
+
+    const result = await runtime.resolveModel({
+      model: sessionModel,
+      modelRegistry: registry,
+      hasUI: false,
+      stageModel: {
+        provider: "github-copilot",
+        id: "cooled-model",
+      },
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.model.baseUrl).toBe(
+        "https://api.enterprise.githubcopilot.com",
+      );
+    }
+    expect(registry.getProviderAuth).toHaveBeenCalledWith("github-copilot");
   });
 
   it("skips primary model when in cooldown, uses fallback", async () => {


### PR DESCRIPTION
## Summary

- Preserve the credential-resolved `baseUrl` on models used by the observer, reflector, and dropper workers.
- Prefer `getApiKeyAndHeaders().baseUrl` from the Pi fix in `e741cb05`.
- Fall back to the public `getProviderAuth()` API for Pi versions whose compatibility auth result does not yet expose `baseUrl`.
- Add regression coverage for configured worker models and session-model fallback.

## Problem

Pi's normal model runtime rewrites a model with the endpoint selected by credential resolution. Blackhole's background workers resolve auth and then call their stream function directly, so the catalog endpoint remained in the model object.

For GitHub Copilot Business/Enterprise credentials this can send a request to the Individual endpoint and produce `421 Misdirected Request`. This is the extension-side counterpart to [Pi commit e741cb05](https://github.com/codingwatching/pi-mono/commit/e741cb05ca7c1c7bc5a9664c99697df32de9fac6) and [Pi issue #7579](https://github.com/earendil-works/pi/issues/7579).

## Validation

- Tested on my local machine with latest pi version, observer and reflector now work properly!
- `node node_modules/typescript/bin/tsc --noEmit` — passed
- `node node_modules/vitest/vitest.mjs run tests/runtime.test.ts` — passed (46 tests)
- `node node_modules/eslint/bin/eslint.js src/om/runtime.ts tests/runtime.test.ts` — passed
- `node node_modules/tsup/dist/cli-default.js` — passed
- Full Windows/MSYS suite: 1103 passed, 6 environment-specific failures in existing filesystem/path tests (`config-simplification`, `model-budget`, `pi-base/env-paths`); the focused changed-path suite passes.
