### PR TITLE
fix: support Pi 0.84.3 bundled AgentSession

### DIFF
--- a/src/om/inline-compaction.ts
+++ b/src/om/inline-compaction.ts
@@ -435,32 +435,76 @@ export function parseHostFramePaths(stack: string): string[] {
   return paths;
 }
 
+function findBundledRuntimeModule(
+  entrypoint: string,
+  packageRoot: string,
+): string | undefined {
+  let resolvedEntrypoint: string;
+  let source: string;
+  try {
+    resolvedEntrypoint = realpathSync(entrypoint);
+    source = readFileSync(resolvedEntrypoint, "utf8");
+  } catch {
+    return undefined;
+  }
+
+  const namedImport = /\bimport\s*\{([^}]*)\}\s*from\s*["']([^"']+)["']/g;
+  for (const match of source.matchAll(namedImport)) {
+    const names = match[1]
+      .split(",")
+      .map((name) => name.trim().split(/\s+as\s+/)[0]);
+    const specifier = match[2];
+    if (!names.includes("main") || !specifier.startsWith(".")) continue;
+
+    try {
+      const candidate = realpathSync(
+        join(dirname(resolvedEntrypoint), specifier),
+      );
+      if (findPiPackageRoot(candidate) === packageRoot) return candidate;
+    } catch {
+      // Keep searching other named imports before falling back to dist/index.js.
+    }
+  }
+
+  return undefined;
+}
+
 export async function installHostInlineCompactionAdapter(
   options: HostInlineCompactionInstallOptions = {},
 ): Promise<InlineCompactionAdapterStatus> {
   const packageRoots = new Set<string>();
+  const hostPaths = new Set<string>();
   const stack = options.stack ?? new Error().stack ?? "";
-  for (const framePath of parseHostFramePaths(stack)) {
-    const root = findPiPackageRoot(framePath);
+  for (const framePath of parseHostFramePaths(stack)) hostPaths.add(framePath);
+
+  const entrypoint = options.entrypoint ?? process.argv[1];
+  if (entrypoint) hostPaths.add(entrypoint);
+
+  for (const hostPath of hostPaths) {
+    const root = findPiPackageRoot(hostPath);
     if (root) packageRoots.add(root);
   }
 
-  const entrypoint = options.entrypoint ?? process.argv[1];
-  if (entrypoint) {
-    const root = findPiPackageRoot(entrypoint);
-    if (root) packageRoots.add(root);
+  const modulePaths = new Set<string>();
+  for (const packageRoot of packageRoots) {
+    modulePaths.add(join(packageRoot, "dist", "index.js"));
+    for (const hostPath of hostPaths) {
+      if (findPiPackageRoot(hostPath) !== packageRoot) continue;
+      const bundledRuntime = findBundledRuntimeModule(hostPath, packageRoot);
+      if (bundledRuntime) modulePaths.add(bundledRuntime);
+    }
   }
-  getRegistry().hostCandidateCount = packageRoots.size;
+  getRegistry().hostCandidateCount = modulePaths.size;
 
   let supportedStatus: InlineCompactionAdapterStatus | undefined;
   const failureReasons: string[] = [];
-  for (const packageRoot of packageRoots) {
+  for (const modulePath of modulePaths) {
     try {
-      const hostModule = (await import(
-        pathToFileURL(join(packageRoot, "dist", "index.js")).href
-      )) as { AgentSession?: PatchableSessionClass };
+      const hostModule = (await import(pathToFileURL(modulePath).href)) as {
+        AgentSession?: PatchableSessionClass;
+      };
       if (!hostModule.AgentSession) {
-        failureReasons.push(`${packageRoot}: AgentSession export missing`);
+        failureReasons.push(`${modulePath}: AgentSession export missing`);
         continue;
       }
 
@@ -469,12 +513,10 @@ export async function installHostInlineCompactionAdapter(
       });
       if (status.supported) supportedStatus ??= status;
       else
-        failureReasons.push(
-          `${packageRoot}: ${status.reason ?? "unsupported"}`,
-        );
+        failureReasons.push(`${modulePath}: ${status.reason ?? "unsupported"}`);
     } catch (error) {
       failureReasons.push(
-        `${packageRoot}: ${error instanceof Error ? error.message : String(error)}`,
+        `${modulePath}: ${error instanceof Error ? error.message : String(error)}`,
       );
     }
   }

--- a/tests/inline-compaction.test.ts
+++ b/tests/inline-compaction.test.ts
@@ -571,6 +571,86 @@ describe("Blackhole inline compaction adapter", () => {
     ).toEqual([windowsPath]);
   });
 
+  it("patches the bundled CLI AgentSession identity", async () => {
+    const fixtureRoot = await mkdtemp(
+      join(tmpdir(), "blackhole-bundled-host-"),
+    );
+    const packageRoot = join(
+      fixtureRoot,
+      "node_modules",
+      "@earendil-works",
+      "pi-coding-agent",
+    );
+    const dist = join(packageRoot, "dist");
+    const chunks = join(dist, "bundle", "chunks");
+    const cli = join(dist, "bundle", "cli.js");
+    const runtimeChunk = join(chunks, "runtime.js");
+    const sessionSource = `export class AgentSession {
+  constructor() {
+    this.agent = { state: { messages: [] } };
+    this.sessionManager = {
+      buildSessionContext: () => ({ messages: [] }),
+      appendCompaction: () => {},
+    };
+  }
+  async abort() {}
+  _bindExtensionCore() {}
+  async compact() {
+    await this.abort();
+    this.sessionManager.appendCompaction();
+    this.agent.state.messages = [];
+    return { summary: "summary", firstKeptEntryId: "kept", tokensBefore: 1 };
+  }
+}`;
+
+    try {
+      await mkdir(chunks, { recursive: true });
+      await writeFile(
+        join(packageRoot, "package.json"),
+        JSON.stringify({
+          name: "@earendil-works/pi-coding-agent",
+          type: "module",
+        }),
+      );
+      await writeFile(join(dist, "index.js"), sessionSource);
+      await writeFile(
+        runtimeChunk,
+        `${sessionSource}\nexport function main() {}`,
+      );
+      await writeFile(
+        cli,
+        '#!/usr/bin/env node\nimport{main}from"./chunks/runtime.js";main();\n',
+      );
+
+      const bundledModule = (await import(
+        pathToFileURL(runtimeChunk).href
+      )) as {
+        AgentSession: new () => {
+          agent: { state: { messages: unknown[] } };
+          sessionManager: object;
+          _bindExtensionCore(runner: unknown): void;
+        };
+      };
+      const originalBind =
+        bundledModule.AgentSession.prototype._bindExtensionCore;
+
+      await expect(
+        installHostInlineCompactionAdapter({ entrypoint: cli, stack: "" }),
+      ).resolves.toEqual({ supported: true });
+      expect(bundledModule.AgentSession.prototype._bindExtensionCore).not.toBe(
+        originalBind,
+      );
+
+      const session = new bundledModule.AgentSession();
+      session._bindExtensionCore({});
+      await expect(
+        compactInlineAtTurnBoundary(session.sessionManager),
+      ).resolves.toMatchObject({ summary: "summary" });
+    } finally {
+      await rm(fixtureRoot, { recursive: true, force: true });
+    }
+  });
+
   it("patches every independently loaded host AgentSession identity", async () => {
     const fixtureRoot = await mkdtemp(
       join(tmpdir(), "blackhole-host-identities-"),


### PR DESCRIPTION
## What

Capture and patch the `AgentSession` class used by Pi's bundled Node CLI, while retaining the existing modular `dist/index.js` path for older and library-hosted Pi runtimes.

## Why

Pi 0.84.3 changed its Node CLI entrypoint to a bundled runtime. The CLI now executes an `AgentSession` class from a hashed bundle chunk, while `dist/index.js` still exports a separate modular class identity.

Blackhole previously patched only `dist/index.js`. Host discovery therefore appeared successful, but the live CLI session never passed through the patched prototype and inline compaction later failed with:

```
Blackhole inline compaction is unavailable: owning AgentSession was not captured or Pi internals are unsupported (host candidates: 1; captured sessions: 0)
```

The adapter now reads the active CLI entrypoint, resolves its same-package static `main` import, and patches the exported bundled `AgentSession` in addition to the modular identity. Candidate paths are realpath-resolved and constrained to the discovered Pi package root.

## Compatibility

- Pi 0.84.3 bundled Node CLI: patches the live bundle class.
- Older/modular Pi runtimes: keep using `dist/index.js`.
- Multiple independently loaded Pi package identities remain supported.
- Unknown or unsupported internals still fail closed.

## Validation

- Added a regression fixture mirroring the minified bundled CLI → runtime chunk split and proved the captured session can compact inline.
- Real fresh Pi 0.84.3 TUI startup probe, with no provider request: `hostCandidateCount=2`, `capturedSessionCount=1`.
- `pnpm check`
- `pnpm format:check`
- `pnpm test` — 87 files, 1417 tests passed
