### PR TITLE
fix: compact mid-run without aborting active runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,6 @@
 - **`midRunCompaction: "resume"` no longer aborts or replaces the active run.** The old `ctx.compact()` + `blackhole-resume` path propagated a false interrupt to background/subagent extensions and let nested child runners resolve before Blackhole's detached resume run finished. Resume mode now performs Pi's native compaction pipeline inline from the awaited `turn_end` handler, refreshes the next low-level turn from the compacted messages, and continues inside the original `session.prompt()` promise. Completed tool calls remain paired; no synthetic user/custom message is injected.
 - **Mid-run compaction compatibility fails closed.** A reload-idempotent, weakly referenced runtime adapter recognizes the known Pi 0.81 and 0.84 `AgentSession.compact()` shapes. Unknown internal drift refuses transparent compaction and leaves the active run alive instead of falling back to the unsafe aborting path. External abort/cancellation still passes through normally.
 
-### Changed
-
-- **`midRunCompaction` defaults to `"resume"` again.** The temporary `"off"` default from 0.4.2 is no longer required now that resume mode does not abort the parent or child run. `"pause"` remains the explicit interrupting mode and still delegates to public `ctx.compact()`.
-
 ### Testing
 
 - Added adapter contract coverage for Pi 0.81/0.84 compact shapes, no-abort behavior, compacted next-turn context refresh, external cancellation, unpaired-tool rejection, fail-closed drift handling, and reload idempotency. A real `AgentSession` + faux-provider integration test runs on both the 0.81.1 compatibility baseline and 0.84.0 dev baseline, proving the active run signal stays live, the next provider request receives the compacted context, and the original `session.prompt()` remains pending through compaction. Trigger tests prove no `ctx.compact()` or `blackhole-resume` dispatch.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 ## [Unreleased]
 
+### Fixed
+
+- **`midRunCompaction: "resume"` no longer aborts or replaces the active run.** The old `ctx.compact()` + `blackhole-resume` path propagated a false interrupt to background/subagent extensions and let nested child runners resolve before Blackhole's detached resume run finished. Resume mode now performs Pi's native compaction pipeline inline from the awaited `turn_end` handler, refreshes the next low-level turn from the compacted messages, and continues inside the original `session.prompt()` promise. Completed tool calls remain paired; no synthetic user/custom message is injected.
+- **Mid-run compaction compatibility fails closed.** A reload-idempotent, weakly referenced runtime adapter recognizes the known Pi 0.81 and 0.84 `AgentSession.compact()` shapes. Unknown internal drift refuses transparent compaction and leaves the active run alive instead of falling back to the unsafe aborting path. External abort/cancellation still passes through normally.
+
+### Changed
+
+- **`midRunCompaction` defaults to `"resume"` again.** The temporary `"off"` default from 0.4.2 is no longer required now that resume mode does not abort the parent or child run. `"pause"` remains the explicit interrupting mode and still delegates to public `ctx.compact()`.
+
+### Testing
+
+- Added adapter contract coverage for Pi 0.81/0.84 compact shapes, no-abort behavior, compacted next-turn context refresh, external cancellation, unpaired-tool rejection, fail-closed drift handling, and reload idempotency. A real `AgentSession` + faux-provider integration test runs on both the 0.81.1 compatibility baseline and 0.84.0 dev baseline, proving the active run signal stays live, the next provider request receives the compacted context, and the original `session.prompt()` remains pending through compaction. Trigger tests prove no `ctx.compact()` or `blackhole-resume` dispatch.
+
+### Dependencies
+
+- Bumped `@earendil-works/pi-*` devDependencies from `0.83.0` to `0.84.0`; the peer range remains `>=0.81.1 <1.0.0`, and the adapter retains a tested legacy-shape path for the minimum supported host.
+
 ## [0.4.3] - 2026-08-01
 
 ### Added

--- a/CONFIG.md
+++ b/CONFIG.md
@@ -22,7 +22,7 @@ The config file must contain **valid JSON**. A trailing comma, partial write, or
   "compaction": "auto",           // "auto" | "manual" | "off"
   "compactionEngine": "blackhole", // "blackhole" | "pi-default"
   "tailBehavior": "minimal",   // "pi-default" | "minimal"
-  "midRunCompaction": "resume", // "resume" | "pause" | "off" (default: resume)
+  "midRunCompaction": "off",    // "resume" | "pause" | "off" (default: off)
   "compactAfterTokens": 81000,    // Token threshold for auto-compaction
 
   // ── Observational Memory ──
@@ -151,9 +151,9 @@ Only applies when `compaction: "auto"` and `compactionEngine: "blackhole"`.
 
 | Value | Behavior |
 |-------|----------|
-| `"resume"` | Compact transparently at an awaited `turn_end`, then continue inside the **same** agent run and outer `session.prompt()` promise (default). No run abort and no synthetic continuation message. |
+| `"resume"` | Compact transparently at an awaited `turn_end`, then continue inside the **same** agent run and outer `session.prompt()` promise. No run abort and no synthetic continuation message. |
 | `"pause"` | Use Pi's native interrupting `ctx.compact()` at the threshold, then stop. The user continues manually. |
-| `"off"` | No mid-run evaluation; only check the threshold when the agent finishes a run. |
+| `"off"` | No mid-run evaluation; only check the threshold when the agent finishes a run (default). |
 
 `"resume"` reuses Pi's native summary, `session_before_compact`, session-entry, and context-rebuild pipeline. Blackhole's runtime adapter suppresses only the compaction method's initial internal quiesce (`abort`, plus disconnect on older Pi), then refreshes the low-level loop from the compacted `agent.state.messages` before another provider request. Completed tools stay paired, the active run signal is not aborted, background agents do not receive a false interrupt, and nested runners keep awaiting their original prompt promise.
 
@@ -164,14 +164,14 @@ Only applies when `compaction: "auto"` and `compactionEngine: "blackhole"`.
 **Re-trigger safety:** after a successful compaction, accumulated tokens are counted from the fresh compaction entry. Failed or cancelled attempts are suspended until pressure drops below the threshold.
 
 ```jsonc
-// Default: compact mid-run without ending or replacing the current run
+// Default: only evaluate when the run ends
+{ "midRunCompaction": "off" }
+
+// Opt in to transparent same-run compaction during long tool loops
 { "midRunCompaction": "resume" }
 
 // Interrupt the run, compact, and hand control back to the user
 { "midRunCompaction": "pause" }
-
-// Only evaluate when the run ends
-{ "midRunCompaction": "off" }
 ```
 
 ### `compactAfterTokens`

--- a/CONFIG.md
+++ b/CONFIG.md
@@ -22,7 +22,7 @@ The config file must contain **valid JSON**. A trailing comma, partial write, or
   "compaction": "auto",           // "auto" | "manual" | "off"
   "compactionEngine": "blackhole", // "blackhole" | "pi-default"
   "tailBehavior": "minimal",   // "pi-default" | "minimal"
-  "midRunCompaction": "off",   // "resume" | "pause" | "off" (default: off — unsafe with subagent workflows)
+  "midRunCompaction": "resume", // "resume" | "pause" | "off" (default: resume)
   "compactAfterTokens": 81000,    // Token threshold for auto-compaction
 
   // ── Observational Memory ──
@@ -151,22 +151,26 @@ Only applies when `compaction: "auto"` and `compactionEngine: "blackhole"`.
 
 | Value | Behavior |
 |-------|----------|
-| `"resume"` | Compact at threshold mid-run, then inject a resume message (`triggerTurn`) so the agent continues the task with the compacted context (explicit opt-in — unsafe with subagent/background-work extensions) |
-| `"pause"` | Compact at threshold mid-run, but stop — the user continues manually |
-| `"off"` | No mid-run evaluation; threshold is only checked when the agent finishes a run (default — safe with subagent/background-work extensions) |
+| `"resume"` | Compact transparently at an awaited `turn_end`, then continue inside the **same** agent run and outer `session.prompt()` promise (default). No run abort and no synthetic continuation message. |
+| `"pause"` | Use Pi's native interrupting `ctx.compact()` at the threshold, then stop. The user continues manually. |
+| `"off"` | No mid-run evaluation; only check the threshold when the agent finishes a run. |
 
-**Why compaction interrupts the run:** Pi's `compact()` aborts the in-flight agent operation by design. `turn_end` is a clean boundary — all tool results of the turn are already persisted, so at most one just-started LLM call is wasted. With `"resume"`, the agent picks the task back up immediately; the compaction summary plus the kept tail (see `tailBehavior`) carry the task state across.
+`"resume"` reuses Pi's native summary, `session_before_compact`, session-entry, and context-rebuild pipeline. Blackhole's runtime adapter suppresses only the compaction method's initial internal quiesce (`abort`, plus disconnect on older Pi), then refreshes the low-level loop from the compacted `agent.state.messages` before another provider request. Completed tools stay paired, the active run signal is not aborted, background agents do not receive a false interrupt, and nested runners keep awaiting their original prompt promise.
 
-**Re-trigger safety:** after a compaction, accumulated tokens are counted from the fresh compaction entry, so the threshold naturally resets — no compact/resume loops.
+**Compatibility is fail-closed.** The adapter recognizes the known Pi 0.81 legacy and Pi 0.84 connected-listener compact shapes. If Pi internals drift, `"resume"` refuses the mid-run attempt, leaves the current run alive, reports the incompatibility, and suspends retries at that pressure level. It never falls back to the old abort + `blackhole-resume` path.
+
+`"pause"` is intentionally different: it calls public `ctx.compact()`, which aborts the active run by design. That abort may propagate to extensions which treat the run signal as user cancellation, so use `"resume"` for transparent/subagent workflows.
+
+**Re-trigger safety:** after a successful compaction, accumulated tokens are counted from the fresh compaction entry. Failed or cancelled attempts are suspended until pressure drops below the threshold.
 
 ```jsonc
-// Compact mid-run and keep working (explicit opt-in; unsafe with subagent workflows)
+// Default: compact mid-run without ending or replacing the current run
 { "midRunCompaction": "resume" }
 
-// Compact mid-run but hand control back to the user
+// Interrupt the run, compact, and hand control back to the user
 { "midRunCompaction": "pause" }
 
-// Safe default: only evaluate when the run ends
+// Only evaluate when the run ends
 { "midRunCompaction": "off" }
 ```
 

--- a/README.md
+++ b/README.md
@@ -278,7 +278,7 @@ Everything else has sensible defaults.
 | `compaction` | `"auto"` | When compaction triggers: `"auto"` (blackhole auto-fires), `"manual"` (only `/blackhole`), `"off"` (Pi handles auto + `/compact`, `/blackhole` still works) |
 | `compactionEngine` | `"blackhole"` | Which engine handles auto-compaction: `"blackhole"` or `"pi-default"`. Only meaningful when `compaction: "auto"` — for `"manual"`/`"off"` the hook lets Pi handle everything except `/blackhole` |
 | `tailBehavior` | `"minimal"` | How much stays visible after compaction: `"minimal"` (last user message only, default) or `"pi-default"` (gentle, ~20k tokens). Both `/blackhole` and auto-triggered default to `"minimal"`; set explicitly to opt into gentler cut |
-| `midRunCompaction` | `"resume"` | `"resume"` compacts transparently during long tool loops without replacing the active run; `"pause"` interrupts, compacts, and stops; `"off"` only checks when the run ends. Transparent mode fails closed on unsupported Pi internals. |
+| `midRunCompaction` | `"off"` | `"resume"` opts into transparent compaction during long tool loops without replacing the active run; `"pause"` interrupts, compacts, and stops; `"off"` only checks when the run ends. Transparent mode fails closed on unsupported Pi internals. |
 | `memory` | `true` | `false` = OM workers off + no memory injection (compaction still runs) |
 | `model` | — | Base fallback model for all workers (last resort before session model) |
 | `observerModel` / `observerFallbackModels` | — / `[]` | Primary + fallback models for observer (extracts facts) |

--- a/README.md
+++ b/README.md
@@ -278,6 +278,7 @@ Everything else has sensible defaults.
 | `compaction` | `"auto"` | When compaction triggers: `"auto"` (blackhole auto-fires), `"manual"` (only `/blackhole`), `"off"` (Pi handles auto + `/compact`, `/blackhole` still works) |
 | `compactionEngine` | `"blackhole"` | Which engine handles auto-compaction: `"blackhole"` or `"pi-default"`. Only meaningful when `compaction: "auto"` — for `"manual"`/`"off"` the hook lets Pi handle everything except `/blackhole` |
 | `tailBehavior` | `"minimal"` | How much stays visible after compaction: `"minimal"` (last user message only, default) or `"pi-default"` (gentle, ~20k tokens). Both `/blackhole` and auto-triggered default to `"minimal"`; set explicitly to opt into gentler cut |
+| `midRunCompaction` | `"resume"` | `"resume"` compacts transparently during long tool loops without replacing the active run; `"pause"` interrupts, compacts, and stops; `"off"` only checks when the run ends. Transparent mode fails closed on unsupported Pi internals. |
 | `memory` | `true` | `false` = OM workers off + no memory injection (compaction still runs) |
 | `model` | — | Base fallback model for all workers (last resort before session model) |
 | `observerModel` / `observerFallbackModels` | — / `[]` | Primary + fallback models for observer (extracts facts) |

--- a/example-config.json
+++ b/example-config.json
@@ -7,7 +7,7 @@
   "compaction": "auto",
   "compactionEngine": "blackhole",
   "tailBehavior": "minimal",
