### PR TITLE
fix: ignore stale tool calls during inline compaction

### DIFF
--- a/src/om/inline-compaction.ts
+++ b/src/om/inline-compaction.ts
@@ -535,31 +535,44 @@ function getToolCallId(block: unknown): string | undefined {
     : undefined;
 }
 
-function hasUnpairedToolCall(messages: unknown[]): boolean {
-  const pending = new Set<string>();
-
-  for (const message of messages) {
+function hasTrailingUnpairedToolCall(messages: unknown[]): boolean {
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = messages[index];
     if (!message || typeof message !== "object") continue;
-    const value = message as {
-      role?: unknown;
-      content?: unknown;
-      toolCallId?: unknown;
-    };
 
-    if (value.role === "assistant" && Array.isArray(value.content)) {
-      for (const block of value.content) {
-        const id = getToolCallId(block);
-        if (id) pending.add(id);
+    const value = message as { role?: unknown; content?: unknown };
+    if (value.role !== "assistant") continue;
+    if (!Array.isArray(value.content)) return false;
+
+    const pending = new Set<string>();
+    for (const block of value.content) {
+      const id = getToolCallId(block);
+      if (id) pending.add(id);
+    }
+    if (pending.size === 0) return false;
+
+    for (
+      let resultIndex = index + 1;
+      resultIndex < messages.length;
+      resultIndex += 1
+    ) {
+      const result = messages[resultIndex];
+      if (!result || typeof result !== "object") continue;
+      const resultValue = result as { role?: unknown; toolCallId?: unknown };
+      if (
+        resultValue.role === "toolResult" &&
+        typeof resultValue.toolCallId === "string"
+      ) {
+        pending.delete(resultValue.toolCallId);
       }
-      continue;
     }
 
-    if (value.role === "toolResult" && typeof value.toolCallId === "string") {
-      pending.delete(value.toolCallId);
-    }
+    // A later assistant message proves any older unmatched call was superseded,
+    // not still executing. Only the newest assistant tool batch can be in flight.
+    return pending.size > 0;
   }
 
-  return pending.size > 0;
+  return false;
 }
 
 /**
@@ -590,7 +603,7 @@ export async function compactInlineAtTurnBoundary(
   }
 
   const activeMessages = session.sessionManager.buildSessionContext().messages;
-  if (hasUnpairedToolCall(activeMessages)) {
+  if (hasTrailingUnpairedToolCall(activeMessages)) {
     throw new Error(
       "Cannot compact inline while a tool call is still in flight",
     );

--- a/tests/inline-compaction.test.ts
+++ b/tests/inline-compaction.test.ts
@@ -244,6 +244,69 @@ describe("Blackhole inline compaction adapter", () => {
     expect(session.originalAbortCalls).toBe(0);
   });
 
+  it("ignores an unpaired tool call from a superseded assistant turn", async () => {
+    const SessionClass = createSessionClass({
+      legacyDisconnect: false,
+      activeMessages: [
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "toolCall",
+              id: "stale-write",
+              name: "write",
+              arguments: {},
+            },
+          ],
+        },
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "toolCall",
+              id: "current-read",
+              name: "read",
+              arguments: {},
+            },
+          ],
+        },
+        { role: "toolResult", toolCallId: "current-read", content: [] },
+      ],
+    });
+    installInlineCompactionAdapter({ sessionClass: SessionClass as never });
+    const session = new SessionClass();
+    session._bindExtensionCore({});
+
+    await expect(
+      compactInlineAtTurnBoundary(session.sessionManager),
+    ).resolves.toMatchObject({ summary: "summary" });
+    expect(session.compactCalls).toBe(1);
+  });
+
+  it("rejects when any call in the latest parallel tool batch is unpaired", async () => {
+    const SessionClass = createSessionClass({
+      legacyDisconnect: false,
+      activeMessages: [
+        {
+          role: "assistant",
+          content: [
+            { type: "toolCall", id: "read-1", name: "read", arguments: {} },
+            { type: "toolCall", id: "read-2", name: "read", arguments: {} },
+          ],
+        },
+        { role: "toolResult", toolCallId: "read-1", content: [] },
+      ],
+    });
+    installInlineCompactionAdapter({ sessionClass: SessionClass as never });
+    const session = new SessionClass();
+    session._bindExtensionCore({});
+
+    await expect(
+      compactInlineAtTurnBoundary(session.sessionManager),
+    ).rejects.toThrow("tool call is still in flight");
+    expect(session.compactCalls).toBe(0);
+  });
+
   it("passes a later external abort through and cancels the inline summary", async () => {
     let releaseSummary: (() => void) | undefined;
     const summaryGate = new Promise<void>((resolve) => {


### PR DESCRIPTION
## What

Treat only the newest assistant tool batch as potentially in flight when starting inline compaction.

## Why

A session can retain an unmatched tool call from an interrupted or superseded assistant turn and then continue normally. The previous safety check accumulated unmatched calls across the entire active context, so one stale historical call permanently blocked every later inline compaction with:

```
Cannot compact inline while a tool call is still in flight
```

A later assistant message proves an older unmatched call is no longer executing. The adapter now checks the newest assistant batch and its following tool results instead of treating all historical unmatched calls as live.

The fail-closed behavior remains intact: if any call in the newest parallel tool batch lacks a result, compaction is still rejected before mutation.

## Validation

- Added regression coverage for a superseded unmatched call followed by a completed tool turn
- Added coverage for a partially completed latest parallel batch
- `pnpm check`
- `pnpm format:check`
- `pnpm test` — 80 files, 1339 tests passed
