### PR TITLE
fix: restore Working after inline compaction

### DIFF
--- a/src/om/compaction-trigger.ts
+++ b/src/om/compaction-trigger.ts
@@ -191,6 +191,10 @@ async function handleTurnEnd(
       }
     } finally {
       runtime.compactInFlight = false;
+
+      if (hasUI && ctx.signal?.aborted !== true) {
+        ui?.setWorkingVisible?.(true);
+      }
     }
     return;
   }


### PR DESCRIPTION
## What

Restore Pi's native `Working` indicator after an inline mid-run compaction attempt while the parent run is still active.

## Why

Pi hides its working row when compaction ends, but an inline `midRunCompaction="resume"` run immediately continues with another provider request. Without restoring the row, that wait looks idle even though the agent is still working.

The setter is called from `finally`, so both successful and failed inline attempts restore the indicator. Aborted runs remain untouched.

## Validation

- `pnpm typecheck`
- `pnpm vitest run tests/compaction-trigger.test.ts` (41 tests passed)
- Real Pi TUI smoke: a new compaction entry was written, the same outer run continued without user input, and the native animated `Working` row was visible before the next provider output.