-  "midRunCompaction": "resume",
+  "midRunCompaction": "off",
 
   "model": {
     "_comment": "Base model (last fallback before session model).",

--- a/index.ts
+++ b/index.ts
@@ -17,8 +17,13 @@ import { registerCompactionTrigger } from "./src/om/compaction-trigger.js";
 import { registerRecallTool } from "./src/tools/recall";
 import { Runtime } from "./src/om/runtime.js";
 import { captureRegisteredProviderStreams } from "./src/om/provider-stream.js";
+import { installHostInlineCompactionAdapter } from "./src/om/inline-compaction.js";
 
-export default (pi: ExtensionAPI) => {
+export default async (pi: ExtensionAPI) => {
+  // Resolve the host's AgentSession identity before this factory returns. Local
+  // package development can otherwise patch a duplicate devDependency module.
+  // The adapter is reload-idempotent and fails closed on unknown Pi internals.
+  await installHostInlineCompactionAdapter();
   // ── Bridge: capture custom provider stream functions for jiti-loaded agents ──
   // pi-blackhole's consolidation agents are loaded via jiti with moduleCache: false,
   // which creates a separate pi-ai instance whose apiProviderRegistry lacks custom
@@ -43,7 +48,7 @@ export default (pi: ExtensionAPI) => {
 
   // Observational memory: background consolidation pipeline
   registerConsolidationTrigger(pi, omRuntime); // agent_start + turn_end → observer/reflector/dropper
-  registerCompactionTrigger(pi, omRuntime); // agent_end → auto-compaction
+  registerCompactionTrigger(pi, omRuntime); // turn_end + agent_end → auto-compaction
 
   // Pi-vcc: compaction + om injection
   registerBeforeCompactHook(pi, omRuntime); // session_before_compact → pi-vcc + om content

--- a/package.json
+++ b/package.json
@@ -61,10 +61,10 @@
     ]
   },
   "devDependencies": {
-    "@earendil-works/pi-agent-core": "0.83.0",
-    "@earendil-works/pi-ai": "0.83.0",
-    "@earendil-works/pi-coding-agent": "0.83.0",
-    "@earendil-works/pi-tui": "0.83.0",
+    "@earendil-works/pi-agent-core": "0.84.0",
+    "@earendil-works/pi-ai": "0.84.0",
+    "@earendil-works/pi-coding-agent": "0.84.0",
+    "@earendil-works/pi-tui": "0.84.0",
     "@typescript-eslint/eslint-plugin": "8.60.0",
     "@typescript-eslint/parser": "8.60.0",
     "eslint": "9.39.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,17 +13,17 @@ importers:
   .:
     devDependencies:
       '@earendil-works/pi-agent-core':
-        specifier: 0.83.0
-        version: 0.83.0(ws@8.21.1)(zod@4.4.3)
+        specifier: 0.84.0
+        version: 0.84.0(ws@8.21.1)(zod@4.4.3)
       '@earendil-works/pi-ai':
-        specifier: 0.83.0
-        version: 0.83.0(ws@8.21.1)(zod@4.4.3)
+        specifier: 0.84.0
+        version: 0.84.0(ws@8.21.1)(zod@4.4.3)
       '@earendil-works/pi-coding-agent':
-        specifier: 0.83.0
-        version: 0.83.0(ws@8.21.1)(zod@4.4.3)
+        specifier: 0.84.0
+        version: 0.84.0(ws@8.21.1)(zod@4.4.3)
       '@earendil-works/pi-tui':
-        specifier: 0.83.0
-        version: 0.83.0
+        specifier: 0.84.0
+        version: 0.84.0
       '@typescript-eslint/eslint-plugin':
         specifier: 8.60.0
         version: 8.60.0(@typescript-eslint/parser@8.60.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
@@ -167,22 +167,34 @@ packages:
     resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
     engines: {node: '>=6.9.0'}
 
-  '@earendil-works/pi-agent-core@0.83.0':
-    resolution: {integrity: sha512-RorGp9OH5l3ElpuC5a5ZQ2eWcchZGXflXRzVGkV99y3y6tT+LLNyxoYIdVKvTKWEObwhExeQbTH0fI2tE4iX4g==}
+  '@earendil-works/pi-agent-core@0.84.0':
+    resolution: {integrity: sha512-L1lw0lwR5LXCzGEeHD9XNEruU2bg0H8clOA8ySdGMHvxutp8GC+yZL6MZp4tqQRnLKP3gHmY7TrWzQ3YnFdJYQ==}
     engines: {node: '>=22.19.0'}
 
-  '@earendil-works/pi-ai@0.83.0':
-    resolution: {integrity: sha512-m3IZD4g3er0V8TC9+Vpgw/sjTKqcJlkcIBy/JvsgRubuuik3tAVzyugUg4rVrShIkkOT69mEd34NEqKUIsl6JQ==}
-    engines: {node: '>=22.19.0'}
-    hasBin: true
-
-  '@earendil-works/pi-coding-agent@0.83.0':
-    resolution: {integrity: sha512-uYhF+FsZxogoSX/AxBcUdiY+ZklubwaXyAoEGA2eQwsHcyEAhUYIKh/WLXe/a8+k8eTCmxb+ZN2Zo9mzQtzbWw==}
+  '@earendil-works/pi-ai@0.84.0':
+    resolution: {integrity: sha512-N9RDk8q0eglGiy+NqTZ3Ev2j+6oFNXSAJa8b0CYhvWB9HGiKZjsoCESXkUvMDLybrn0wXp75sdsoBzEtHxk9kA==}
     engines: {node: '>=22.19.0'}
     hasBin: true
 
-  '@earendil-works/pi-tui@0.83.0':
-    resolution: {integrity: sha512-IoYrb0rORjELmEpNtoCA/U8je3KopMkRAVJRdSzvXRvgb+Huo1gNh8Q5CSZvNOiYtDxJdj2tYZZHZ4B3+IN3hA==}
+  '@earendil-works/pi-client@0.84.0':
+    resolution: {integrity: sha512-fHXgw1FdLDh+uw42SvTkJRBfgc3nsrslghvbRFEAxdjfcOxJt7hPsTj4HHNK96wMy1f+zvQYL8Y2znvFoZ8JDA==}
+    engines: {node: '>=22.19.0'}
+
+  '@earendil-works/pi-coding-agent@0.84.0':
+    resolution: {integrity: sha512-oxEU7BT9xuVT6UKNwUNDzNP5dVGb+DZRGfaEyMyAab8dRlqTSxxyhSlMAxmYsu//YOeasj9E8n2+px1BzIai0g==}
+    engines: {node: '>=22.19.0'}
+    hasBin: true
+
+  '@earendil-works/pi-protocol@0.84.0':
+    resolution: {integrity: sha512-Fc28cCYGg5+aRnMzbAD7QAi6Xl//kbETyFroLHCs3Zf4oaXH9L2gzBqVLVAwrKIKeS0uffUrmihocGTECfKW6Q==}
+    engines: {node: '>=22.19.0'}
+
+  '@earendil-works/pi-telemetry@0.84.0':
+    resolution: {integrity: sha512-g6hLxEfAUk3zJlDmFWhWHJNcYXYiNGeWuJC9YkcHpkdkj0gxD4uaMNNNU3QsAEJXW9Qcxnl21+U8GfhVsc8C5g==}
+    engines: {node: '>=22.19.0'}
+
+  '@earendil-works/pi-tui@0.84.0':
+    resolution: {integrity: sha512-nbs0FeZJ5rWDD6VpKfXXmYbEHnHqb40V9glE2l9f8ftoWpsP8nw0WcXK8jOjfRsDPnT9dJHy3dItOHdn/AFGjA==}
     engines: {node: '>=22.19.0'}
 
   '@emnapi/core@1.10.0':
@@ -1288,6 +1300,10 @@ packages:
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
+  grok-mermaid@0.2.2:
+    resolution: {integrity: sha512-XcJEP5dDC8liHBh52mlLjU18fNvu1ckFsu0QpIG3+APZ270fsj9wxpiA6cOURmbUEuoMVgjbC2+UYgTdCqqgzA==}
+    engines: {node: '>=18'}
+
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
@@ -1925,8 +1941,8 @@ packages:
   undici-types@8.3.0:
     resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
 
-  undici@8.5.0:
-    resolution: {integrity: sha512-xamtWoB1EshgjpmlXd7GGm2VfdDtw1+rD8uhry8pSNW3If6S8E0m2T2+orSKeZXEn/aPJMviCpDBA65WJt8zhg==}
+  undici@8.9.0:
+    resolution: {integrity: sha512-aWZpUj7XoGonMClx4gdDRfgBjqeA+F473aDmROQQbM9n6PRfK/u1q/a0X4wMTgcHfT8H6fpbt98PFuDUwFg2YA==}
     engines: {node: '>=22.19.0'}
 
   uri-js@4.4.1:
@@ -2291,9 +2307,10 @@ snapshots:
 
   '@babel/runtime@7.29.7': {}
 
-  '@earendil-works/pi-agent-core@0.83.0(ws@8.21.1)(zod@4.4.3)':
+  '@earendil-works/pi-agent-core@0.84.0(ws@8.21.1)(zod@4.4.3)':
     dependencies:
-      '@earendil-works/pi-ai': 0.83.0(ws@8.21.1)(zod@4.4.3)
+      '@earendil-works/pi-ai': 0.84.0(ws@8.21.1)(zod@4.4.3)
+      '@earendil-works/pi-telemetry': 0.84.0
       diff: 8.0.4
       ignore: 7.0.5
       typebox: 1.3.7
@@ -2306,10 +2323,11 @@ snapshots:
       - ws
       - zod
 
-  '@earendil-works/pi-ai@0.83.0(ws@8.21.1)(zod@4.4.3)':
+  '@earendil-works/pi-ai@0.84.0(ws@8.21.1)(zod@4.4.3)':
     dependencies:
       '@anthropic-ai/sdk': 0.91.1(zod@4.4.3)
       '@aws-sdk/client-bedrock-runtime': 3.1048.0
+      '@earendil-works/pi-telemetry': 0.84.0
       '@google/genai': 1.52.0
       '@mistralai/mistralai': 2.2.6(@opentelemetry/api@1.9.0)
       '@opentelemetry/api': 1.9.0
@@ -2327,16 +2345,23 @@ snapshots:
       - ws
       - zod
 
-  '@earendil-works/pi-coding-agent@0.83.0(ws@8.21.1)(zod@4.4.3)':
+  '@earendil-works/pi-client@0.84.0':
     dependencies:
-      '@earendil-works/pi-agent-core': 0.83.0(ws@8.21.1)(zod@4.4.3)
-      '@earendil-works/pi-ai': 0.83.0(ws@8.21.1)(zod@4.4.3)
-      '@earendil-works/pi-tui': 0.83.0
+      '@earendil-works/pi-protocol': 0.84.0
+
+  '@earendil-works/pi-coding-agent@0.84.0(ws@8.21.1)(zod@4.4.3)':
+    dependencies:
+      '@earendil-works/pi-agent-core': 0.84.0(ws@8.21.1)(zod@4.4.3)
+      '@earendil-works/pi-ai': 0.84.0(ws@8.21.1)(zod@4.4.3)
+      '@earendil-works/pi-client': 0.84.0
+      '@earendil-works/pi-protocol': 0.84.0
+      '@earendil-works/pi-tui': 0.84.0
       '@silvia-odwyer/photon-node': 0.3.4
       chalk: 5.6.2
       cross-spawn: 7.0.6
       diff: 8.0.4
       glob: 13.0.6
+      grok-mermaid: 0.2.2
       highlight.js: 10.7.3
       hosted-git-info: 9.0.3
       ignore: 7.0.5
@@ -2345,7 +2370,7 @@ snapshots:
       proper-lockfile: 4.1.2
       semver: 7.8.0
       typebox: 1.3.7
-      undici: 8.5.0
+      undici: 8.9.0
       yaml: 2.9.0
     optionalDependencies:
       '@mariozechner/clipboard': 0.3.9
@@ -2357,7 +2382,13 @@ snapshots:
       - ws
       - zod
 
-  '@earendil-works/pi-tui@0.83.0':
+  '@earendil-works/pi-protocol@0.84.0':
+    dependencies:
+      typebox: 1.3.7
+
+  '@earendil-works/pi-telemetry@0.84.0': {}
+
+  '@earendil-works/pi-tui@0.84.0':
     dependencies:
       get-east-asian-width: 1.6.0
       marked: 18.0.5
@@ -3328,6 +3359,8 @@ snapshots:
 
   graceful-fs@4.2.11: {}
 
+  grok-mermaid@0.2.2: {}
+
   has-flag@4.0.0: {}
 
   highlight.js@10.7.3: {}
@@ -3916,7 +3949,7 @@ snapshots:
 
   undici-types@8.3.0: {}
 
-  undici@8.5.0: {}
+  undici@8.9.0: {}
 
   uri-js@4.4.1:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,6 +4,15 @@ allowBuilds:
   koffi: true
   protobufjs: true
 
+minimumReleaseAgeExclude:
+  - "@earendil-works/pi-agent-core@0.84.0"
+  - "@earendil-works/pi-ai@0.84.0"
+  - "@earendil-works/pi-client@0.84.0"
+  - "@earendil-works/pi-coding-agent@0.84.0"
+  - "@earendil-works/pi-protocol@0.84.0"
+  - "@earendil-works/pi-telemetry@0.84.0"
+  - "@earendil-works/pi-tui@0.84.0"
+
 overrides:
   vite: 8.0.16
   js-yaml: ">=4.2.0 <5.0.0"

--- a/src/core/unified-config.ts
+++ b/src/core/unified-config.ts
@@ -84,9 +84,9 @@ export interface UnifiedConfig {
 
   /** Mid-run auto-compaction (turn_end trigger, fires while the agent is still
    *  executing tool loops — agent_end alone never fires during long runs).
-   *  "resume" — compact transparently at the turn boundary; the same run continues (default)
+   *  "resume" — compact transparently at the turn boundary; the same run continues (opt-in)
    *  "pause"  — use Pi's interrupting compaction; user continues manually
-   *  "off"    — only evaluate the threshold when the agent finishes a run */
+   *  "off"    — only evaluate the threshold when the agent finishes a run (default) */
   midRunCompaction: "resume" | "pause" | "off";
 
   /** How much recent transcript to keep visible after compaction.
@@ -179,7 +179,7 @@ export const DEFAULTS: UnifiedConfig = {
   compaction: "auto",
   compactionEngine: "blackhole",
   tailBehavior: "minimal",
-  midRunCompaction: "resume",
+  midRunCompaction: "off",
 
   observeAfterTokens: 15_000,
   reflectAfterTokens: 25_000,

--- a/src/core/unified-config.ts
+++ b/src/core/unified-config.ts
@@ -84,9 +84,8 @@ export interface UnifiedConfig {
 
   /** Mid-run auto-compaction (turn_end trigger, fires while the agent is still
    *  executing tool loops — agent_end alone never fires during long runs).
-   *  "resume" — compact at threshold and inject a resume message so the agent
-   *             continues the task (default)
-   *  "pause"  — compact at threshold but stop; user continues manually
+   *  "resume" — compact transparently at the turn boundary; the same run continues (default)
+   *  "pause"  — use Pi's interrupting compaction; user continues manually
    *  "off"    — only evaluate the threshold when the agent finishes a run */
   midRunCompaction: "resume" | "pause" | "off";
 
@@ -180,7 +179,7 @@ export const DEFAULTS: UnifiedConfig = {
   compaction: "auto",
   compactionEngine: "blackhole",
   tailBehavior: "minimal",
-  midRunCompaction: "off",
+  midRunCompaction: "resume",
 
   observeAfterTokens: 15_000,
   reflectAfterTokens: 25_000,

--- a/src/om/compaction-trigger.ts
+++ b/src/om/compaction-trigger.ts
@@ -3,6 +3,10 @@ import { rawTokensSinceLastCompaction, type Entry } from "./ledger/index.js";
 import type { Runtime } from "./runtime.js";
 import { debugLog } from "./debug-log.js";
 import { RETRYABLE_ERROR_RE } from "./retryable-error.js";
+import {
+  compactInlineAtTurnBoundary,
+  type InlineCompaction,
+} from "./inline-compaction.js";
 
 function getErrorMessage(error: unknown): string {
   if (error instanceof Error) return error.message;
@@ -35,16 +39,6 @@ function notifySafely(
 }
 
 /**
- * Message injected after a mid-run compaction so the agent resumes the task
- * instead of stopping (ctx.compact() aborts the in-flight run and Pi does not
- * auto-continue).
- */
-export const MID_RUN_RESUME_CUSTOM_TYPE = "blackhole-resume";
-export const MID_RUN_RESUME_MESSAGE =
-  "Context was auto-compacted mid-task to stay under the token threshold. " +
-  "The summary above preserves prior progress. Continue the task from where you left off.";
-
-/**
  * Shared config gating for auto-compaction (agent_end and turn_end paths).
  * Returns null when compaction may proceed, or a skip reason string.
  */
@@ -72,6 +66,7 @@ function autoCompactionSkipReason(runtime: Runtime): string | null {
 export function registerCompactionTrigger(
   pi: ExtensionAPI,
   runtime: Runtime,
+  inlineCompact: InlineCompaction = compactInlineAtTurnBoundary,
 ): void {
   pi.on("agent_start", () => {
     // Reset the info gate — allow one info notification during the new turn.
@@ -101,9 +96,9 @@ export function registerCompactionTrigger(
   // exits, so during long tool loops the threshold would otherwise never be
   // evaluated (the configured compactAfterTokens could be exceeded many times
   // over before compaction had a chance to run).
-  pi.on("turn_end", (_event: any, ctx: any) => {
+  pi.on("turn_end", async (_event: any, ctx: any) => {
     try {
-      handleTurnEnd(ctx, runtime, pi);
+      await handleTurnEnd(ctx, runtime, inlineCompact);
     } catch (error) {
       if (isStaleExtensionContextError(error)) return;
       throw error;
@@ -111,12 +106,16 @@ export function registerCompactionTrigger(
   });
 }
 
-function handleTurnEnd(ctx: any, runtime: Runtime, pi: ExtensionAPI): void {
+async function handleTurnEnd(
+  ctx: any,
+  runtime: Runtime,
+  inlineCompact: InlineCompaction,
+): Promise<void> {
   runtime.ensureConfig(ctx.cwd, (msg) => ctx.ui?.notify?.(msg, "warning"));
   const dbg = (ev: string, d?: Record<string, unknown>) =>
     debugLog(ev, d, runtime.config.debugLog === true);
 
-  const mode = runtime.config.midRunCompaction ?? "off";
+  const mode = runtime.config.midRunCompaction ?? "resume";
   if (mode === "off") {
     dbg("compaction_trigger.turn_end.skip", { reason: "midRunCompaction_off" });
     return;
@@ -130,6 +129,10 @@ function handleTurnEnd(ctx: any, runtime: Runtime, pi: ExtensionAPI): void {
     dbg("compaction_trigger.turn_end.skip", { reason: "compactInFlight" });
     return;
   }
+  if (ctx.signal?.aborted === true) {
+    dbg("compaction_trigger.turn_end.skip", { reason: "active_run_aborted" });
+    return;
+  }
 
   const entries = ctx.sessionManager.getBranch() as Entry[];
   const tokens = rawTokensSinceLastCompaction(entries);
@@ -140,7 +143,7 @@ function handleTurnEnd(ctx: any, runtime: Runtime, pi: ExtensionAPI): void {
   }
   if (runtime.midRunCompactionSuspended) {
     // A previous mid-run attempt failed/cancelled at this pressure level.
-    // Re-triggering every turn would thrash (each attempt aborts the run).
+    // Re-triggering every turn would retry the same failure and spam the user.
     // Stay suspended until a compaction lowers pressure below the threshold.
     dbg("compaction_trigger.turn_end.skip", {
       reason: "suspended_after_failure",
@@ -159,69 +162,63 @@ function handleTurnEnd(ctx: any, runtime: Runtime, pi: ExtensionAPI): void {
   runtime.tryEmitInfo(
     hasUI,
     ui,
-    `Observational memory: compaction threshold reached mid-run (~${tokens.toLocaleString()} tokens); compacting${mode === "resume" ? " and resuming" : ""}`,
+    `Observational memory: compaction threshold reached mid-run (~${tokens.toLocaleString()} tokens); compacting${mode === "resume" ? " inline" : " and pausing"}`,
   );
 
-  // ctx.compact() aborts the in-flight agent run before compacting — that is
-  // the intended trade: turn_end is a clean boundary (tool results are already
-  // persisted; at most one just-started LLM call is wasted).
   runtime.compactInFlight = true;
-  ctx.compact({
-    onComplete: (_result: any) => {
-      runtime.compactInFlight = false;
-      dbg("compaction_trigger.turn_end.onComplete", { mode });
-      if (mode === "resume") {
-        try {
-          pi.sendMessage(
-            {
-              customType: MID_RUN_RESUME_CUSTOM_TYPE,
-              content: MID_RUN_RESUME_MESSAGE,
-              display: true,
-            },
-            { triggerTurn: true },
-          );
-        } catch (error) {
-          if (!isStaleExtensionContextError(error)) throw error;
-        }
-      }
+
+  if (mode === "resume") {
+    try {
+      await inlineCompact(ctx.sessionManager);
+      dbg("compaction_trigger.turn_end.inline_complete");
       runtime.tryEmitInfo(
         hasUI,
         ui,
-        "Observational memory: mid-run compaction complete",
+        "Observational memory: transparent mid-run compaction complete",
+      );
+    } catch (error) {
+      if (isStaleExtensionContextError(error)) throw error;
+      runtime.midRunCompactionSuspended = true;
+      const message = getErrorMessage(error);
+      dbg("compaction_trigger.turn_end.inline_error", { message });
+      if (message !== "Compaction cancelled") {
+        notifySafely(
+          hasUI,
+          ui,
+          `Observational memory: transparent mid-run compaction failed: ${message}`,
+          "error",
+        );
+      }
+    } finally {
+      runtime.compactInFlight = false;
+    }
+    return;
+  }
+
+  // pause is explicitly interrupting: native ctx.compact() aborts the current
+  // run and leaves continuation to the user.
+  ctx.compact({
+    onComplete: () => {
+      runtime.compactInFlight = false;
+      dbg("compaction_trigger.turn_end.pause_complete");
+      runtime.tryEmitInfo(
+        hasUI,
+        ui,
+        "Observational memory: mid-run compaction complete; agent paused",
       );
     },
     onError: (error: { message: string }) => {
       runtime.compactInFlight = false;
-      // Don't retry at this pressure level — the next attempt would abort the
-      // run again just to fail the same way. Cleared when pressure drops.
       runtime.midRunCompactionSuspended = true;
-      dbg("compaction_trigger.turn_end.onError", {
-        message: error?.message ?? String(error),
-      });
-      if (error.message !== "Compaction cancelled") {
+      const message = error?.message ?? String(error);
+      dbg("compaction_trigger.turn_end.pause_error", { message });
+      if (message !== "Compaction cancelled") {
         notifySafely(
           hasUI,
           ui,
-          `Observational memory: mid-run compaction failed: ${error.message}`,
+          `Observational memory: mid-run compaction failed: ${message}`,
           "error",
         );
-      }
-      // ctx.compact() already aborted the run. In resume mode the agent must
-      // continue regardless of the failed compaction — otherwise it stalls
-      // mid-task with no one at the wheel.
-      if (mode === "resume") {
-        try {
-          pi.sendMessage(
-            {
-              customType: MID_RUN_RESUME_CUSTOM_TYPE,
-              content: MID_RUN_RESUME_MESSAGE,
-              display: true,
-            },
-            { triggerTurn: true },
-          );
-        } catch (sendError) {
-          if (!isStaleExtensionContextError(sendError)) throw sendError;
-        }
       }
     },
   });
@@ -297,6 +294,13 @@ function handleAgentEnd(event: any, ctx: any, runtime: Runtime): void {
       reason: "below_threshold",
       tokens,
       threshold: runtime.config.compactAfterTokens,
+    });
+    return;
+  }
+  if (runtime.midRunCompactionSuspended) {
+    dbg("compaction_trigger.skip", {
+      reason: "suspended_after_mid_run_failure",
+      tokens,
     });
     return;
   }

--- a/src/om/compaction-trigger.ts
+++ b/src/om/compaction-trigger.ts
@@ -115,7 +115,7 @@ async function handleTurnEnd(
   const dbg = (ev: string, d?: Record<string, unknown>) =>
     debugLog(ev, d, runtime.config.debugLog === true);
 
-  const mode = runtime.config.midRunCompaction ?? "resume";
+  const mode = runtime.config.midRunCompaction ?? "off";
   if (mode === "off") {
     dbg("compaction_trigger.turn_end.skip", { reason: "midRunCompaction_off" });
     return;

--- a/src/om/configure-overlay.ts
+++ b/src/om/configure-overlay.ts
@@ -72,7 +72,7 @@ const FIELDS: FieldDef[] = [
     section: "Compaction",
     enumValues: ["resume", "pause", "off"],
     helpText:
-      "resume=compact at threshold during tool loops and continue (default), pause=compact and stop, off=only check when run ends",
+      "resume=transparent same-run compact (default), pause=interrupt+compact+stop, off=end-of-run only",
   },
   {
     key: "compactAfterTokens",

--- a/src/om/configure-overlay.ts
+++ b/src/om/configure-overlay.ts
@@ -72,7 +72,7 @@ const FIELDS: FieldDef[] = [
     section: "Compaction",
     enumValues: ["resume", "pause", "off"],
     helpText:
-      "resume=transparent same-run compact (default), pause=interrupt+compact+stop, off=end-of-run only",
+      "resume=transparent same-run compact, pause=interrupt+compact+stop, off=end-of-run only (default)",
   },
   {
     key: "compactAfterTokens",

--- a/src/om/inline-compaction.ts
+++ b/src/om/inline-compaction.ts
@@ -1,0 +1,525 @@
+import {
+  AgentSession,
+  type CompactionResult,
+} from "@earendil-works/pi-coding-agent";
+import { existsSync, readFileSync, realpathSync } from "node:fs";
+import { dirname, join, parse } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const REGISTRY_KEY = Symbol.for("pi-blackhole:inline-compaction-adapter:v1");
+
+interface TurnContextLike {
+  messages: unknown[];
+  [key: string]: unknown;
+}
+
+interface TurnLike {
+  context: TurnContextLike;
+}
+
+interface NextTurnSnapshotLike {
+  context?: TurnContextLike;
+  [key: string]: unknown;
+}
+
+type PrepareNextTurn = (
+  turn: TurnLike,
+  signal: AbortSignal,
+) => Promise<NextTurnSnapshotLike | undefined>;
+
+interface AgentLike {
+  state: { messages: unknown[] };
+  prepareNextTurnWithContext?: PrepareNextTurn;
+}
+
+interface SessionManagerLike {
+  buildSessionContext(): { messages: unknown[] };
+}
+
+interface PatchableSession {
+  agent: AgentLike;
+  sessionManager: SessionManagerLike;
+  abort(): Promise<void>;
+  compact(customInstructions?: string): Promise<CompactionResult>;
+  _bindExtensionCore(runner: unknown): unknown;
+  _disconnectFromAgent?(): void;
+  _reconnectToAgent?(): void;
+  _compactionAbortController?: AbortController;
+  _autoCompactionAbortController?: AbortController;
+}
+
+type PatchableSessionPrototype = Pick<
+  PatchableSession,
+  "abort" | "compact" | "_bindExtensionCore"
+> &
+  Partial<Pick<PatchableSession, "_disconnectFromAgent" | "_reconnectToAgent">>;
+
+interface PatchableSessionClass {
+  prototype: PatchableSessionPrototype;
+}
+
+interface CompactShape {
+  disconnectsAgent: boolean;
+}
+
+interface InstalledAdapter {
+  status: InlineCompactionAdapterStatus;
+  originalCompact?: PatchableSession["compact"];
+  shape?: CompactShape;
+}
+
+interface SessionRecord {
+  session: PatchableSession;
+  originalCompact: PatchableSession["compact"];
+  shape: CompactShape;
+}
+
+interface AdapterRegistry {
+  installs: WeakMap<object, InstalledAdapter>;
+  sessions: WeakMap<object, SessionRecord>;
+  refreshInstalled: WeakSet<object>;
+  refreshPending: WeakSet<object>;
+  compactionInFlight: WeakSet<object>;
+  hostCandidateCount?: number;
+  capturedSessionCount?: number;
+}
+
+export interface InlineCompactionAdapterStatus {
+  supported: boolean;
+  reason?: string;
+}
+
+export interface InlineCompactionInstallOptions {
+  sessionClass?: PatchableSessionClass;
+}
+
+export interface HostInlineCompactionInstallOptions {
+  entrypoint?: string;
+  stack?: string;
+}
+
+export type InlineCompaction = (
+  sessionManager: object,
+  customInstructions?: string,
+) => Promise<CompactionResult>;
+
+export class InlineCompactionUnavailableError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "InlineCompactionUnavailableError";
+  }
+}
+
+function getRegistry(): AdapterRegistry {
+  const host = globalThis as typeof globalThis & { [key: symbol]: unknown };
+  const existing = host[REGISTRY_KEY] as AdapterRegistry | undefined;
+  if (existing) {
+    existing.hostCandidateCount ??= 0;
+    existing.capturedSessionCount ??= 0;
+    return existing;
+  }
+
+  const registry: AdapterRegistry = {
+    installs: new WeakMap(),
+    sessions: new WeakMap(),
+    refreshInstalled: new WeakSet(),
+    refreshPending: new WeakSet(),
+    compactionInFlight: new WeakSet(),
+    hostCandidateCount: 0,
+    capturedSessionCount: 0,
+  };
+  host[REGISTRY_KEY] = registry;
+  return registry;
+}
+
+function countMethodCalls(source: string, method: string): number {
+  const pattern = new RegExp(`this\\.${method}\\s*\\(\\s*\\)`, "g");
+  return source.match(pattern)?.length ?? 0;
+}
+
+function detectCompactShape(
+  prototype: PatchableSessionPrototype,
+): CompactShape | string {
+  if (typeof prototype.compact !== "function") {
+    return "AgentSession.compact() is missing";
+  }
+  if (typeof prototype.abort !== "function") {
+    return "AgentSession.abort() is missing";
+  }
+  if (typeof prototype._bindExtensionCore !== "function") {
+    return "AgentSession._bindExtensionCore() is missing";
+  }
+
+  const source = Function.prototype.toString.call(prototype.compact);
+  const abortCalls = countMethodCalls(source, "abort");
+  if (
+    abortCalls !== 1 ||
+    !source.includes("appendCompaction") ||
+    !source.includes("agent.state.messages")
+  ) {
+    return "unsupported AgentSession.compact() shape";
+  }
+
+  const disconnectCalls = countMethodCalls(source, "_disconnectFromAgent");
+  const reconnectCalls = countMethodCalls(source, "_reconnectToAgent");
+  if (disconnectCalls === 0 && reconnectCalls === 0) {
+    return { disconnectsAgent: false };
+  }
+  if (
+    disconnectCalls === 1 &&
+    reconnectCalls === 1 &&
+    typeof prototype._disconnectFromAgent === "function" &&
+    typeof prototype._reconnectToAgent === "function"
+  ) {
+    return { disconnectsAgent: true };
+  }
+  return "unsupported AgentSession disconnect/reconnect shape";
+}
+
+function shadowProperty(
+  target: object,
+  key: string,
+  value: unknown,
+): () => void {
+  const record = target as Record<string, unknown>;
+  const ownDescriptor = Object.getOwnPropertyDescriptor(target, key);
+  Object.defineProperty(target, key, {
+    configurable: true,
+    enumerable: ownDescriptor?.enumerable ?? false,
+    writable: true,
+    value,
+  });
+
+  return () => {
+    if (ownDescriptor) {
+      Object.defineProperty(target, key, ownDescriptor);
+    } else {
+      delete record[key];
+    }
+  };
+}
+
+function installNextTurnRefresh(
+  session: PatchableSession,
+  registry: AdapterRegistry,
+): void {
+  const agent = session.agent;
+  if (registry.refreshInstalled.has(agent)) return;
+
+  const previous = agent.prepareNextTurnWithContext;
+  agent.prepareNextTurnWithContext = async (turn, signal) => {
+    const snapshot = await previous?.call(agent, turn, signal);
+    if (!registry.refreshPending.has(session)) return snapshot;
+
+    registry.refreshPending.delete(session);
+    const context = snapshot?.context ?? turn.context;
+    return {
+      ...snapshot,
+      context: {
+        ...context,
+        messages: session.agent.state.messages.slice(),
+      },
+    };
+  };
+  registry.refreshInstalled.add(agent);
+}
+
+function registerSession(
+  session: PatchableSession,
+  installed: InstalledAdapter,
+  registry: AdapterRegistry,
+): void {
+  if (!installed.originalCompact || !installed.shape) return;
+  if (
+    !session.sessionManager ||
+    typeof session.sessionManager !== "object" ||
+    typeof session.sessionManager.buildSessionContext !== "function"
+  ) {
+    return;
+  }
+
+  if (!registry.sessions.has(session.sessionManager)) {
+    registry.capturedSessionCount = (registry.capturedSessionCount ?? 0) + 1;
+  }
+  registry.sessions.set(session.sessionManager, {
+    session,
+    originalCompact: installed.originalCompact,
+    shape: installed.shape,
+  });
+  installNextTurnRefresh(session, registry);
+}
+
+function findPiPackageRoot(startPath: string): string | undefined {
+  let current: string;
+  try {
+    current = dirname(realpathSync(startPath));
+  } catch {
+    return undefined;
+  }
+
+  const filesystemRoot = parse(current).root;
+  while (current !== filesystemRoot) {
+    const packagePath = join(current, "package.json");
+    if (existsSync(packagePath)) {
+      try {
+        const manifest = JSON.parse(readFileSync(packagePath, "utf8")) as {
+          name?: string;
+        };
+        if (manifest.name === "@earendil-works/pi-coding-agent") return current;
+      } catch {
+        // Keep walking: an unrelated malformed package must not select a host.
+      }
+    }
+    current = dirname(current);
+  }
+  return undefined;
+}
+
+function hostFramePaths(stack: string): string[] {
+  const paths: string[] = [];
+  for (const line of stack.split("\n")) {
+    const match =
+      line.match(/\((file:\/\/.*|\/.*):\d+:\d+\)$/) ??
+      line.match(/at (file:\/\/.*|\/.*):\d+:\d+$/);
+    if (!match?.[1]) continue;
+    const rawPath = match[1];
+    if (!rawPath.includes("@earendil-works/pi-coding-agent")) continue;
+    try {
+      paths.push(
+        rawPath.startsWith("file://") ? fileURLToPath(rawPath) : rawPath,
+      );
+    } catch {
+      // Ignore malformed stack locations and continue to the CLI entrypoint.
+    }
+  }
+  return paths;
+}
+
+export async function installHostInlineCompactionAdapter(
+  options: HostInlineCompactionInstallOptions = {},
+): Promise<InlineCompactionAdapterStatus> {
+  const packageRoots = new Set<string>();
+  const stack = options.stack ?? new Error().stack ?? "";
+  for (const framePath of hostFramePaths(stack)) {
+    const root = findPiPackageRoot(framePath);
+    if (root) packageRoots.add(root);
+  }
+
+  const entrypoint = options.entrypoint ?? process.argv[1];
+  if (entrypoint) {
+    const root = findPiPackageRoot(entrypoint);
+    if (root) packageRoots.add(root);
+  }
+  getRegistry().hostCandidateCount = packageRoots.size;
+
+  let supportedStatus: InlineCompactionAdapterStatus | undefined;
+  const failureReasons: string[] = [];
+  for (const packageRoot of packageRoots) {
+    try {
+      const hostModule = (await import(
+        pathToFileURL(join(packageRoot, "dist", "index.js")).href
+      )) as { AgentSession?: PatchableSessionClass };
+      if (!hostModule.AgentSession) {
+        failureReasons.push(`${packageRoot}: AgentSession export missing`);
+        continue;
+      }
+
+      const status = installInlineCompactionAdapter({
+        sessionClass: hostModule.AgentSession,
+      });
+      if (status.supported) supportedStatus ??= status;
+      else
+        failureReasons.push(
+          `${packageRoot}: ${status.reason ?? "unsupported"}`,
+        );
+    } catch (error) {
+      failureReasons.push(
+        `${packageRoot}: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  }
+
+  if (supportedStatus) return supportedStatus;
+  const details =
+    failureReasons.length > 0 ? ` (${failureReasons.join("; ")})` : "";
+  return {
+    supported: false,
+    reason:
+      "Blackhole inline compaction is unavailable: host AgentSession module could not be resolved" +
+      details,
+  };
+}
+
+export function installInlineCompactionAdapter(
+  options: InlineCompactionInstallOptions = {},
+): InlineCompactionAdapterStatus {
+  const sessionClass =
+    options.sessionClass ?? (AgentSession as unknown as PatchableSessionClass);
+  const prototype = sessionClass.prototype;
+  const registry = getRegistry();
+  const existing = registry.installs.get(prototype);
+  if (existing) return existing.status;
+
+  const shape = detectCompactShape(prototype);
+  if (typeof shape === "string") {
+    const status = { supported: false, reason: shape };
+    registry.installs.set(prototype, { status });
+    return status;
+  }
+
+  const originalCompact = prototype.compact;
+  const originalBindExtensionCore = prototype._bindExtensionCore;
+  const installed: InstalledAdapter = {
+    status: { supported: true },
+    originalCompact,
+    shape,
+  };
+
+  prototype._bindExtensionCore = function patchedBindExtensionCore(
+    this: PatchableSession,
+    runner: unknown,
+  ): unknown {
+    registerSession(this, installed, registry);
+    return originalBindExtensionCore.call(this, runner);
+  };
+
+  registry.installs.set(prototype, installed);
+  return installed.status;
+}
+
+function getToolCallId(block: unknown): string | undefined {
+  if (!block || typeof block !== "object") return undefined;
+  const value = block as { type?: unknown; id?: unknown };
+  return value.type === "toolCall" && typeof value.id === "string"
+    ? value.id
+    : undefined;
+}
+
+function hasUnpairedToolCall(messages: unknown[]): boolean {
+  const pending = new Set<string>();
+
+  for (const message of messages) {
+    if (!message || typeof message !== "object") continue;
+    const value = message as {
+      role?: unknown;
+      content?: unknown;
+      toolCallId?: unknown;
+    };
+
+    if (value.role === "assistant" && Array.isArray(value.content)) {
+      for (const block of value.content) {
+        const id = getToolCallId(block);
+        if (id) pending.add(id);
+      }
+      continue;
+    }
+
+    if (value.role === "toolResult" && typeof value.toolCallId === "string") {
+      pending.delete(value.toolCallId);
+    }
+  }
+
+  return pending.size > 0;
+}
+
+/**
+ * Run Pi's native compaction pipeline at an awaited turn_end boundary without
+ * aborting the active agent run. This is intentionally private to Blackhole:
+ * callers must ensure all tools for the turn have completed.
+ */
+export async function compactInlineAtTurnBoundary(
+  sessionManager: object,
+  customInstructions?: string,
+): Promise<CompactionResult> {
+  const registry = getRegistry();
+  const record = registry.sessions.get(sessionManager);
+  if (!record) {
+    throw new InlineCompactionUnavailableError(
+      "Blackhole inline compaction is unavailable: owning AgentSession was not captured or Pi internals are unsupported" +
+        ` (host candidates: ${registry.hostCandidateCount ?? 0}; captured sessions: ${registry.capturedSessionCount ?? 0})`,
+    );
+  }
+
+  const { session, originalCompact, shape } = record;
+  if (
+    registry.compactionInFlight.has(session) ||
+    session._compactionAbortController ||
+    session._autoCompactionAbortController
+  ) {
+    throw new Error("Compaction already in progress");
+  }
+
+  const activeMessages = session.sessionManager.buildSessionContext().messages;
+  if (hasUnpairedToolCall(activeMessages)) {
+    throw new Error(
+      "Cannot compact inline while a tool call is still in flight",
+    );
+  }
+
+  registry.compactionInFlight.add(session);
+  const restores: Array<() => void> = [];
+  const realAbort = session.abort;
+  let abortSuppressed = false;
+  let disconnectSuppressed = false;
+  const messagesBefore = session.agent.state.messages;
+
+  try {
+    if (shape.disconnectsAgent) {
+      const realDisconnect = session._disconnectFromAgent;
+      if (!realDisconnect) {
+        throw new InlineCompactionUnavailableError(
+          "Blackhole inline compaction is unavailable: disconnect hook disappeared",
+        );
+      }
+      restores.push(
+        shadowProperty(
+          session,
+          "_disconnectFromAgent",
+          function inlineDisconnect(this: PatchableSession): void {
+            if (!disconnectSuppressed) {
+              disconnectSuppressed = true;
+              return;
+            }
+            realDisconnect.call(this);
+          },
+        ),
+      );
+    }
+
+    restores.push(
+      shadowProperty(
+        session,
+        "abort",
+        async function inlineAbort(this: PatchableSession): Promise<void> {
+          if (!abortSuppressed) {
+            abortSuppressed = true;
+            return;
+          }
+          this._compactionAbortController?.abort();
+          await realAbort.call(this);
+        },
+      ),
+    );
+
+    const result = await originalCompact.call(session, customInstructions);
+    // Mark the refresh before validating the quiesce invariant. If a future Pi
+    // shape mutates state but does not invoke the expected hook, the error stays
+    // explicit while the still-active loop is prevented from using stale context.
+    registry.refreshPending.add(session);
+    if (!abortSuppressed || (shape.disconnectsAgent && !disconnectSuppressed)) {
+      throw new InlineCompactionUnavailableError(
+        "Blackhole inline compaction invariant failed: Pi quiesce hooks were not invoked as expected",
+      );
+    }
+
+    return result;
+  } catch (error) {
+    if (session.agent.state.messages !== messagesBefore) {
+      registry.refreshPending.add(session);
+    }
+    throw error;
+  } finally {
+    registry.compactionInFlight.delete(session);
+    for (const restore of restores.reverse()) restore();
+  }
+}

--- a/src/om/inline-compaction.ts
+++ b/src/om/inline-compaction.ts
@@ -132,6 +132,63 @@ function getRegistry(): AdapterRegistry {
   return registry;
 }
 
+function maskNonCodeText(source: string): string {
+  const masked = source.split("");
+  let index = 0;
+  const blank = (position: number) => {
+    if (masked[position] !== "\n" && masked[position] !== "\r") {
+      masked[position] = " ";
+    }
+  };
+
+  while (index < source.length) {
+    const current = source[index];
+    const next = source[index + 1];
+
+    if (current === '"' || current === "'" || current === "`") {
+      const delimiter = current;
+      blank(index++);
+      while (index < source.length) {
+        const value = source[index];
+        blank(index);
+        index += 1;
+        if (value === "\\" && index < source.length) {
+          blank(index++);
+          continue;
+        }
+        if (value === delimiter) break;
+      }
+      continue;
+    }
+
+    if (current === "/" && next === "/") {
+      blank(index++);
+      blank(index++);
+      while (index < source.length && source[index] !== "\n") blank(index++);
+      continue;
+    }
+
+    if (current === "/" && next === "*") {
+      blank(index++);
+      blank(index++);
+      while (index < source.length) {
+        const value = source[index];
+        const following = source[index + 1];
+        blank(index++);
+        if (value === "*" && following === "/") {
+          blank(index++);
+          break;
+        }
+      }
+      continue;
+    }
+
+    index += 1;
+  }
+
+  return masked.join("");
+}
+
 function countMethodCalls(source: string, method: string): number {
   const pattern = new RegExp(`this\\.${method}\\s*\\(\\s*\\)`, "g");
   return source.match(pattern)?.length ?? 0;
@@ -150,7 +207,9 @@ function detectCompactShape(
     return "AgentSession._bindExtensionCore() is missing";
   }
 
-  const source = Function.prototype.toString.call(prototype.compact);
+  const source = maskNonCodeText(
+    Function.prototype.toString.call(prototype.compact),
+  );
   const abortCalls = countMethodCalls(source, "abort");
   if (
     abortCalls !== 1 ||
@@ -275,15 +334,25 @@ function findPiPackageRoot(startPath: string): string | undefined {
   return undefined;
 }
 
-function hostFramePaths(stack: string): string[] {
+export function parseHostFramePaths(stack: string): string[] {
   const paths: string[] = [];
   for (const line of stack.split("\n")) {
     const match =
-      line.match(/\((file:\/\/.*|\/.*):\d+:\d+\)$/) ??
-      line.match(/at (file:\/\/.*|\/.*):\d+:\d+$/);
+      line.match(/\((.+):\d+:\d+\)\s*$/) ?? line.match(/\bat (.+):\d+:\d+\s*$/);
     if (!match?.[1]) continue;
-    const rawPath = match[1];
-    if (!rawPath.includes("@earendil-works/pi-coding-agent")) continue;
+    const rawPath = match[1].trim();
+    const normalizedPath = rawPath.replaceAll("\\", "/");
+    if (!normalizedPath.includes("@earendil-works/pi-coding-agent")) {
+      continue;
+    }
+    if (
+      !rawPath.startsWith("file://") &&
+      !rawPath.startsWith("/") &&
+      !rawPath.startsWith("\\\\") &&
+      !/^[A-Za-z]:[\\/]/.test(rawPath)
+    ) {
+      continue;
+    }
     try {
       paths.push(
         rawPath.startsWith("file://") ? fileURLToPath(rawPath) : rawPath,
@@ -300,7 +369,7 @@ export async function installHostInlineCompactionAdapter(
 ): Promise<InlineCompactionAdapterStatus> {
   const packageRoots = new Set<string>();
   const stack = options.stack ?? new Error().stack ?? "";
-  for (const framePath of hostFramePaths(stack)) {
+  for (const framePath of parseHostFramePaths(stack)) {
     const root = findPiPackageRoot(framePath);
     if (root) packageRoots.add(root);
   }
@@ -463,63 +532,95 @@ export async function compactInlineAtTurnBoundary(
   let disconnectSuppressed = false;
   const messagesBefore = session.agent.state.messages;
 
+  let result!: CompactionResult;
+  let operationFailed = false;
+  let operationError: unknown;
+  const cleanupErrors: unknown[] = [];
+
   try {
-    if (shape.disconnectsAgent) {
-      const realDisconnect = session._disconnectFromAgent;
-      if (!realDisconnect) {
-        throw new InlineCompactionUnavailableError(
-          "Blackhole inline compaction is unavailable: disconnect hook disappeared",
+    try {
+      if (shape.disconnectsAgent) {
+        const realDisconnect = session._disconnectFromAgent;
+        if (!realDisconnect) {
+          throw new InlineCompactionUnavailableError(
+            "Blackhole inline compaction is unavailable: disconnect hook disappeared",
+          );
+        }
+        restores.push(
+          shadowProperty(
+            session,
+            "_disconnectFromAgent",
+            function inlineDisconnect(this: PatchableSession): void {
+              if (!disconnectSuppressed) {
+                disconnectSuppressed = true;
+                return;
+              }
+              realDisconnect.call(this);
+            },
+          ),
         );
       }
+
       restores.push(
         shadowProperty(
           session,
-          "_disconnectFromAgent",
-          function inlineDisconnect(this: PatchableSession): void {
-            if (!disconnectSuppressed) {
-              disconnectSuppressed = true;
+          "abort",
+          async function inlineAbort(this: PatchableSession): Promise<void> {
+            if (!abortSuppressed) {
+              abortSuppressed = true;
               return;
             }
-            realDisconnect.call(this);
+            this._compactionAbortController?.abort();
+            await realAbort.call(this);
           },
         ),
       );
-    }
 
-    restores.push(
-      shadowProperty(
-        session,
-        "abort",
-        async function inlineAbort(this: PatchableSession): Promise<void> {
-          if (!abortSuppressed) {
-            abortSuppressed = true;
-            return;
-          }
-          this._compactionAbortController?.abort();
-          await realAbort.call(this);
-        },
-      ),
-    );
-
-    const result = await originalCompact.call(session, customInstructions);
-    // Mark the refresh before validating the quiesce invariant. If a future Pi
-    // shape mutates state but does not invoke the expected hook, the error stays
-    // explicit while the still-active loop is prevented from using stale context.
-    registry.refreshPending.add(session);
-    if (!abortSuppressed || (shape.disconnectsAgent && !disconnectSuppressed)) {
-      throw new InlineCompactionUnavailableError(
-        "Blackhole inline compaction invariant failed: Pi quiesce hooks were not invoked as expected",
-      );
-    }
-
-    return result;
-  } catch (error) {
-    if (session.agent.state.messages !== messagesBefore) {
+      result = await originalCompact.call(session, customInstructions);
+      // Mark the refresh before validating the quiesce invariant. If a future Pi
+      // shape mutates state but does not invoke the expected hook, the error stays
+      // explicit while the still-active loop is prevented from using stale context.
       registry.refreshPending.add(session);
+      if (
+        !abortSuppressed ||
+        (shape.disconnectsAgent && !disconnectSuppressed)
+      ) {
+        throw new InlineCompactionUnavailableError(
+          "Blackhole inline compaction invariant failed: Pi quiesce hooks were not invoked as expected",
+        );
+      }
+    } catch (error) {
+      if (session.agent.state.messages !== messagesBefore) {
+        registry.refreshPending.add(session);
+      }
+      operationFailed = true;
+      operationError = error;
     }
-    throw error;
   } finally {
     registry.compactionInFlight.delete(session);
-    for (const restore of restores.reverse()) restore();
+    for (let index = restores.length - 1; index >= 0; index -= 1) {
+      try {
+        restores[index]();
+      } catch (error) {
+        cleanupErrors.push(error);
+      }
+    }
   }
+
+  if (operationFailed) {
+    if (cleanupErrors.length > 0) {
+      throw new AggregateError(
+        [operationError, ...cleanupErrors],
+        "Blackhole inline compaction failed and could not restore all session properties",
+      );
+    }
+    throw operationError;
+  }
+  if (cleanupErrors.length > 0) {
+    throw new AggregateError(
+      cleanupErrors,
+      "Blackhole inline compaction could not restore all session properties",
+    );
+  }
+  return result;
 }

--- a/src/om/inline-compaction.ts
+++ b/src/om/inline-compaction.ts
@@ -134,55 +134,126 @@ function getRegistry(): AdapterRegistry {
 
 function maskNonCodeText(source: string): string {
   const masked = source.split("");
-  let index = 0;
   const blank = (position: number) => {
     if (masked[position] !== "\n" && masked[position] !== "\r") {
       masked[position] = " ";
     }
   };
 
+  const maskQuoted = (start: number, delimiter: string): number => {
+    let index = start;
+    blank(index++);
+    while (index < source.length) {
+      const value = source[index];
+      blank(index++);
+      if (value === "\\" && index < source.length) {
+        blank(index++);
+        continue;
+      }
+      if (value === delimiter) break;
+    }
+    return index;
+  };
+
+  const maskLineComment = (start: number): number => {
+    let index = start;
+    blank(index++);
+    blank(index++);
+    while (index < source.length && source[index] !== "\n") blank(index++);
+    return index;
+  };
+
+  const maskBlockComment = (start: number): number => {
+    let index = start;
+    blank(index++);
+    blank(index++);
+    while (index < source.length) {
+      const value = source[index];
+      const next = source[index + 1];
+      blank(index++);
+      if (value === "*" && next === "/") {
+        blank(index++);
+        break;
+      }
+    }
+    return index;
+  };
+
+  function maskTemplateExpression(start: number): number {
+    let index = start;
+    let braceDepth = 1;
+    while (index < source.length && braceDepth > 0) {
+      const current = source[index];
+      const next = source[index + 1];
+      if (current === '"' || current === "'") {
+        index = maskQuoted(index, current);
+        continue;
+      }
+      if (current === "`") {
+        index = maskTemplate(index);
+        continue;
+      }
+      if (current === "/" && next === "/") {
+        index = maskLineComment(index);
+        continue;
+      }
+      if (current === "/" && next === "*") {
+        index = maskBlockComment(index);
+        continue;
+      }
+      if (current === "{") braceDepth += 1;
+      if (current === "}") braceDepth -= 1;
+      blank(index++);
+    }
+    return index;
+  }
+
+  function maskTemplate(start: number): number {
+    let index = start;
+    blank(index++);
+    while (index < source.length) {
+      const current = source[index];
+      const next = source[index + 1];
+      if (current === "\\") {
+        blank(index++);
+        if (index < source.length) blank(index++);
+        continue;
+      }
+      if (current === "`") {
+        blank(index++);
+        break;
+      }
+      if (current === "$" && next === "{") {
+        blank(index++);
+        blank(index++);
+        index = maskTemplateExpression(index);
+        continue;
+      }
+      blank(index++);
+    }
+    return index;
+  }
+
+  let index = 0;
   while (index < source.length) {
     const current = source[index];
     const next = source[index + 1];
-
-    if (current === '"' || current === "'" || current === "`") {
-      const delimiter = current;
-      blank(index++);
-      while (index < source.length) {
-        const value = source[index];
-        blank(index);
-        index += 1;
-        if (value === "\\" && index < source.length) {
-          blank(index++);
-          continue;
-        }
-        if (value === delimiter) break;
-      }
+    if (current === '"' || current === "'") {
+      index = maskQuoted(index, current);
       continue;
     }
-
+    if (current === "`") {
+      index = maskTemplate(index);
+      continue;
+    }
     if (current === "/" && next === "/") {
-      blank(index++);
-      blank(index++);
-      while (index < source.length && source[index] !== "\n") blank(index++);
+      index = maskLineComment(index);
       continue;
     }
-
     if (current === "/" && next === "*") {
-      blank(index++);
-      blank(index++);
-      while (index < source.length) {
-        const value = source[index];
-        const following = source[index + 1];
-        blank(index++);
-        if (value === "*" && following === "/") {
-          blank(index++);
-          break;
-        }
-      }
+      index = maskBlockComment(index);
       continue;
     }
-
     index += 1;
   }
 

--- a/src/om/runtime.ts
+++ b/src/om/runtime.ts
@@ -94,7 +94,7 @@ export class Runtime {
   autoCompactionController: AbortController | null = null;
   /** Mid-run (turn_end) compaction is suspended after a failed/cancelled attempt
    * at the current pressure level. Cleared when accumulated tokens drop below
-   * the threshold again (i.e. a compaction ran). Prevents abort/cancel thrash. */
+   * the threshold again (i.e. a compaction ran). Prevents per-turn retry thrash. */
   midRunCompactionSuspended = false;
   resolveFailureNotified = false;
   lastObserverError: string | undefined;

--- a/src/pi-base/blackhole-settings.ts
+++ b/src/pi-base/blackhole-settings.ts
@@ -95,12 +95,12 @@ export const config = new ConfigManager<UnifiedConfig>({
       type: "enum",
       label: "Mid-run compaction",
       description:
-        "resume=compact at threshold during tool loops and continue (default), pause=compact and stop, off=only check when run ends",
+        "resume=compact transparently and continue the same run (default), pause=interrupt and stop, off=only check when run ends",
       value: cfg.midRunCompaction,
       options: ["resume", "pause", "off"],
       optionLabels: {
-        resume: "resume — compact and continue (default)",
-        pause: "pause — compact and stop",
+        resume: "resume — transparent compact, same run (default)",
+        pause: "pause — interrupt, compact, and stop",
         off: "off — only check when run ends",
       },
     },

--- a/src/pi-base/blackhole-settings.ts
+++ b/src/pi-base/blackhole-settings.ts
@@ -95,13 +95,13 @@ export const config = new ConfigManager<UnifiedConfig>({
       type: "enum",
       label: "Mid-run compaction",
       description:
-        "resume=compact transparently and continue the same run (default), pause=interrupt and stop, off=only check when run ends",
+        "resume=compact transparently and continue the same run, pause=interrupt and stop, off=only check when run ends (default)",
       value: cfg.midRunCompaction,
       options: ["resume", "pause", "off"],
       optionLabels: {
-        resume: "resume — transparent compact, same run (default)",
+        resume: "resume — transparent compact, same run",
         pause: "pause — interrupt, compact, and stop",
-        off: "off — only check when run ends",
+        off: "off — only check when run ends (default)",
       },
     },
     {

--- a/tests/compaction-trigger.test.ts
+++ b/tests/compaction-trigger.test.ts
@@ -54,10 +54,12 @@ function captureHandler(
     /** NEW: Mid-run (turn_end) compaction behavior */
     midRunCompaction?: "resume" | "pause" | "off";
   } = {},
+  inlineCompact = vi.fn(async () => ({ summary: "inline summary" })),
 ) {
   let agentEndHandler: ((event: unknown, ctx: unknown) => void) | undefined;
   let agentStartHandler: (() => void) | undefined;
-  let turnEndHandler: ((event: unknown, ctx: unknown) => void) | undefined;
+  let turnEndHandler:
+    ((event: unknown, ctx: unknown) => void | Promise<void>) | undefined;
   const pi = {
     on: vi.fn((name: string, cb: any) => {
       if (name === "agent_end") agentEndHandler = cb;
@@ -93,8 +95,9 @@ function captureHandler(
     },
     compactInFlight: args.compactInFlight ?? false,
     autoCompactionController: null as AbortController | null,
+    midRunCompactionSuspended: false,
   };
-  registerCompactionTrigger(pi as any, runtime as any);
+  registerCompactionTrigger(pi as any, runtime as any, inlineCompact);
   if (!agentEndHandler) throw new Error("agent_end handler was not registered");
   if (!agentStartHandler)
     throw new Error("agent_start handler was not registered");
@@ -105,6 +108,7 @@ function captureHandler(
     turnHandler: turnEndHandler,
     runtime,
     pi,
+    inlineCompact,
   };
 }
 
@@ -535,38 +539,69 @@ describe("mid-run compaction trigger (turn_end)", () => {
     expect(ctx.compact).not.toHaveBeenCalled();
   });
 
-  it("M2: compacts immediately at threshold — no idle wait, agent is mid-run by definition", () => {
-    const { turnHandler, runtime } = captureHandler({
+  it("M2: awaits transparent compaction immediately at the threshold", async () => {
+    const { turnHandler, runtime, inlineCompact } = captureHandler({
       compactAfterTokens: 3,
       midRunCompaction: "resume",
     });
     const ctx = fakeCtx([dueBranch]);
 
-    turnHandler(turnEnd(), ctx);
+    const pending = turnHandler(turnEnd(), ctx);
 
-    // Synchronous: no flushAll/timer advance — ctx.compact must already be called.
     expect(runtime.compactInFlight).toBe(true);
-    expect(ctx.compact).toHaveBeenCalledTimes(1);
+    expect(inlineCompact).toHaveBeenCalledOnce();
+    expect(inlineCompact).toHaveBeenCalledWith(ctx.sessionManager);
+    expect(ctx.compact).not.toHaveBeenCalled();
     expect(ctx.isIdle).not.toHaveBeenCalled();
+
+    await pending;
+    expect(runtime.compactInFlight).toBe(false);
   });
 
-  it("M3: resume mode — onComplete injects a resume message with triggerTurn", () => {
+  it("M3: resume mode continues the same run without a synthetic message", async () => {
     const { turnHandler, runtime, pi } = captureHandler({
       compactAfterTokens: 3,
       midRunCompaction: "resume",
     });
     const ctx = fakeCtx([dueBranch]);
-    turnHandler(turnEnd(), ctx);
-    const options = ctx.compact.mock.calls[0][0];
-    options.onComplete({});
+
+    await turnHandler(turnEnd(), ctx);
 
     expect(runtime.compactInFlight).toBe(false);
-    expect(pi.sendMessage).toHaveBeenCalledTimes(1);
-    const [message, sendOptions] = pi.sendMessage.mock.calls[0];
-    expect(message.customType).toBe("blackhole-resume");
-    expect(typeof message.content).toBe("string");
-    expect(message.content.length).toBeGreaterThan(0);
-    expect(sendOptions).toMatchObject({ triggerTurn: true });
+    expect(ctx.compact).not.toHaveBeenCalled();
+    expect(pi.sendMessage).not.toHaveBeenCalled();
+  });
+
+  it("M3a: keeps the outer run pending until inline compaction finishes", async () => {
+    let release: (() => void) | undefined;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const inlineCompact = vi.fn(async () => {
+      await gate;
+      return { summary: "inline summary" };
+    });
+    const { turnHandler } = captureHandler(
+      {
+        compactAfterTokens: 3,
+        midRunCompaction: "resume",
+      },
+      inlineCompact,
+    );
+    const ctx = fakeCtx([dueBranch]);
+    let continued = false;
+
+    const outerRun = (async () => {
+      await turnHandler(turnEnd(), ctx);
+      continued = true;
+      return "continued";
+    })();
+    await Promise.resolve();
+
+    expect(continued).toBe(false);
+    release?.();
+    await expect(outerRun).resolves.toBe("continued");
+    expect(continued).toBe(true);
   });
 
   it("M4: pause mode compacts but does not inject a resume message", () => {
@@ -601,22 +636,25 @@ describe("mid-run compaction trigger (turn_end)", () => {
     expect(ctx.compact).toHaveBeenCalledTimes(1);
   });
 
-  it("M6: onError clears compactInFlight, suspends further attempts, and still resumes (resume mode)", () => {
-    const { turnHandler, runtime, pi } = captureHandler({
-      compactAfterTokens: 3,
-      midRunCompaction: "resume",
+  it("M6: inline failure clears in-flight state and suspends retries without aborting", async () => {
+    const inlineCompact = vi.fn(async () => {
+      throw new Error("boom");
     });
+    const { turnHandler, runtime, pi } = captureHandler(
+      {
+        compactAfterTokens: 3,
+        midRunCompaction: "resume",
+      },
+      inlineCompact,
+    );
     const ctx = fakeCtx([dueBranch]);
 
-    turnHandler(turnEnd(), ctx);
-    const options = ctx.compact.mock.calls[0][0];
-    options.onError({ message: "boom" });
+    await turnHandler(turnEnd(), ctx);
 
     expect(runtime.compactInFlight).toBe(false);
     expect(runtime.midRunCompactionSuspended).toBe(true);
-    // The run was already aborted by ctx.compact() — resume mode must still
-    // send the resume message or the agent stalls mid-task.
-    expect(pi.sendMessage).toHaveBeenCalledTimes(1);
+    expect(ctx.compact).not.toHaveBeenCalled();
+    expect(pi.sendMessage).not.toHaveBeenCalled();
   });
 
   it("M7: skips when compaction is already in flight", () => {
@@ -629,6 +667,22 @@ describe("mid-run compaction trigger (turn_end)", () => {
     turnHandler(turnEnd(), ctx);
 
     expect(ctx.sessionManager.getBranch).not.toHaveBeenCalled();
+    expect(ctx.compact).not.toHaveBeenCalled();
+  });
+
+  it("M7a: skips inline compaction when another operation already aborted the run", async () => {
+    const { turnHandler, inlineCompact } = captureHandler({
+      compactAfterTokens: 3,
+      midRunCompaction: "resume",
+    });
+    const controller = new AbortController();
+    controller.abort();
+    const ctx = fakeCtx([dueBranch], { signal: controller.signal });
+
+    await turnHandler(turnEnd(), ctx);
+
+    expect(ctx.sessionManager.getBranch).not.toHaveBeenCalled();
+    expect(inlineCompact).not.toHaveBeenCalled();
     expect(ctx.compact).not.toHaveBeenCalled();
   });
 
@@ -737,44 +791,74 @@ describe("mid-run compaction trigger (turn_end)", () => {
 });
 
 describe("mid-run compaction cancellation resilience", () => {
-  it("M15: cancelled compaction still resumes the agent and suspends further mid-run attempts", () => {
-    const { turnHandler, runtime, pi } = captureHandler({
-      compactAfterTokens: 3,
-      midRunCompaction: "resume",
+  it("M15: cancelled inline compaction suspends retries without injecting continuation", async () => {
+    const inlineCompact = vi.fn(async () => {
+      throw new Error("Compaction cancelled");
     });
+    const { turnHandler, runtime, pi } = captureHandler(
+      {
+        compactAfterTokens: 3,
+        midRunCompaction: "resume",
+      },
+      inlineCompact,
+    );
     const ctx = fakeCtx([dueBranch, dueBranch]);
-    turnHandler(turnEnd(), ctx);
-    const options = ctx.compact.mock.calls[0][0];
-    // The before-compact hook cancelled (e.g. too few live messages).
-    // The run was already aborted by ctx.compact() — without a resume
-    // message the agent would stall mid-task.
-    options.onError({ message: "Compaction cancelled" });
+
+    await turnHandler(turnEnd(), ctx);
 
     expect(runtime.compactInFlight).toBe(false);
-    expect(pi.sendMessage).toHaveBeenCalledTimes(1);
+    expect(runtime.midRunCompactionSuspended).toBe(true);
+    expect(pi.sendMessage).not.toHaveBeenCalled();
 
-    // Next turn_end must NOT re-trigger (tokens unchanged, compaction would
-    // cancel again — abort/cancel thrash loop).
-    turnHandler(turnEnd(), ctx);
-    expect(ctx.compact).toHaveBeenCalledTimes(1);
+    await turnHandler(turnEnd(), ctx);
+    expect(inlineCompact).toHaveBeenCalledTimes(1);
   });
 
-  it("M16: suspension clears once pressure drops below threshold (successful compaction elsewhere)", () => {
-    const { turnHandler } = captureHandler({
-      compactAfterTokens: 3,
-      midRunCompaction: "resume",
+  it("M15a: agent_end does not immediately retry a failed mid-run compaction", async () => {
+    const inlineCompact = vi.fn(async () => {
+      throw new Error("Compaction cancelled");
     });
-    // Sequence: due (trigger+cancel) → due (suspended) → below (clears) → due (triggers again)
+    const { turnHandler, handler, runtime } = captureHandler(
+      {
+        compactAfterTokens: 3,
+        midRunCompaction: "resume",
+      },
+      inlineCompact,
+    );
+    const ctx = fakeCtx([dueBranch, dueBranch]);
+
+    await turnHandler(turnEnd(), ctx);
+    expect(runtime.midRunCompactionSuspended).toBe(true);
+
+    handler(agentEnd(), ctx);
+
+    expect(inlineCompact).toHaveBeenCalledTimes(1);
+    expect(ctx.compact).not.toHaveBeenCalled();
+    expect(runtime.compactInFlight).toBe(false);
+  });
+
+  it("M16: suspension clears once pressure drops below threshold", async () => {
+    const inlineCompact = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("Compaction cancelled"))
+      .mockResolvedValue({ summary: "inline summary" });
+    const { turnHandler } = captureHandler(
+      {
+        compactAfterTokens: 3,
+        midRunCompaction: "resume",
+      },
+      inlineCompact,
+    );
+    // Sequence: due (cancel) → due (suspended) → below (clear) → due (trigger again)
     const ctx = fakeCtx([dueBranch, dueBranch, belowBranch, dueBranch]);
 
-    turnHandler(turnEnd(), ctx);
-    ctx.compact.mock.calls[0][0].onError({ message: "Compaction cancelled" });
-    turnHandler(turnEnd(), ctx); // suspended — no new compact
-    expect(ctx.compact).toHaveBeenCalledTimes(1);
+    await turnHandler(turnEnd(), ctx);
+    await turnHandler(turnEnd(), ctx);
+    expect(inlineCompact).toHaveBeenCalledTimes(1);
 
-    turnHandler(turnEnd(), ctx); // below threshold — clears suspension
-    turnHandler(turnEnd(), ctx); // due again — triggers
-    expect(ctx.compact).toHaveBeenCalledTimes(2);
+    await turnHandler(turnEnd(), ctx);
+    await turnHandler(turnEnd(), ctx);
+    expect(inlineCompact).toHaveBeenCalledTimes(2);
   });
 
   it("M17: pause mode does not resume on cancellation", () => {

--- a/tests/config-simplification.test.ts
+++ b/tests/config-simplification.test.ts
@@ -80,6 +80,7 @@ describe("New config keys — defaults", () => {
     expect(config.compaction).toBe("auto");
     expect(config.compactionEngine).toBe("blackhole");
     expect(config.tailBehavior).toBe("minimal");
+    expect(config.midRunCompaction).toBe("resume");
   });
 
   it("T1b: existing old DEFAULTS are preserved", async () => {

--- a/tests/config-simplification.test.ts
+++ b/tests/config-simplification.test.ts
@@ -80,7 +80,16 @@ describe("New config keys — defaults", () => {
     expect(config.compaction).toBe("auto");
     expect(config.compactionEngine).toBe("blackhole");
     expect(config.tailBehavior).toBe("minimal");
-    expect(config.midRunCompaction).toBe("resume");
+    expect(config.midRunCompaction).toBe("off");
+  });
+
+  it("T1a: existing configs without midRunCompaction remain off", async () => {
+    const { loadUnifiedConfig } = await import("../src/core/unified-config.js");
+    writeConfig({ memory: true });
+
+    const config = loadUnifiedConfig(testDir);
+
+    expect(config.midRunCompaction).toBe("off");
   });
 
   it("T1b: existing old DEFAULTS are preserved", async () => {
@@ -116,6 +125,15 @@ describe("New key parsing", () => {
     writeConfig({ tailBehavior: "minimal" });
     const config = loadUnifiedConfig(testDir);
     expect(config.tailBehavior).toBe("minimal");
+  });
+
+  it("parses an explicit midRunCompaction opt-in", async () => {
+    const { loadUnifiedConfig } = await import("../src/core/unified-config.js");
+    writeConfig({ midRunCompaction: "resume" });
+
+    const config = loadUnifiedConfig(testDir);
+
+    expect(config.midRunCompaction).toBe("resume");
   });
 
   it("T11: invalid compaction value falls back to default", async () => {

--- a/tests/fixtures/pi-agent-session.ts
+++ b/tests/fixtures/pi-agent-session.ts
@@ -1,0 +1,113 @@
+import { Agent, type AgentTool } from "@earendil-works/pi-agent-core";
+import { InMemoryCredentialStore, type FauxProviderRegistration, type FauxResponseStep } from "@earendil-works/pi-ai";
+import { registerFauxProvider, streamSimple } from "@earendil-works/pi-ai/compat";
+import { AgentSession, convertToLlm, createExtensionRuntime, ModelRuntime, SessionManager, SettingsManager, type ResourceLoader } from "@earendil-works/pi-coding-agent";
+
+/** Minimal public-API adaptation of Pi's MIT-licensed v0.84 test harness. */
+export interface PiAgentSessionHarness {
+  agent: Agent;
+  session: AgentSession;
+  sessionManager: SessionManager;
+  setResponses(responses: FauxResponseStep[]): void;
+  cleanup(): void;
+}
+
+function createEmptyResourceLoader(): ResourceLoader {
+  const extensionsResult = {
+    extensions: [],
+    errors: [],
+    runtime: createExtensionRuntime(),
+  };
+
+  return {
+    getExtensions: () => extensionsResult,
+    getSkills: () => ({ skills: [], diagnostics: [] }),
+    getPrompts: () => ({ prompts: [], diagnostics: [] }),
+    getThemes: () => ({ themes: [], diagnostics: [] }),
+    getAgentsFiles: () => ({ agentsFiles: [] }),
+    getSystemPrompt: () => undefined,
+    getSystemPromptSource: () => undefined,
+    getAppendSystemPrompt: () => [],
+    getAppendSystemPromptSources: () => [],
+    extendResources: () => {},
+    reload: async () => {},
+  };
+}
+
+function registerRuntimeProvider(runtime: ModelRuntime, faux: FauxProviderRegistration): void {
+  const model = faux.getModel();
+  runtime.registerProvider(model.provider, {
+    baseUrl: model.baseUrl,
+    apiKey: "faux-key",
+    api: faux.api,
+    models: faux.models.map((registeredModel) => ({
+      id: registeredModel.id,
+      name: registeredModel.name,
+      api: registeredModel.api,
+      reasoning: registeredModel.reasoning,
+      input: registeredModel.input,
+      cost: registeredModel.cost,
+      contextWindow: registeredModel.contextWindow,
+      maxTokens: registeredModel.maxTokens,
+      baseUrl: registeredModel.baseUrl,
+    })),
+  });
+}
+
+export async function createPiAgentSessionHarness(tools: AgentTool[]): Promise<PiAgentSessionHarness> {
+  const faux = registerFauxProvider();
+  faux.setResponses([]);
+  const model = faux.getModel();
+
+  const credentials = new InMemoryCredentialStore();
+  await credentials.modify(model.provider, async () => ({
+    type: "api_key",
+    key: "faux-key",
+  }));
+  const modelRuntime = await ModelRuntime.create({
+    credentials,
+    modelsPath: null,
+    allowModelNetwork: false,
+  });
+  registerRuntimeProvider(modelRuntime, faux);
+
+  const agent = new Agent({
+    getApiKey: () => "faux-key",
+    streamFn: streamSimple,
+    initialState: {
+      model,
+      systemPrompt: "You are a test assistant.",
+      tools: [],
+    },
+    convertToLlm,
+  });
+  const sessionManager = SessionManager.inMemory();
+  const settingsManager = SettingsManager.inMemory({
+    compaction: {
+      enabled: true,
+      reserveTokens: 1_024,
+      keepRecentTokens: 1_000,
+    },
+  });
+  const session = new AgentSession({
+    agent,
+    sessionManager,
+    settingsManager,
+    cwd: process.cwd(),
+    modelRuntime,
+    resourceLoader: createEmptyResourceLoader(),
+    baseToolsOverride: Object.fromEntries(tools.map((tool) => [tool.name, tool])),
+    initialActiveToolNames: tools.map((tool) => tool.name),
+  });
+
+  return {
+    agent,
+    session,
+    sessionManager,
+    setResponses: faux.setResponses,
+    cleanup() {
+      session.dispose();
+      faux.unregister();
+    },
+  };
+}

--- a/tests/inline-compaction.test.ts
+++ b/tests/inline-compaction.test.ts
@@ -1,0 +1,580 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import { describe, expect, it, vi } from "vitest";
+import type { AgentTool } from "@earendil-works/pi-agent-core";
+import {
+  fauxAssistantMessage,
+  fauxToolCall,
+  type Context,
+} from "@earendil-works/pi-ai/compat";
+import { Type } from "typebox";
+import { convertToLlm } from "@earendil-works/pi-coding-agent";
+
+import {
+  compactInlineAtTurnBoundary,
+  InlineCompactionUnavailableError,
+  installHostInlineCompactionAdapter,
+  installInlineCompactionAdapter,
+} from "../src/om/inline-compaction.js";
+import { createPiAgentSessionHarness } from "./fixtures/pi-agent-session.js";
+
+interface FakeTurnContext {
+  messages: unknown[];
+  systemPrompt: string;
+  tools: unknown[];
+}
+
+interface FakeTurn {
+  context: FakeTurnContext;
+}
+
+function createDeferred() {
+  let release!: () => void;
+  const promise = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  let released = false;
+  return {
+    promise,
+    release() {
+      if (released) return;
+      released = true;
+      release();
+    },
+  };
+}
+
+function createSessionClass(options: {
+  legacyDisconnect?: boolean;
+  activeMessages?: unknown[];
+  summaryGate?: Promise<void>;
+}) {
+  const activeMessages = options.activeMessages ?? [
+    { role: "user", content: "before" },
+    { role: "assistant", content: "done", stopReason: "stop" },
+  ];
+
+  class FakeSessionBase {
+    originalAbortCalls = 0;
+    disconnectCalls = 0;
+    reconnectCalls = 0;
+    bindCalls = 0;
+    compactCalls = 0;
+    customInstructions: string | undefined;
+    _compactionAbortController: AbortController | undefined;
+    _autoCompactionAbortController: AbortController | undefined;
+
+    sessionManager = {
+      buildSessionContext: vi.fn(() => ({ messages: activeMessages })),
+      appendCompaction: vi.fn(),
+    };
+
+    agent = {
+      state: {
+        messages: [{ role: "user", content: "stale" }] as unknown[],
+      },
+      prepareNextTurnWithContext: vi.fn(
+        async (turn: FakeTurn): Promise<{ context: FakeTurnContext }> => ({
+          context: turn.context,
+        }),
+      ),
+    };
+
+    async abort(): Promise<void> {
+      this.originalAbortCalls += 1;
+      this._compactionAbortController?.abort();
+    }
+
+    _disconnectFromAgent(): void {
+      this.disconnectCalls += 1;
+    }
+
+    _reconnectToAgent(): void {
+      this.reconnectCalls += 1;
+    }
+
+    _bindExtensionCore(runner: unknown): void {
+      void runner;
+      this.bindCalls += 1;
+    }
+  }
+
+  if (options.legacyDisconnect) {
+    return class LegacySession extends FakeSessionBase {
+      async compact(customInstructions?: string) {
+        this._disconnectFromAgent();
+        await this.abort();
+        this._compactionAbortController = new AbortController();
+        try {
+          await options.summaryGate;
+          if (this._compactionAbortController.signal.aborted) {
+            throw new Error("Compaction cancelled");
+          }
+          this.compactCalls += 1;
+          this.customInstructions = customInstructions;
+          this.sessionManager.appendCompaction();
+          this.agent.state.messages = [
+            { role: "user", content: "summary" },
+            { role: "assistant", content: "kept-tail" },
+          ];
+          return {
+            summary: "summary",
+            firstKeptEntryId: "kept-1",
+            tokensBefore: 42,
+          };
+        } finally {
+          this._compactionAbortController = undefined;
+          this._reconnectToAgent();
+        }
+      }
+    };
+  }
+
+  return class ModernSession extends FakeSessionBase {
+    async compact(customInstructions?: string) {
+      await this.abort();
+      this._compactionAbortController = new AbortController();
+      try {
+        await options.summaryGate;
+        if (this._compactionAbortController.signal.aborted) {
+          throw new Error("Compaction cancelled");
+        }
+        this.compactCalls += 1;
+        this.customInstructions = customInstructions;
+        this.sessionManager.appendCompaction();
+        this.agent.state.messages = [
+          { role: "user", content: "summary" },
+          { role: "assistant", content: "kept-tail" },
+        ];
+        return {
+          summary: "summary",
+          firstKeptEntryId: "kept-1",
+          tokensBefore: 42,
+        };
+      } finally {
+        this._compactionAbortController = undefined;
+      }
+    }
+  };
+}
+
+async function refreshNextTurn(
+  session: InstanceType<ReturnType<typeof createSessionClass>>,
+) {
+  return await session.agent.prepareNextTurnWithContext(
+    {
+      context: {
+        messages: [{ role: "user", content: "uncompacted-loop-snapshot" }],
+        systemPrompt: "system",
+        tools: [],
+      },
+    },
+    new AbortController().signal,
+  );
+}
+
+describe("Blackhole inline compaction adapter", () => {
+  it.each([
+    ["Pi 0.81 legacy disconnect shape", true],
+    ["Pi 0.84 connected-listener shape", false],
+  ])(
+    "compacts without aborting the active run on %s",
+    async (_label, legacyDisconnect) => {
+      const SessionClass = createSessionClass({ legacyDisconnect });
+      const status = installInlineCompactionAdapter({
+        sessionClass: SessionClass as never,
+      });
+      const session = new SessionClass();
+
+      session._bindExtensionCore({});
+      const result = await compactInlineAtTurnBoundary(
+        session.sessionManager,
+        "preserve active work",
+      );
+
+      expect(status).toEqual({ supported: true });
+      expect(result.summary).toBe("summary");
+      expect(session.customInstructions).toBe("preserve active work");
+      expect(session.compactCalls).toBe(1);
+      expect(session.originalAbortCalls).toBe(0);
+      expect(session.disconnectCalls).toBe(0);
+      expect(session.reconnectCalls).toBe(legacyDisconnect ? 1 : 0);
+      expect(session.bindCalls).toBe(1);
+    },
+  );
+
+  it("replaces the low-level loop snapshot with compacted agent messages on the next turn", async () => {
+    const SessionClass = createSessionClass({ legacyDisconnect: false });
+    installInlineCompactionAdapter({ sessionClass: SessionClass as never });
+    const session = new SessionClass();
+    session._bindExtensionCore({});
+
+    await compactInlineAtTurnBoundary(session.sessionManager);
+    const next = await refreshNextTurn(session);
+
+    expect(next.context.messages).toEqual([
+      { role: "user", content: "summary" },
+      { role: "assistant", content: "kept-tail" },
+    ]);
+  });
+
+  it("rejects before mutation when the active branch has an unpaired tool call", async () => {
+    const SessionClass = createSessionClass({
+      legacyDisconnect: false,
+      activeMessages: [
+        {
+          role: "assistant",
+          content: [
+            { type: "toolCall", id: "tool-1", name: "read", arguments: {} },
+          ],
+        },
+      ],
+    });
+    installInlineCompactionAdapter({ sessionClass: SessionClass as never });
+    const session = new SessionClass();
+    session._bindExtensionCore({});
+
+    await expect(
+      compactInlineAtTurnBoundary(session.sessionManager),
+    ).rejects.toThrow("tool call is still in flight");
+    expect(session.compactCalls).toBe(0);
+    expect(session.originalAbortCalls).toBe(0);
+  });
+
+  it("passes a later external abort through and cancels the inline summary", async () => {
+    let releaseSummary: (() => void) | undefined;
+    const summaryGate = new Promise<void>((resolve) => {
+      releaseSummary = resolve;
+    });
+    const SessionClass = createSessionClass({
+      legacyDisconnect: false,
+      summaryGate,
+    });
+    installInlineCompactionAdapter({ sessionClass: SessionClass as never });
+    const session = new SessionClass();
+    session._bindExtensionCore({});
+
+    const compaction = compactInlineAtTurnBoundary(session.sessionManager);
+    await Promise.resolve();
+    await session.abort();
+    releaseSummary?.();
+
+    await expect(compaction).rejects.toThrow("Compaction cancelled");
+    expect(session.originalAbortCalls).toBe(1);
+  });
+
+  it("keeps captured sessions independent for nested-agent concurrency", async () => {
+    const SessionClass = createSessionClass({ legacyDisconnect: false });
+    installInlineCompactionAdapter({ sessionClass: SessionClass as never });
+    const parent = new SessionClass();
+    const child = new SessionClass();
+    parent._bindExtensionCore({});
+    child._bindExtensionCore({});
+
+    await Promise.all([
+      compactInlineAtTurnBoundary(parent.sessionManager),
+      compactInlineAtTurnBoundary(child.sessionManager),
+    ]);
+
+    expect(parent.originalAbortCalls).toBe(0);
+    expect(child.originalAbortCalls).toBe(0);
+    expect(parent.compactCalls).toBe(1);
+    expect(child.compactCalls).toBe(1);
+  });
+
+  it("refreshes mutated state even when a post-compaction invariant fails", async () => {
+    const SessionClass = createSessionClass({ legacyDisconnect: false });
+    class PostMutationDriftSession extends SessionClass {
+      invokeExpectedAbort = false;
+
+      override async compact() {
+        if (this.invokeExpectedAbort) await this.abort();
+        this.sessionManager.appendCompaction();
+        this.agent.state.messages = [
+          { role: "user", content: "mutated-summary" },
+        ];
+        return {
+          summary: "mutated-summary",
+          firstKeptEntryId: "kept-1",
+          tokensBefore: 42,
+        };
+      }
+    }
+
+    expect(
+      installInlineCompactionAdapter({
+        sessionClass: PostMutationDriftSession as never,
+      }),
+    ).toEqual({ supported: true });
+    const session = new PostMutationDriftSession();
+    session._bindExtensionCore({});
+
+    await expect(
+      compactInlineAtTurnBoundary(session.sessionManager),
+    ).rejects.toThrow("quiesce hooks were not invoked");
+    const next = await refreshNextTurn(session);
+
+    expect(next.context.messages).toEqual([
+      { role: "user", content: "mutated-summary" },
+    ]);
+  });
+
+  it("fails closed when Pi compact internals do not match a supported shape", async () => {
+    class DriftedSession {
+      sessionManager = {};
+      _bindExtensionCore(): void {}
+      async abort(): Promise<void> {}
+      async compact(): Promise<void> {
+        // Deliberately no abort/quiesce contract.
+      }
+    }
+
+    const status = installInlineCompactionAdapter({
+      sessionClass: DriftedSession as never,
+    });
+    const session = new DriftedSession();
+    session._bindExtensionCore();
+
+    expect(status.supported).toBe(false);
+    expect(status.reason).toContain("unsupported AgentSession.compact() shape");
+    await expect(
+      compactInlineAtTurnBoundary(session.sessionManager),
+    ).rejects.toBeInstanceOf(InlineCompactionUnavailableError);
+  });
+
+  it("patches every independently loaded host AgentSession identity", async () => {
+    const fixtureRoot = await mkdtemp(
+      join(tmpdir(), "blackhole-host-identities-"),
+    );
+    const makeHostPackage = async (name: string) => {
+      const packageRoot = join(
+        fixtureRoot,
+        name,
+        "node_modules",
+        "@earendil-works",
+        "pi-coding-agent",
+      );
+      const dist = join(packageRoot, "dist");
+      await mkdir(dist, { recursive: true });
+      await writeFile(
+        join(packageRoot, "package.json"),
+        JSON.stringify({
+          name: "@earendil-works/pi-coding-agent",
+          type: "module",
+        }),
+      );
+      await writeFile(
+        join(dist, "index.js"),
+        `export class AgentSession {
+  async abort() {}
+  _bindExtensionCore() {}
+  async compact() {
+    await this.abort();
+    this.sessionManager.appendCompaction();
+    this.agent.state.messages = [];
+    return { summary: "summary", firstKeptEntryId: "kept", tokensBefore: 1 };
+  }
+}`,
+      );
+      const frame = join(dist, "frame.js");
+      const cli = join(dist, "cli.js");
+      await Promise.all([writeFile(frame, ""), writeFile(cli, "")]);
+      return { packageRoot, frame, cli };
+    };
+
+    try {
+      const [first, second] = await Promise.all([
+        makeHostPackage("first"),
+        makeHostPackage("second"),
+      ]);
+      const modules = await Promise.all(
+        [first, second].map(
+          async ({ packageRoot }) =>
+            (await import(
+              pathToFileURL(join(packageRoot, "dist", "index.js")).href
+            )) as {
+              AgentSession: { prototype: { _bindExtensionCore: unknown } };
+            },
+        ),
+      );
+      const originalBinds = modules.map(
+        ({ AgentSession: SessionClass }) =>
+          SessionClass.prototype._bindExtensionCore,
+      );
+
+      await expect(
+        installHostInlineCompactionAdapter({
+          entrypoint: second.cli,
+          stack: `Error\n    at first (${first.frame}:1:1)`,
+        }),
+      ).resolves.toEqual({ supported: true });
+
+      for (const [index, { AgentSession: SessionClass }] of modules.entries()) {
+        expect(SessionClass.prototype._bindExtensionCore).not.toBe(
+          originalBinds[index],
+        );
+      }
+    } finally {
+      await rm(fixtureRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("fails closed when the host Pi module identity cannot be resolved", async () => {
+    const status = await installHostInlineCompactionAdapter({
+      entrypoint: join(process.cwd(), "not-a-pi-entrypoint.js"),
+      stack: "",
+    });
+
+    expect(status.supported).toBe(false);
+    expect(status.reason).toContain("host AgentSession module");
+  });
+
+  it("recognizes the installed Pi compact implementation", () => {
+    expect(installInlineCompactionAdapter()).toEqual({ supported: true });
+  });
+
+  it("continues through inline compaction inside a real Pi AgentSession run", async () => {
+    expect(installInlineCompactionAdapter()).toEqual({ supported: true });
+
+    const summaryStarted = createDeferred();
+    const releaseSummary = createDeferred();
+    const nextRequestStarted = createDeferred();
+    const releaseFinalResponse = createDeferred();
+    const parameters = Type.Object({});
+    const tool: AgentTool<typeof parameters> = {
+      name: "echo",
+      label: "Echo",
+      description: "Return a deterministic result",
+      parameters,
+      execute: async () => ({
+        content: [{ type: "text", text: "tool-result" }],
+        details: {},
+      }),
+    };
+    const harness = await createPiAgentSessionHarness([tool]);
+    let promptPromise: Promise<void> | undefined;
+
+    try {
+      harness.sessionManager.appendMessage({
+        role: "user",
+        content: `old-user-1 ${"x".repeat(5_000)}`,
+        timestamp: 1,
+      });
+      harness.sessionManager.appendMessage(
+        fauxAssistantMessage("old-assistant-1", { timestamp: 2 }),
+      );
+      harness.sessionManager.appendMessage({
+        role: "user",
+        content: `old-user-2 ${"y".repeat(5_000)}`,
+        timestamp: 3,
+      });
+      harness.sessionManager.appendMessage(
+        fauxAssistantMessage("old-assistant-2", { timestamp: 4 }),
+      );
+      harness.agent.state.messages =
+        harness.sessionManager.buildSessionContext().messages;
+
+      let nextRequestMessages: Context["messages"] | undefined;
+      harness.setResponses([
+        fauxAssistantMessage(fauxToolCall("echo", {}, { id: "tool-1" }), {
+          stopReason: "toolUse",
+        }),
+        async () => {
+          summaryStarted.release();
+          await releaseSummary.promise;
+          return fauxAssistantMessage("COMPACTED-SUMMARY");
+        },
+        async (context) => {
+          nextRequestMessages = context.messages;
+          nextRequestStarted.release();
+          await releaseFinalResponse.promise;
+          return fauxAssistantMessage("finished");
+        },
+      ]);
+
+      let compacted = false;
+      let activeRunSignal: AbortSignal | undefined;
+      let compactionError: unknown;
+      harness.agent.subscribe(async (event, signal) => {
+        if (event.type !== "turn_end" || compacted) return;
+        compacted = true;
+        activeRunSignal = signal;
+        try {
+          await compactInlineAtTurnBoundary(harness.sessionManager);
+          expect(signal.aborted).toBe(false);
+        } catch (error) {
+          compactionError = error;
+          throw error;
+        }
+      });
+
+      let promptSettled = false;
+      promptPromise = harness.session
+        .prompt("use the echo tool and then finish")
+        .finally(() => {
+          promptSettled = true;
+        });
+
+      await Promise.race([
+        summaryStarted.promise,
+        promptPromise.then(() => {
+          throw new Error(
+            `prompt settled before compaction summary started: ${String(compactionError)}; messages=${JSON.stringify(harness.session.messages)}`,
+          );
+        }),
+      ]);
+      expect(promptSettled).toBe(false);
+      expect(harness.session.isStreaming).toBe(true);
+      expect(activeRunSignal?.aborted).toBe(false);
+
+      releaseSummary.release();
+      await Promise.race([
+        nextRequestStarted.promise,
+        promptPromise.then(() => {
+          throw new Error("prompt settled before the post-compaction request");
+        }),
+      ]);
+      expect(promptSettled).toBe(false);
+      expect(activeRunSignal?.aborted).toBe(false);
+
+      const compactedMessages =
+        harness.sessionManager.buildSessionContext().messages;
+      expect(nextRequestMessages).toEqual(convertToLlm(compactedMessages));
+      expect(JSON.stringify(nextRequestMessages)).toContain(
+        "COMPACTED-SUMMARY",
+      );
+      expect(JSON.stringify(nextRequestMessages)).not.toContain("old-user-1");
+
+      releaseFinalResponse.release();
+      await promptPromise;
+      expect(promptSettled).toBe(true);
+      expect(harness.session.messages.at(-1)).toMatchObject({
+        role: "assistant",
+        stopReason: "stop",
+      });
+    } finally {
+      releaseSummary.release();
+      releaseFinalResponse.release();
+      await promptPromise?.catch(() => undefined);
+      harness.cleanup();
+    }
+  });
+
+  it("installs idempotently across extension reloads", () => {
+    const SessionClass = createSessionClass({ legacyDisconnect: false });
+    const originalBind = SessionClass.prototype._bindExtensionCore;
+
+    expect(
+      installInlineCompactionAdapter({ sessionClass: SessionClass as never }),
+    ).toEqual({ supported: true });
+    const patchedBind = SessionClass.prototype._bindExtensionCore;
+    expect(patchedBind).not.toBe(originalBind);
+
+    expect(
+      installInlineCompactionAdapter({ sessionClass: SessionClass as never }),
+    ).toEqual({ supported: true });
+    expect(SessionClass.prototype._bindExtensionCore).toBe(patchedBind);
+  });
+});

--- a/tests/inline-compaction.test.ts
+++ b/tests/inline-compaction.test.ts
@@ -17,6 +17,7 @@ import {
   InlineCompactionUnavailableError,
   installHostInlineCompactionAdapter,
   installInlineCompactionAdapter,
+  parseHostFramePaths,
 } from "../src/om/inline-compaction.js";
 import { createPiAgentSessionHarness } from "./fixtures/pi-agent-session.js";
 
@@ -321,6 +322,74 @@ describe("Blackhole inline compaction adapter", () => {
     ]);
   });
 
+  it("ignores method-like text in literals when detecting compact shape", () => {
+    const SessionClass = createSessionClass({ legacyDisconnect: false });
+    class TextBearingSession extends SessionClass {
+      override async compact(customInstructions?: string) {
+        const diagnostic =
+          "this.abort() this._disconnectFromAgent() this._reconnectToAgent()";
+        void diagnostic;
+        await this.abort();
+        this.compactCalls += 1;
+        this.customInstructions = customInstructions;
+        this.sessionManager.appendCompaction();
+        this.agent.state.messages = [{ role: "user", content: "summary" }];
+        return {
+          summary: "summary",
+          firstKeptEntryId: "kept-1",
+          tokensBefore: 42,
+        };
+      }
+    }
+
+    expect(
+      installInlineCompactionAdapter({
+        sessionClass: TextBearingSession as never,
+      }),
+    ).toEqual({ supported: true });
+  });
+
+  it("attempts every shadow restoration when one cleanup step fails", async () => {
+    const SessionClass = createSessionClass({ legacyDisconnect: true });
+    class CleanupFailureSession extends SessionClass {
+      override async compact() {
+        this._disconnectFromAgent();
+        await this.abort();
+        this._compactionAbortController = new AbortController();
+        try {
+          this.sessionManager.appendCompaction();
+          this.agent.state.messages = [{ role: "user", content: "summary" }];
+          Object.defineProperty(this, "abort", {
+            configurable: false,
+            writable: true,
+            value: this.abort,
+          });
+          return {
+            summary: "summary",
+            firstKeptEntryId: "kept-1",
+            tokensBefore: 42,
+          };
+        } finally {
+          this._compactionAbortController = undefined;
+          this._reconnectToAgent();
+        }
+      }
+    }
+
+    expect(
+      installInlineCompactionAdapter({
+        sessionClass: CleanupFailureSession as never,
+      }),
+    ).toEqual({ supported: true });
+    const session = new CleanupFailureSession();
+    session._bindExtensionCore({});
+
+    await expect(
+      compactInlineAtTurnBoundary(session.sessionManager),
+    ).rejects.toThrow("restore");
+    expect(Object.hasOwn(session, "_disconnectFromAgent")).toBe(false);
+  });
+
   it("fails closed when Pi compact internals do not match a supported shape", async () => {
     class DriftedSession {
       sessionManager = {};
@@ -342,6 +411,14 @@ describe("Blackhole inline compaction adapter", () => {
     await expect(
       compactInlineAtTurnBoundary(session.sessionManager),
     ).rejects.toBeInstanceOf(InlineCompactionUnavailableError);
+  });
+
+  it("parses Windows native host stack paths", () => {
+    const windowsPath = String.raw`C:\Users\maple\node_modules\@earendil-works\pi-coding-agent\dist\runner.js`;
+
+    expect(
+      parseHostFramePaths(`Error\n    at run (${windowsPath}:12:34)`),
+    ).toEqual([windowsPath]);
   });
 
   it("patches every independently loaded host AgentSession identity", async () => {

--- a/tests/inline-compaction.test.ts
+++ b/tests/inline-compaction.test.ts
@@ -329,6 +329,8 @@ describe("Blackhole inline compaction adapter", () => {
         const diagnostic =
           "this.abort() this._disconnectFromAgent() this._reconnectToAgent()";
         void diagnostic;
+        const nestedDiagnostic = `outer ${`this.abort()`} tail`;
+        void nestedDiagnostic;
         await this.abort();
         this.compactCalls += 1;
         this.customInstructions = customInstructions;


### PR DESCRIPTION
## Problem

Follow-up to #38 and #40.

`midRunCompaction: "resume"` currently calls public `ctx.compact()` from `turn_end`. Pi's native method first aborts the active run, so extensions that treat the run `AbortSignal` as cancellation can stop parent/background work. Nested runners can also resolve their original `session.prompt()` while Blackhole continues later in a detached `blackhole-resume` run.

That means "resume" does not actually preserve one run lifecycle, and the synthetic continuation is too late to repair consumers that already observed the abort.

## What changed

- Replaced the aborting `ctx.compact()` + synthetic `blackhole-resume` path in `resume` mode with a Blackhole-private inline adapter at the awaited `turn_end` boundary.
- Reused Pi's native compaction pipeline (`session_before_compact`, summary generation, compaction entry append, and context rebuild) while suppressing only its initial internal quiesce abort (and the legacy disconnect on Pi 0.81).
- Refreshed the next low-level turn from compacted `agent.state.messages`, keeping continuation inside the original `session.prompt()` promise.
- Preserved external cancellation: a later real abort still reaches Pi's active compaction controller and session abort path.
- Rejected inline compaction before mutation when a tool call is unpaired or another compaction is active.
- Added strict capability detection for the known Pi 0.81 and 0.84 `AgentSession.compact()` shapes. Unknown internal drift fails closed, leaves the run alive, and suspends retries at the same pressure level.
- Resolved and patched the **host** `AgentSession` identities (all independently loaded candidates), rather than assuming Blackhole's devDependency module is the same instance as the Pi CLI host. The registry is reload-idempotent and weakly referenced.
- Kept `midRunCompaction` defaulting to `off` for backward compatibility. `resume` is an explicit opt-in to transparent same-run compaction; `pause` remains explicitly interrupting via public `ctx.compact()`.
- Updated the Pi dev baseline from 0.83.0 to 0.84.0; peer support remains `>=0.81.1 <1.0.0`.

## Why a private adapter

Pi 0.84 still has no public non-aborting extension compaction seam. `SessionManager.appendCompaction()` and the owning `AgentSession` pipeline exist, but the extension-facing session manager is readonly and `ctx.compact()` is abort-based. This adapter is intentionally narrow and fail-closed instead of reimplementing Pi's summarizer/session protocol or special-casing a particular subagent plugin.

## Validation

### Automated — Pi 0.84.0 dev baseline

- `pnpm build`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm format:check`
- `pnpm test` — **72 files, 1,128 tests passed**
- `npm pack --dry-run` — packaged `dist/index.js`, adapter source, README, and example config

Coverage includes both supported compact shapes, same-run `AgentSession` integration with a faux provider, next-request compacted context, outer-prompt continuity, external cancellation, unpaired tools, nested session independence, post-mutation invariant failure, unsupported-host fail-closed behavior, every discovered host module identity, Windows native stack paths, non-code lexical false positives (including nested templates), exhaustive shadow restoration, and reload idempotency.

### Minimum compatibility — Pi 0.81.1

Re-pinned all four Pi packages to 0.81.1, then ran:

- `pnpm typecheck`
- `pnpm test` — **72 files, 1,128 tests passed**

Package metadata, lockfile, and installed dev dependencies were then restored to 0.84.0.

### Fresh-process live smoke

A reversible local Pi smoke used the branch build with `midRunCompaction: "resume"`, debug logging, and a threshold already exceeded by the parent. The first action launched a 60-second background child.

Evidence after the launch `turn_end`:

- debug emitted `compaction_trigger.turn_end.inline_complete`;
- the session appended compaction entry **1293**;
- assistant entry **1294** followed that compaction in the same active run;
- the child was still `running` after parent compaction;
- the child then completed normally after **60.002 seconds** with `FRESH_INLINE_CHILD_COMPLETED`.

The first reload-only attempts also exposed the host-module identity bug: the running CLI and local package had distinct `AgentSession` module instances. After changing host resolution to patch all candidate identities and starting one genuinely fresh Pi process (rather than relying on process-global module-cache reload), the smoke passed.

After evidence collection, the local install/config was restored byte-for-byte to `npm:pi-blackhole` 0.4.3 with the user's original `compactAfterTokens`, `midRunCompaction`, and debug settings, then reloaded.


