### PR TITLE
feat(context): budget historical tool outputs newest-first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [Unreleased]
+
+### Added
+
+- **Newest-first retained tool-output budgeting.** Historical tool and shell output text now uses a dedicated provider-context budget. Recent consumed text retains full fidelity, while older or oversized text becomes compact `recall #N` references without changing raw session history or compaction inputs. Pending results and non-text content remain visible. Configure with `retainedToolOutputMaxTokens` or `PI_BLACKHOLE_RETAINED_TOOL_OUTPUT_MAX_TOKENS`.
+
+---
+
 ## [0.4.8] - 2026-08-23
 
 ### Added

--- a/CONFIG.md
+++ b/CONFIG.md
@@ -25,6 +25,7 @@ The config file must contain **valid JSON**. A trailing comma, partial write, or
   "midRunCompaction": "off",    // "resume" | "pause" | "off" (default: off)
   "compactionSummaryMode": "default", // "default" | "append" (default: "default")
   "compactAfterTokens": 81000,    // Token threshold for auto-compaction
+  "retainedToolOutputMaxTokens": 20000, // Full historical tool-output budget
 
   // ── Observational Memory ──
   "memory": true,                 // Enable OM workers + content injection
@@ -185,6 +186,16 @@ Token threshold for auto-compaction. When `compaction: "auto"` and accumulated t
 | number | 81000 |
 
 **The interaction with Pi's threshold:** Pi has its own `keepRecentTokens` default (~20k tokens). Blackhole's threshold is independent — it's the trigger point, not the keep point. When blackhole's trigger fires, `tailBehavior` determines how much is actually kept visible.
+
+### `retainedToolOutputMaxTokens`
+
+Dedicated token budget for historical `toolResult` text and shell output in provider-visible context. Blackhole scans outputs newest-first, retaining each full text output while it fits. The text crossing the budget and all older text outputs are replaced with compact markers that point to `recall #N` when a stable transcript index is available. Non-text parts such as images are preserved and do not count against this budget.
+
+This only changes the context sent to the provider. Session JSONL, compaction summaries' source messages, and recall data remain full fidelity. Trailing results that have not yet been consumed by an assistant response are protected even when they exceed the budget; they become eligible on a later provider call.
+
+| Type | Default | Range |
+|------|---------|-------|
+| number | 20000 | positive integer |
 
 ## Observational Memory Section
 
@@ -434,6 +445,7 @@ Positive-integer fields (invalid values fall back):
 | Variable | Overrides |
 |----------|-----------|
 | `PI_BLACKHOLE_COMPACT_AFTER_TOKENS` | `compactAfterTokens` |
+| `PI_BLACKHOLE_RETAINED_TOOL_OUTPUT_MAX_TOKENS` | `retainedToolOutputMaxTokens` |
 | `PI_BLACKHOLE_OBSERVE_AFTER_TOKENS` | `observeAfterTokens` |
 | `PI_BLACKHOLE_REFLECT_AFTER_TOKENS` | `reflectAfterTokens` |
 | `PI_BLACKHOLE_OBSERVATIONS_POOL_MAX_TOKENS` | `observationsPoolMaxTokens` |

--- a/README.md
+++ b/README.md
@@ -290,6 +290,7 @@ Everything else has sensible defaults.
 | `compaction` | `"auto"` | When compaction triggers: `"auto"` (blackhole auto-fires), `"manual"` (only `/blackhole`), `"off"` (Pi handles auto + `/compact`, `/blackhole` still works) |
 | `compactionEngine` | `"blackhole"` | Which engine handles auto-compaction: `"blackhole"` or `"pi-default"`. Only meaningful when `compaction: "auto"` — for `"manual"`/`"off"` the hook lets Pi handle everything except `/blackhole` |
 | `tailBehavior` | `"minimal"` | How much stays visible after compaction: `"minimal"` (last user message only, default) or `"pi-default"` (gentle, ~20k tokens). Both `/blackhole` and auto-triggered default to `"minimal"`; set explicitly to opt into gentler cut |
+| `retainedToolOutputMaxTokens` | `20000` | Dedicated budget for historical tool-output text in provider context. Newest consumed text is retained first; older or oversized text becomes compact `recall #N` markers while raw session history remains unchanged. Pending results and non-text parts such as images remain visible. |
 | `midRunCompaction` | `"off"` | `"resume"` *(experimental)* opts into transparent compaction during long tool loops without replacing the active run; `"pause"` interrupts, compacts, and stops; `"off"` only checks when the run ends. Transparent mode fails closed on unsupported Pi internals. |
 | `memory` | `true` | `false` = OM workers off + no memory injection (compaction still runs) |
 | `model` | — | Base fallback model for all workers (last resort before session model) |
@@ -329,6 +330,7 @@ Paste the appropriate block into your config to match your main session model's 
   "observeAfterTokens": 5000,
   "reflectAfterTokens": 10000,
   "compactAfterTokens": 30000,
+  "retainedToolOutputMaxTokens": 8000,
   "observerChunkMaxTokens": 15000,
   "observerPreambleMaxTokens": 0,
   "observationsPoolMaxTokens": 8000,
@@ -347,6 +349,7 @@ These are the built-in defaults. If you reset your config, these are what you ge
   "observeAfterTokens": 15000,
   "reflectAfterTokens": 25000,
   "compactAfterTokens": 81000,
+  "retainedToolOutputMaxTokens": 20000,
   "observerChunkMaxTokens": 40000,
   "observerPreambleMaxTokens": 0,
   "observationsPoolMaxTokens": 20000,
@@ -363,6 +366,7 @@ These are the built-in defaults. If you reset your config, these are what you ge
   "observeAfterTokens": 20000,
   "reflectAfterTokens": 40000,
   "compactAfterTokens": 180000,
+  "retainedToolOutputMaxTokens": 50000,
   "observerChunkMaxTokens": 80000,
   "observerPreambleMaxTokens": 0,
   "observationsPoolMaxTokens": 40000,

--- a/example-config.json
+++ b/example-config.json
@@ -96,6 +96,7 @@
   "observeAfterTokens": 15000,
   "reflectAfterTokens": 25000,
   "compactAfterTokens": 81000,
+  "retainedToolOutputMaxTokens": 20000,
   "observationsPoolMaxTokens": 20000,
   "observationsPoolTargetTokens": 10000,
   "reflectorInputMaxTokens": 80000,
@@ -118,6 +119,7 @@
     "  compactionSummaryMode (default|append) — replace one summary or freeze auto-compaction segments",
     "  tailBehavior (pi-default|minimal) — how much stays visible",
     "  midRunCompaction (resume|pause|off) — threshold check during tool loops",
+    "  retainedToolOutputMaxTokens — newest-first historical tool-output text budget; older text remains available through recall",
     "  sessionFallback (true|false) — if false, skip session model as last-resort fallback",
     "  dropperPressureThreshold (0-1, default 0.70) — pressure relief valve: fraction of reflectorInputMaxTokens where dropper fires even without new data",
     "  providerIdleTimeoutMs (ms, 0=disabled, unset=inherit pi default) — body-idle timeout for background provider streams",
@@ -129,6 +131,7 @@
     "  PI_BLACKHOLE_PASSIVE=1  → compaction:off + memory:false",
     "  PI_BLACKHOLE_COMPACTION  → override compaction setting",
     "  PI_BLACKHOLE_COMPACTION_ENGINE → override compactionEngine setting",
-    "  PI_BLACKHOLE_COMPACTION_SUMMARY_MODE → override compactionSummaryMode setting"
+    "  PI_BLACKHOLE_COMPACTION_SUMMARY_MODE → override compactionSummaryMode setting",
+    "  PI_BLACKHOLE_RETAINED_TOOL_OUTPUT_MAX_TOKENS → override retained tool-output budget"
   ]
 }

--- a/src/commands/pi-vcc.ts
+++ b/src/commands/pi-vcc.ts
@@ -31,6 +31,12 @@ import {
 } from "../pi-base/blackhole-settings.js";
 
 export const registerPiVccCommand = (pi: ExtensionAPI, runtime: Runtime) => {
+  pi.on("session_start", (_event, ctx) => {
+    config.syncSession(ctx, ctx.cwd);
+    runtime.config = config.loadWithWarnings(ctx.cwd, GLOBAL_CONFIG_DIR).config;
+    runtime.configLoaded = true;
+  });
+
   const prefixMatch = (value: string, prefix: string): boolean => {
     return value.toLowerCase().startsWith(prefix.toLowerCase());
   };
@@ -69,6 +75,11 @@ export const registerPiVccCommand = (pi: ExtensionAPI, runtime: Runtime) => {
       if (trimmed === "configure" || trimmed === "settings") {
         // Open the config overlay ("configure" kept as a hidden alias)
         await openBlackholeSettings(ctx);
+        runtime.config = config.loadWithWarnings(
+          ctx.cwd,
+          GLOBAL_CONFIG_DIR,
+        ).config;
+        runtime.configLoaded = true;
         return;
       }
       if (trimmed === "cleanup") {

--- a/src/core/config-env.ts
+++ b/src/core/config-env.ts
@@ -89,6 +89,7 @@ export const DECLARATIVE_ENV_OVERRIDES: Record<string, EnvOverride> = {
   fullFoldAlways: "PI_BLACKHOLE_FULL_FOLD_ALWAYS",
   // Positive integers
   compactAfterTokens: "PI_BLACKHOLE_COMPACT_AFTER_TOKENS",
+  retainedToolOutputMaxTokens: "PI_BLACKHOLE_RETAINED_TOOL_OUTPUT_MAX_TOKENS",
   observeAfterTokens: "PI_BLACKHOLE_OBSERVE_AFTER_TOKENS",
   reflectAfterTokens: "PI_BLACKHOLE_REFLECT_AFTER_TOKENS",
   observationsPoolMaxTokens: "PI_BLACKHOLE_OBSERVATIONS_POOL_MAX_TOKENS",

--- a/src/core/tool-output-budget.ts
+++ b/src/core/tool-output-budget.ts
@@ -12,12 +12,15 @@ export interface ToolOutputBudgetResult {
 const isToolOutput = (message: any): boolean =>
   message?.role === "toolResult" || message?.role === "bashExecution";
 
-const outputText = (message: any): string =>
-  message.role === "bashExecution"
-    ? typeof message.output === "string"
-      ? message.output
-      : ""
-    : textOf(message.content);
+const outputText = (message: any): string => {
+  if (message.role === "bashExecution") {
+    return typeof message.output === "string" ? message.output : "";
+  }
+  if (typeof message.content === "string" || Array.isArray(message.content)) {
+    return textOf(message.content);
+  }
+  return "";
+};
 
 const omissionMarker = (recallIndex?: number): string =>
   `[Tool output text omitted from active context; ${recallIndex === undefined ? "use recall" : `recall #${recallIndex}`}.]`;

--- a/src/core/tool-output-budget.ts
+++ b/src/core/tool-output-budget.ts
@@ -1,0 +1,97 @@
+import { textOf } from "./content.js";
+import { estimateStringTokens } from "../om/tokens.js";
+
+export interface ToolOutputBudgetResult {
+  messages: any[];
+  retainedTokens: number;
+  omittedTokens: number;
+  omittedCount: number;
+  pendingCount: number;
+}
+
+const isToolOutput = (message: any): boolean =>
+  message?.role === "toolResult" || message?.role === "bashExecution";
+
+const outputText = (message: any): string =>
+  message.role === "bashExecution"
+    ? typeof message.output === "string"
+      ? message.output
+      : ""
+    : textOf(message.content);
+
+const omissionMarker = (recallIndex?: number): string =>
+  `[Tool output text omitted from active context; ${recallIndex === undefined ? "use recall" : `recall #${recallIndex}`}.]`;
+
+const omitOutput = (message: any, recallIndex?: number): any => {
+  const marker = omissionMarker(recallIndex);
+  if (message.role === "bashExecution") return { ...message, output: marker };
+  if (typeof message.content === "string") {
+    return { ...message, content: marker };
+  }
+  if (Array.isArray(message.content)) {
+    const nonText = message.content.filter(
+      (part: any) => part?.type !== "text",
+    );
+    return {
+      ...message,
+      content: [{ type: "text", text: marker }, ...nonText],
+    };
+  }
+  return { ...message, content: marker };
+};
+
+export function applyToolOutputBudget(
+  messages: any[],
+  maxTokens: number,
+  recallIndexes: ReadonlyMap<number, number> = new Map(),
+): ToolOutputBudgetResult {
+  let lastSuccessfulAssistantIndex = -1;
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const message = messages[i];
+    if (
+      message?.role === "assistant" &&
+      message.stopReason !== "error" &&
+      message.stopReason !== "aborted"
+    ) {
+      lastSuccessfulAssistantIndex = i;
+      break;
+    }
+  }
+
+  let retainedTokens = 0;
+  let omittedTokens = 0;
+  let omittedCount = 0;
+  let pendingCount = 0;
+  let exhausted = false;
+  let output = messages;
+
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const message = messages[i];
+    if (!isToolOutput(message)) continue;
+    if (lastSuccessfulAssistantIndex < 0 || i > lastSuccessfulAssistantIndex) {
+      pendingCount++;
+      continue;
+    }
+
+    const tokens = estimateStringTokens(outputText(message));
+    if (tokens === 0) continue;
+    if (!exhausted && retainedTokens + tokens <= maxTokens) {
+      retainedTokens += tokens;
+      continue;
+    }
+
+    exhausted = true;
+    omittedTokens += tokens;
+    omittedCount++;
+    if (output === messages) output = [...messages];
+    output[i] = omitOutput(message, recallIndexes.get(i));
+  }
+
+  return {
+    messages: output,
+    retainedTokens,
+    omittedTokens,
+    omittedCount,
+    pendingCount,
+  };
+}

--- a/src/core/unified-config.ts
+++ b/src/core/unified-config.ts
@@ -108,6 +108,10 @@ export interface UnifiedConfig {
    *  ONLY applies when compactionEngine: "blackhole" */
   tailBehavior: "pi-default" | "minimal";
 
+  /** Maximum historical tool-output text tokens retained in provider context.
+   *  Newest consumed outputs are retained first; omitted outputs remain recallable. */
+  retainedToolOutputMaxTokens: number;
+
   /** Token threshold for observer runs. */
   observeAfterTokens: number;
   /** Token threshold for reflector and dropper. */
@@ -198,6 +202,7 @@ export const DEFAULTS: UnifiedConfig = {
 
   skipForProviders: [],
   tailBehavior: "minimal",
+  retainedToolOutputMaxTokens: 20_000,
   midRunCompaction: "off",
 
   observeAfterTokens: 15_000,
@@ -354,6 +359,7 @@ function parseConfig(raw: Record<string, unknown>): Partial<UnifiedConfig> {
     "observeAfterTokens",
     "reflectAfterTokens",
     "compactAfterTokens",
+    "retainedToolOutputMaxTokens",
     "observationsPoolMaxTokens",
     "observationsPoolTargetTokens",
     "reflectorInputMaxTokens",

--- a/src/hooks/compaction-context.ts
+++ b/src/hooks/compaction-context.ts
@@ -1,9 +1,69 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { projectAppendOnlyContext } from "../core/compaction-chain.js";
+import { applyToolOutputBudget } from "../core/tool-output-budget.js";
 import { debugLog } from "../om/debug-log.js";
 import type { Runtime } from "../om/runtime.js";
 
-/** Project persisted version-2 checkpoints into immutable provider messages. */
+const buildRecallIndexes = (
+  messages: any[],
+  branchEntries: any[],
+  allEntries: any[],
+): Map<number, number> => {
+  const globalIndexById = new Map<string, number>();
+  let messageIndex = 0;
+  for (const entry of allEntries) {
+    if (entry?.type !== "message" || !entry.message) continue;
+    if (entry.id != null) globalIndexById.set(String(entry.id), messageIndex);
+    messageIndex++;
+  }
+
+  const indexByMessage = new Map<any, number>();
+  const indexByToolCallId = new Map<string, number>();
+  const duplicateToolCallIds = new Set<string>();
+  const indexedShellMessages: Array<{ message: any; index: number }> = [];
+  for (const entry of branchEntries) {
+    if (entry?.type !== "message" || !entry.message) continue;
+    const index = globalIndexById.get(String(entry.id));
+    if (index === undefined) continue;
+    indexByMessage.set(entry.message, index);
+    if (entry.message.role === "bashExecution") {
+      indexedShellMessages.push({ message: entry.message, index });
+    }
+    const toolCallId = entry.message.toolCallId;
+    if (typeof toolCallId === "string" && toolCallId.length > 0) {
+      if (indexByToolCallId.has(toolCallId))
+        duplicateToolCallIds.add(toolCallId);
+      else indexByToolCallId.set(toolCallId, index);
+    }
+  }
+
+  const result = new Map<number, number>();
+  messages.forEach((message, index) => {
+    let transcriptIndex = indexByMessage.get(message);
+    const toolCallId = message?.toolCallId;
+    if (
+      transcriptIndex === undefined &&
+      typeof toolCallId === "string" &&
+      !duplicateToolCallIds.has(toolCallId)
+    ) {
+      transcriptIndex = indexByToolCallId.get(toolCallId);
+    }
+    if (transcriptIndex === undefined && message?.role === "bashExecution") {
+      const matches = indexedShellMessages.filter(
+        (candidate) =>
+          candidate.message.command === message.command &&
+          candidate.message.output === message.output &&
+          candidate.message.exitCode === message.exitCode &&
+          candidate.message.timestamp === message.timestamp,
+      );
+      if (matches.length === 1) transcriptIndex = matches[0].index;
+    }
+    if (transcriptIndex !== undefined) result.set(index, transcriptIndex);
+  });
+  return result;
+};
+
+/** Project compaction checkpoints and budget historical tool outputs. */
 export function registerCompactionContextHook(
   pi: ExtensionAPI,
   runtime: Runtime,
@@ -12,17 +72,61 @@ export function registerCompactionContextHook(
     runtime.ensureConfig(ctx.cwd ?? process.cwd());
     const dbg = (ev: string, data?: Record<string, unknown>) =>
       debugLog(ev, data, runtime.config.debugLog === true);
+    let branchEntries: any[];
+    let projected: any[];
     try {
-      const branchEntries = ctx.sessionManager.getBranch();
-      const messages = projectAppendOnlyContext(event.messages, branchEntries);
-      if (messages === event.messages) return;
-      return { messages };
+      branchEntries = ctx.sessionManager.getBranch();
+      projected = projectAppendOnlyContext(event.messages, branchEntries);
     } catch (error) {
       // Keep Pi's complete fallback summary if the projection cannot be built.
       dbg("compaction_context.projection_failed", {
         error: error instanceof Error ? error.message : String(error),
       });
       return;
+    }
+
+    try {
+      const budget = runtime.config.retainedToolOutputMaxTokens;
+      let recallIndexes = new Map<number, number>();
+      try {
+        const allEntries = ctx.sessionManager.getEntries?.();
+        if (Array.isArray(allEntries)) {
+          recallIndexes = buildRecallIndexes(
+            projected,
+            branchEntries,
+            allEntries,
+          );
+        }
+      } catch {
+        // A generic recall marker is safer than an incorrect transcript index.
+      }
+      const result =
+        typeof budget === "number" && budget > 0
+          ? applyToolOutputBudget(projected, budget, recallIndexes)
+          : {
+              messages: projected,
+              retainedTokens: 0,
+              omittedTokens: 0,
+              omittedCount: 0,
+              pendingCount: 0,
+            };
+      const messages = result.messages;
+      if (messages === event.messages) return;
+      if (result.omittedCount > 0) {
+        dbg("compaction_context.tool_outputs_omitted", {
+          retainedTokens: result.retainedTokens,
+          omittedTokens: result.omittedTokens,
+          omittedCount: result.omittedCount,
+          pendingCount: result.pendingCount,
+        });
+      }
+      return { messages };
+    } catch (error) {
+      // Budgeting is optional; never discard a valid append projection.
+      dbg("compaction_context.tool_output_budget_failed", {
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return projected === event.messages ? undefined : { messages: projected };
     }
   });
 }

--- a/src/om/inline-compaction.ts
+++ b/src/om/inline-compaction.ts
@@ -435,32 +435,76 @@ export function parseHostFramePaths(stack: string): string[] {
   return paths;
 }
 
+function findBundledRuntimeModule(
+  entrypoint: string,
+  packageRoot: string,
+): string | undefined {
+  let resolvedEntrypoint: string;
+  let source: string;
+  try {
+    resolvedEntrypoint = realpathSync(entrypoint);
+    source = readFileSync(resolvedEntrypoint, "utf8");
+  } catch {
+    return undefined;
+  }
+
+  const namedImport = /\bimport\s*\{([^}]*)\}\s*from\s*["']([^"']+)["']/g;
+  for (const match of source.matchAll(namedImport)) {
+    const names = match[1]
+      .split(",")
+      .map((name) => name.trim().split(/\s+as\s+/)[0]);
+    const specifier = match[2];
+    if (!names.includes("main") || !specifier.startsWith(".")) continue;
+
+    try {
+      const candidate = realpathSync(
+        join(dirname(resolvedEntrypoint), specifier),
+      );
+      if (findPiPackageRoot(candidate) === packageRoot) return candidate;
+    } catch {
+      // Keep searching other named imports before falling back to dist/index.js.
+    }
+  }
+
+  return undefined;
+}
+
 export async function installHostInlineCompactionAdapter(
   options: HostInlineCompactionInstallOptions = {},
 ): Promise<InlineCompactionAdapterStatus> {
   const packageRoots = new Set<string>();
+  const hostPaths = new Set<string>();
   const stack = options.stack ?? new Error().stack ?? "";
-  for (const framePath of parseHostFramePaths(stack)) {
-    const root = findPiPackageRoot(framePath);
+  for (const framePath of parseHostFramePaths(stack)) hostPaths.add(framePath);
+
+  const entrypoint = options.entrypoint ?? process.argv[1];
+  if (entrypoint) hostPaths.add(entrypoint);
+
+  for (const hostPath of hostPaths) {
+    const root = findPiPackageRoot(hostPath);
     if (root) packageRoots.add(root);
   }
 
-  const entrypoint = options.entrypoint ?? process.argv[1];
-  if (entrypoint) {
-    const root = findPiPackageRoot(entrypoint);
-    if (root) packageRoots.add(root);
+  const modulePaths = new Set<string>();
+  for (const packageRoot of packageRoots) {
+    modulePaths.add(join(packageRoot, "dist", "index.js"));
+    for (const hostPath of hostPaths) {
+      if (findPiPackageRoot(hostPath) !== packageRoot) continue;
+      const bundledRuntime = findBundledRuntimeModule(hostPath, packageRoot);
+      if (bundledRuntime) modulePaths.add(bundledRuntime);
+    }
   }
-  getRegistry().hostCandidateCount = packageRoots.size;
+  getRegistry().hostCandidateCount = modulePaths.size;
 
   let supportedStatus: InlineCompactionAdapterStatus | undefined;
   const failureReasons: string[] = [];
-  for (const packageRoot of packageRoots) {
+  for (const modulePath of modulePaths) {
     try {
-      const hostModule = (await import(
-        pathToFileURL(join(packageRoot, "dist", "index.js")).href
-      )) as { AgentSession?: PatchableSessionClass };
+      const hostModule = (await import(pathToFileURL(modulePath).href)) as {
+        AgentSession?: PatchableSessionClass;
+      };
       if (!hostModule.AgentSession) {
-        failureReasons.push(`${packageRoot}: AgentSession export missing`);
+        failureReasons.push(`${modulePath}: AgentSession export missing`);
         continue;
       }
 
@@ -469,12 +513,10 @@ export async function installHostInlineCompactionAdapter(
       });
       if (status.supported) supportedStatus ??= status;
       else
-        failureReasons.push(
-          `${packageRoot}: ${status.reason ?? "unsupported"}`,
-        );
+        failureReasons.push(`${modulePath}: ${status.reason ?? "unsupported"}`);
     } catch (error) {
       failureReasons.push(
-        `${packageRoot}: ${error instanceof Error ? error.message : String(error)}`,
+        `${modulePath}: ${error instanceof Error ? error.message : String(error)}`,
       );
     }
   }

--- a/src/pi-base/blackhole-settings.ts
+++ b/src/pi-base/blackhole-settings.ts
@@ -417,7 +417,7 @@ export const config = new ConfigManager<UnifiedConfig>({
       if (
         typeof v !== "number" ||
         !Number.isFinite(v) ||
-        !Number.isInteger(v) ||
+        (k === "retainedToolOutputMaxTokens" && !Number.isInteger(v)) ||
         v < minVal
       ) {
         (merged as unknown as Record<string, unknown>)[k] = DEFAULTS[k];

--- a/src/pi-base/blackhole-settings.ts
+++ b/src/pi-base/blackhole-settings.ts
@@ -113,6 +113,17 @@ export const config = new ConfigManager<UnifiedConfig>({
       max: 500_000,
       step: 1_000,
     },
+    {
+      key: "retainedToolOutputMaxTokens",
+      type: "number",
+      label: "Retained tool outputs",
+      description:
+        "Token budget for historical tool-output text; newest is retained first and older text remains available via recall",
+      value: cfg.retainedToolOutputMaxTokens,
+      min: 1_000,
+      max: 200_000,
+      step: 1_000,
+    },
 
     // ── Observational Memory ──
     {
@@ -391,6 +402,7 @@ export const config = new ConfigManager<UnifiedConfig>({
       "observeAfterTokens",
       "reflectAfterTokens",
       "compactAfterTokens",
+      "retainedToolOutputMaxTokens",
       "observationsPoolMaxTokens",
       "observationsPoolTargetTokens",
       "reflectorInputMaxTokens",
@@ -402,7 +414,12 @@ export const config = new ConfigManager<UnifiedConfig>({
     for (const k of REQUIRED_NUMERIC_KEYS) {
       const v = (merged as unknown as Record<string, unknown>)[k];
       const minVal = k === "observerPreambleMaxTokens" ? 0 : 1;
-      if (typeof v !== "number" || !Number.isFinite(v) || v < minVal) {
+      if (
+        typeof v !== "number" ||
+        !Number.isFinite(v) ||
+        !Number.isInteger(v) ||
+        v < minVal
+      ) {
         (merged as unknown as Record<string, unknown>)[k] = DEFAULTS[k];
       }
     }
@@ -451,12 +468,5 @@ export const config = new ConfigManager<UnifiedConfig>({
 export async function openBlackholeSettings(
   ctx: ExtensionContext,
 ): Promise<void> {
-  await config.openSettings(
-    ctx,
-    ctx.cwd,
-    (_updated) => {
-      // Caller (pi-vcc.ts) reloads runtime.config after save.
-    },
-    GLOBAL_CONFIG_DIR,
-  );
+  await config.openSettings(ctx, ctx.cwd, () => {}, GLOBAL_CONFIG_DIR);
 }

--- a/src/pi-base/config-manager.test.ts
+++ b/src/pi-base/config-manager.test.ts
@@ -1349,10 +1349,16 @@ describe("ConfigManager._ensureSession()", () => {
 
       // Fresh manager: initSession with the entry
       const mgr2 = createManager({ sessionConfig: true });
-      mgr2.initSession("sid-recovery", "leaf-1", entries);
-      // initSession recovery writes to process.cwd(); load must match
-      expect(mgr2.load(process.cwd(), tempDir).threshold).toBe(3);
-      expect(mgr2.load(process.cwd(), tempDir).enabled).toBe(true);
+      mgr2.initSession(
+        "sid-recovery",
+        "leaf-1",
+        entries,
+        undefined,
+        undefined,
+        tempDir,
+      );
+      expect(mgr2.load(tempDir, tempDir).threshold).toBe(3);
+      expect(mgr2.load(tempDir, tempDir).enabled).toBe(true);
     });
 
     // ── flush→reset→save ────────────────────────────────────────────────

--- a/src/pi-base/config-manager.ts
+++ b/src/pi-base/config-manager.ts
@@ -278,6 +278,7 @@ export class ConfigManager<T extends object> {
         sm.getEntries?.() ?? [],
         appendEntryFn,
         () => sm.getEntries?.(),
+        cwd,
       );
       this._sessionPersist = "persisted";
       this._sessionManager = mutable; // keep facade for identity guard (F1)
@@ -409,12 +410,19 @@ export class ConfigManager<T extends object> {
     this._sessionPersist = "persisted";
     return Object.keys(pendingConfig).length > 0;
   }
+
+  /** Synchronize session-scoped state from a live extension context. */
+  syncSession(ctx: ExtensionContext, cwd: string): boolean {
+    return this._ensureSession(ctx, cwd);
+  }
+
   initSession(
     sessionId: string,
     leafId: string,
     entries: FileEntry[],
     appendEntry?: (type: string, data: unknown) => void,
     getEntries?: () => FileEntry[],
+    cwd: string = process.cwd(),
   ): void {
     if (
       this.opts.scopes?.session === false ||
@@ -444,13 +452,7 @@ export class ConfigManager<T extends object> {
         const data = entry.data as
           { leafId: string; config: Record<string, unknown> } | undefined;
         if (data && data.leafId === leafId) {
-          setSessionConfig(
-            entryType,
-            process.cwd(),
-            sessionId,
-            leafId,
-            data.config,
-          );
+          setSessionConfig(entryType, cwd, sessionId, leafId, data.config);
           break;
         }
       }

--- a/tests/blackhole-command.test.ts
+++ b/tests/blackhole-command.test.ts
@@ -30,6 +30,7 @@ vi.mock("../src/pi-base/settings/config-flow.js", () => ({
 }));
 
 import { registerPiVccCommand } from "../src/commands/pi-vcc.js";
+import { openConfigFlow } from "../src/pi-base/settings/config-flow.js";
 
 function createMockEnvironment() {
   const compactCalls: Array<{
@@ -39,8 +40,12 @@ function createMockEnvironment() {
   }> = [];
   const appendEntryCalls: Array<{ customType: string; data: unknown }> = [];
   const notifyCalls: Array<{ msg: string; level: string }> = [];
+  const eventHandlers = new Map<string, (event: unknown, ctx: any) => void>();
 
   const pi = {
+    on: vi.fn((name: string, handler: (event: unknown, ctx: any) => void) => {
+      eventHandlers.set(name, handler);
+    }),
     registerCommand: vi.fn(
       (
         name: string,
@@ -127,6 +132,7 @@ function createMockEnvironment() {
     compactCalls,
     appendEntryCalls,
     notifyCalls,
+    eventHandlers,
   };
 }
 
@@ -166,6 +172,106 @@ describe("/blackhole command", () => {
       (c) => c.value,
     );
     expect(configMatches).toEqual(["settings"]);
+  });
+
+  it("refreshes runtime config after saving settings", async () => {
+    const { pi, runtime, handlerMap, makeHandlerArgs } =
+      createMockEnvironment();
+    vi.mocked(openConfigFlow).mockImplementationOnce(async (params: any) => {
+      await params.save({ retainedToolOutputMaxTokens: 9_000 }, "global");
+    });
+    registerPiVccCommand(pi as any, runtime as any);
+
+    await handlerMap.get("blackhole")!("settings", makeHandlerArgs());
+
+    expect(runtime.config.retainedToolOutputMaxTokens).toBe(9_000);
+  });
+
+  it("recovers a persisted session budget on session_start", () => {
+    const { pi, runtime, eventHandlers } = createMockEnvironment();
+    registerPiVccCommand(pi as any, runtime as any);
+    const sessionFile = join(testRoot, "session.jsonl");
+    writeFileSync(sessionFile, "");
+    const sessionConfigEntry = {
+      id: "config-1",
+      parentId: "leaf-1",
+      type: "custom",
+      customType: "session-config-pi-blackhole",
+      data: {
+        leafId: "leaf-1",
+        config: { retainedToolOutputMaxTokens: 7_000 },
+      },
+    };
+
+    eventHandlers.get("session_start")!(undefined, {
+      cwd: testRoot,
+      sessionManager: {
+        getSessionId: () => "session-1",
+        getLeafId: () => "leaf-1",
+        getSessionFile: () => sessionFile,
+        getEntries: () => [
+          {
+            id: "leaf-1",
+            parentId: null,
+            type: "message",
+            message: { role: "user", content: "question" },
+          },
+          sessionConfigEntry,
+        ],
+        appendCustomEntry: vi.fn(),
+      },
+    });
+
+    expect(runtime.config.retainedToolOutputMaxTokens).toBe(7_000);
+  });
+
+  it("does not leak a session budget into a new session without a leaf", () => {
+    const { pi, runtime, eventHandlers } = createMockEnvironment();
+    registerPiVccCommand(pi as any, runtime as any);
+    const start = eventHandlers.get("session_start")!;
+    const sessionFile = join(testRoot, "session.jsonl");
+    writeFileSync(sessionFile, "");
+    const firstEntries = [
+      {
+        id: "leaf-1",
+        parentId: null,
+        type: "message",
+        message: { role: "user", content: "question" },
+      },
+      {
+        id: "config-1",
+        parentId: "leaf-1",
+        type: "custom",
+        customType: "session-config-pi-blackhole",
+        data: {
+          leafId: "leaf-1",
+          config: { retainedToolOutputMaxTokens: 7_000 },
+        },
+      },
+    ];
+    start(undefined, {
+      cwd: testRoot,
+      sessionManager: {
+        getSessionId: () => "session-1",
+        getLeafId: () => "leaf-1",
+        getSessionFile: () => sessionFile,
+        getEntries: () => firstEntries,
+        appendCustomEntry: vi.fn(),
+      },
+    });
+
+    start(undefined, {
+      cwd: testRoot,
+      sessionManager: {
+        getSessionId: () => "session-2",
+        getLeafId: () => null,
+        getSessionFile: () => undefined,
+        getEntries: () => [],
+        appendCustomEntry: vi.fn(),
+      },
+    });
+
+    expect(runtime.config.retainedToolOutputMaxTokens).toBe(20_000);
   });
 
   it("calls ctx.compact with PI_VCC_COMPACT_INSTRUCTION", async () => {

--- a/tests/compaction-context-hook.test.ts
+++ b/tests/compaction-context-hook.test.ts
@@ -82,4 +82,227 @@ describe("append context hook", () => {
     );
     expect(result).toBeUndefined();
   });
+
+  it("keeps a successful append projection when tool budgeting cannot read a payload", () => {
+    let handler: ((event: any, ctx: any) => any) | undefined;
+    registerCompactionContextHook(
+      {
+        on: (_name: string, callback: (event: any, ctx: any) => any) => {
+          handler = callback;
+        },
+      } as any,
+      {
+        config: {
+          debugLog: false,
+          retainedToolOutputMaxTokens: 1,
+        },
+        ensureConfig: () => {},
+      } as any,
+    );
+
+    const result = handler!(
+      {
+        messages: [
+          { role: "compactionSummary", summary: "complete fallback" },
+          { role: "toolResult", toolName: "odd", content: { value: 1 } },
+          { role: "assistant", content: "consumed" },
+        ],
+      },
+      {
+        sessionManager: {
+          getBranch: () => branch,
+          getEntries: () => branch,
+        },
+      },
+    );
+
+    expect(result.messages[0].summary).toBe(details.segment.summary);
+    expect(result.messages[1]).toMatchObject({
+      role: "custom",
+      customType: "blackhole-compaction-tail",
+    });
+  });
+
+  it("applies tool budgeting after a successful append projection", () => {
+    let handler: ((event: any, ctx: any) => any) | undefined;
+    registerCompactionContextHook(
+      {
+        on: (_name: string, callback: (event: any, ctx: any) => any) => {
+          handler = callback;
+        },
+      } as any,
+      {
+        config: {
+          debugLog: false,
+          retainedToolOutputMaxTokens: 1,
+        },
+        ensureConfig: () => {},
+      } as any,
+    );
+
+    const result = handler!(
+      {
+        messages: [
+          { role: "compactionSummary", summary: "complete fallback" },
+          { role: "toolResult", toolName: "read", content: "abcdefgh" },
+          { role: "assistant", content: "consumed" },
+        ],
+      },
+      {
+        sessionManager: {
+          getBranch: () => branch,
+          getEntries: () => branch,
+        },
+      },
+    );
+
+    expect(result.messages[0].summary).toBe(details.segment.summary);
+    expect(result.messages[2].content).toContain("omitted from active context");
+  });
+});
+
+describe("retained tool-output budget", () => {
+  const registerBudgetHandler = (budget: number, branchEntries: any[] = []) => {
+    let handler: ((event: any, ctx: any) => any) | undefined;
+    registerCompactionContextHook(
+      {
+        on: (_name: string, callback: (event: any, ctx: any) => any) => {
+          handler = callback;
+        },
+      } as any,
+      {
+        config: {
+          debugLog: false,
+          retainedToolOutputMaxTokens: budget,
+        },
+        ensureConfig: () => {},
+      } as any,
+    );
+    return (messages: any[]) =>
+      handler!(
+        { messages },
+        {
+          sessionManager: {
+            getBranch: () => branchEntries,
+            getEntries: () => branchEntries,
+          },
+        },
+      );
+  };
+
+  it("retains newest tool outputs first and masks older outputs", () => {
+    const apply = registerBudgetHandler(2);
+    const messages = [
+      { role: "toolResult", toolName: "old", content: "12345678" },
+      { role: "assistant", content: "used old output" },
+      { role: "toolResult", toolName: "new", content: "abcdefgh" },
+      { role: "assistant", content: "used new output" },
+    ];
+
+    const result = apply(messages);
+
+    expect(result.messages[0].content).toContain("omitted from active context");
+    expect(result.messages[1]).toBe(messages[1]);
+    expect(result.messages[2]).toBe(messages[2]);
+    expect(result.messages[3]).toBe(messages[3]);
+  });
+
+  it("masks an oversized historical output", () => {
+    const apply = registerBudgetHandler(1);
+    const messages = [
+      { role: "toolResult", toolName: "read", content: "x".repeat(20) },
+      { role: "assistant", content: "consumed" },
+    ];
+
+    const result = apply(messages);
+
+    expect(result.messages[0].content).toContain("omitted from active context");
+    expect(result.messages[0]).toMatchObject({
+      role: "toolResult",
+      toolName: "read",
+    });
+  });
+
+  it("preserves interleaved conversation while masking exhausted tool outputs", () => {
+    const apply = registerBudgetHandler(1);
+    const messages = [
+      { role: "user", content: "question" },
+      { role: "toolResult", toolName: "old", content: "a".repeat(8) },
+      { role: "assistant", content: "analysis" },
+      { role: "toolResult", toolName: "new", content: "b".repeat(4) },
+      { role: "assistant", content: "answer" },
+    ];
+
+    const result = apply(messages);
+
+    expect(result.messages).toHaveLength(messages.length);
+    expect(result.messages[0]).toBe(messages[0]);
+    expect(result.messages[1].content).toContain("omitted from active context");
+    expect(result.messages[2]).toBe(messages[2]);
+    expect(result.messages[3]).toBe(messages[3]);
+    expect(result.messages[4]).toBe(messages[4]);
+  });
+
+  it("protects trailing tool results until an assistant consumes them", () => {
+    const apply = registerBudgetHandler(1);
+    const messages = [
+      { role: "toolResult", toolName: "old", content: "a".repeat(8) },
+      { role: "assistant", content: "calling another tool" },
+      { role: "toolResult", toolName: "pending", content: "b".repeat(20) },
+    ];
+
+    const result = apply(messages);
+
+    expect(result.messages[0].content).toContain("omitted from active context");
+    expect(result.messages[2]).toBe(messages[2]);
+  });
+
+  it("adds a stable recall index when the tool result maps to a session entry", () => {
+    const oldResult = {
+      role: "toolResult",
+      toolCallId: "call-1",
+      toolName: "read",
+      content: "abcdefgh",
+    };
+    const consumed = { role: "assistant", content: "consumed" };
+    const branchEntries = [
+      {
+        id: "u1",
+        type: "message",
+        message: { role: "user", content: "question" },
+      },
+      { id: "t1", type: "message", message: oldResult },
+      { id: "a1", type: "message", message: consumed },
+    ];
+    const apply = registerBudgetHandler(1, branchEntries);
+
+    const result = apply([oldResult, consumed]);
+
+    expect(result.messages[0].content).toContain("recall #1");
+  });
+
+  it("maps a structured-cloned shell output to its recall index", () => {
+    const shellResult = {
+      role: "bashExecution",
+      command: "build",
+      output: "abcdefgh",
+      exitCode: 0,
+      timestamp: 20,
+    };
+    const consumed = { role: "assistant", content: "consumed", timestamp: 30 };
+    const branchEntries = [
+      {
+        id: "u1",
+        type: "message",
+        message: { role: "user", content: "question", timestamp: 10 },
+      },
+      { id: "b1", type: "message", message: shellResult },
+      { id: "a1", type: "message", message: consumed },
+    ];
+    const apply = registerBudgetHandler(1, branchEntries);
+
+    const result = apply(structuredClone([shellResult, consumed]));
+
+    expect(result.messages[0].output).toContain("recall #1");
+  });
 });

--- a/tests/config-manager-modal.test.ts
+++ b/tests/config-manager-modal.test.ts
@@ -92,4 +92,19 @@ describe("openSettings configDir forwarding (canonical config-flow)", () => {
     expect(typeof params.layerValues).toBe("function");
     expect(typeof params.save).toBe("function");
   });
+
+  it("validates retainedToolOutputMaxTokens through ConfigManager", async () => {
+    const { config, GLOBAL_CONFIG_DIR } =
+      await import("../src/pi-base/blackhole-settings.js");
+    const { mkdirSync, writeFileSync } = await import("node:fs");
+    mkdirSync(GLOBAL_CONFIG_DIR, { recursive: true });
+    writeFileSync(
+      join(GLOBAL_CONFIG_DIR, "pi-blackhole-config.json"),
+      JSON.stringify({ retainedToolOutputMaxTokens: 0 }),
+    );
+
+    expect(
+      config.load(testDir, GLOBAL_CONFIG_DIR).retainedToolOutputMaxTokens,
+    ).toBe(20_000);
+  });
 });

--- a/tests/config-manager-modal.test.ts
+++ b/tests/config-manager-modal.test.ts
@@ -107,4 +107,20 @@ describe("openSettings configDir forwarding (canonical config-flow)", () => {
       config.load(testDir, GLOBAL_CONFIG_DIR).retainedToolOutputMaxTokens,
     ).toBe(20_000);
   });
+
+  it("does not make existing numeric settings integer-only", async () => {
+    const { config, GLOBAL_CONFIG_DIR } =
+      await import("../src/pi-base/blackhole-settings.js");
+    const { mkdirSync, writeFileSync } = await import("node:fs");
+    mkdirSync(GLOBAL_CONFIG_DIR, { recursive: true });
+    writeFileSync(
+      join(GLOBAL_CONFIG_DIR, "pi-blackhole-config.json"),
+      JSON.stringify({ compactAfterTokens: 81_000.5 }),
+    );
+
+    expect(config.load(testDir, GLOBAL_CONFIG_DIR).compactAfterTokens).toBe(
+      81_000.5,
+    );
+  });
+
 });

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -55,6 +55,7 @@ describe("Config defaults", () => {
     expect(config.observeAfterTokens).toBe(15_000);
     expect(config.reflectAfterTokens).toBe(25_000);
     expect(config.compactAfterTokens).toBe(81_000);
+    expect(config.retainedToolOutputMaxTokens).toBe(20_000);
     expect(config.observationsPoolMaxTokens).toBe(20_000);
     expect(config.agentMaxTurns).toBe(16);
     expect(config.memory).toBe(true);
@@ -66,6 +67,32 @@ describe("Config defaults", () => {
     // Legacy fields are deleted during migration so not present
     expect((config as any).overrideDefaultCompaction).toBeUndefined();
     expect((config as any).passive).toBeUndefined();
+  });
+});
+
+describe("retainedToolOutputMaxTokens", () => {
+  const envKey = "PI_BLACKHOLE_RETAINED_TOOL_OUTPUT_MAX_TOKENS";
+
+  afterEach(() => {
+    delete process.env[envKey];
+  });
+
+  it("accepts a positive file override", async () => {
+    const { loadUnifiedConfig } = await import("../src/core/unified-config.js");
+    writeConfig({ retainedToolOutputMaxTokens: 12_000 });
+    expect(loadUnifiedConfig(testDir).retainedToolOutputMaxTokens).toBe(12_000);
+  });
+
+  it("rejects non-positive values", async () => {
+    const { loadUnifiedConfig } = await import("../src/core/unified-config.js");
+    writeConfig({ retainedToolOutputMaxTokens: 0 });
+    expect(loadUnifiedConfig(testDir).retainedToolOutputMaxTokens).toBe(20_000);
+  });
+
+  it("accepts a positive environment override", async () => {
+    const { loadUnifiedConfig } = await import("../src/core/unified-config.js");
+    process.env[envKey] = "9000";
+    expect(loadUnifiedConfig(testDir).retainedToolOutputMaxTokens).toBe(9_000);
   });
 });
 

--- a/tests/inline-compaction.test.ts
+++ b/tests/inline-compaction.test.ts
@@ -571,6 +571,86 @@ describe("Blackhole inline compaction adapter", () => {
     ).toEqual([windowsPath]);
   });
 
+  it("patches the bundled CLI AgentSession identity", async () => {
+    const fixtureRoot = await mkdtemp(
+      join(tmpdir(), "blackhole-bundled-host-"),
+    );
+    const packageRoot = join(
+      fixtureRoot,
+      "node_modules",
+      "@earendil-works",
+      "pi-coding-agent",
+    );
+    const dist = join(packageRoot, "dist");
+    const chunks = join(dist, "bundle", "chunks");
+    const cli = join(dist, "bundle", "cli.js");
+    const runtimeChunk = join(chunks, "runtime.js");
+    const sessionSource = `export class AgentSession {
+  constructor() {
+    this.agent = { state: { messages: [] } };
+    this.sessionManager = {
+      buildSessionContext: () => ({ messages: [] }),
+      appendCompaction: () => {},
+    };
+  }
+  async abort() {}
+  _bindExtensionCore() {}
+  async compact() {
+    await this.abort();
+    this.sessionManager.appendCompaction();
+    this.agent.state.messages = [];
+    return { summary: "summary", firstKeptEntryId: "kept", tokensBefore: 1 };
+  }
+}`;
+
+    try {
+      await mkdir(chunks, { recursive: true });
+      await writeFile(
+        join(packageRoot, "package.json"),
+        JSON.stringify({
+          name: "@earendil-works/pi-coding-agent",
+          type: "module",
+        }),
+      );
+      await writeFile(join(dist, "index.js"), sessionSource);
+      await writeFile(
+        runtimeChunk,
+        `${sessionSource}\nexport function main() {}`,
+      );
+      await writeFile(
+        cli,
+        '#!/usr/bin/env node\nimport{main}from"./chunks/runtime.js";main();\n',
+      );
+
+      const bundledModule = (await import(
+        pathToFileURL(runtimeChunk).href
+      )) as {
+        AgentSession: new () => {
+          agent: { state: { messages: unknown[] } };
+          sessionManager: object;
+          _bindExtensionCore(runner: unknown): void;
+        };
+      };
+      const originalBind =
+        bundledModule.AgentSession.prototype._bindExtensionCore;
+
+      await expect(
+        installHostInlineCompactionAdapter({ entrypoint: cli, stack: "" }),
+      ).resolves.toEqual({ supported: true });
+      expect(bundledModule.AgentSession.prototype._bindExtensionCore).not.toBe(
+        originalBind,
+      );
+
+      const session = new bundledModule.AgentSession();
+      session._bindExtensionCore({});
+      await expect(
+        compactInlineAtTurnBoundary(session.sessionManager),
+      ).resolves.toMatchObject({ summary: "summary" });
+    } finally {
+      await rm(fixtureRoot, { recursive: true, force: true });
+    }
+  });
+
   it("patches every independently loaded host AgentSession identity", async () => {
     const fixtureRoot = await mkdtemp(
       join(tmpdir(), "blackhole-host-identities-"),

--- a/tests/tool-output-budget-recall.test.ts
+++ b/tests/tool-output-budget-recall.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { loadAllMessages } from "../src/core/load-messages.js";
+import { registerCompactionContextHook } from "../src/hooks/compaction-context.js";
+import { registerRecallTool } from "../src/tools/recall.js";
+
+describe("tool-output budget recovery", () => {
+  it("recovers an omitted output through its recall index without changing raw history", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "blackhole-tool-budget-"));
+    const sessionFile = join(dir, "session.jsonl");
+    const fullOutput =
+      "full historical tool output that must remain recoverable";
+    const entries = [
+      {
+        id: "u1",
+        type: "message",
+        message: { role: "user", content: "inspect it" },
+      },
+      {
+        id: "t1",
+        type: "message",
+        message: {
+          role: "toolResult",
+          toolCallId: "call-1",
+          toolName: "read",
+          content: [{ type: "text", text: fullOutput }],
+        },
+      },
+      {
+        id: "a1",
+        type: "message",
+        message: { role: "assistant", content: "I used the result" },
+      },
+    ];
+    writeFileSync(
+      sessionFile,
+      entries.map((entry) => JSON.stringify(entry)).join("\n") + "\n",
+      "utf8",
+    );
+
+    try {
+      let contextHandler: ((event: any, ctx: any) => any) | undefined;
+      registerCompactionContextHook(
+        {
+          on: (_name: string, callback: (event: any, ctx: any) => any) => {
+            contextHandler = callback;
+          },
+        } as any,
+        {
+          config: {
+            debugLog: false,
+            retainedToolOutputMaxTokens: 1,
+          },
+          ensureConfig: () => {},
+        } as any,
+      );
+      const sessionManager = {
+        getBranch: () => entries,
+        getEntries: () => entries,
+        getSessionFile: () => sessionFile,
+      };
+      const masked = contextHandler!(
+        { messages: entries.map((entry) => entry.message) },
+        { sessionManager },
+      ).messages;
+      const marker = masked[1].content[0].text as string;
+      const recallQuery = marker.match(/recall (#\d+)/)?.[1];
+      expect(recallQuery).toBe("#1");
+      expect(marker).not.toContain(fullOutput);
+
+      let recallTool: any;
+      registerRecallTool({
+        registerTool: (tool: any) => {
+          recallTool = tool;
+        },
+      } as any);
+      const recalled = await recallTool.execute(
+        "recall-call",
+        { query: recallQuery },
+        undefined,
+        undefined,
+        { sessionManager },
+      );
+
+      expect(recalled.content[0].text).toContain(fullOutput);
+      expect(loadAllMessages(sessionFile, true).rawMessages[1].content).toEqual(
+        [{ type: "text", text: fullOutput }],
+      );
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/tool-output-budget.test.ts
+++ b/tests/tool-output-budget.test.ts
@@ -81,6 +81,23 @@ describe("applyToolOutputBudget", () => {
     }
   });
 
+  it("treats non-string/non-array tool-result content as textless", () => {
+    const messages = [
+      {
+        role: "toolResult",
+        toolName: "custom",
+        content: { data: "opaque" },
+      },
+      { role: "assistant", content: "consumed" },
+    ];
+
+    const result = applyToolOutputBudget(messages, 1);
+
+    expect(result.messages).toBe(messages);
+    expect(result.retainedTokens).toBe(0);
+    expect(result.omittedCount).toBe(0);
+  });
+
   it("leaves image-only results unchanged after the text budget is exhausted", () => {
     const image = { type: "image", data: "encoded", mimeType: "image/png" };
     const messages = [

--- a/tests/tool-output-budget.test.ts
+++ b/tests/tool-output-budget.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest";
+import { applyToolOutputBudget } from "../src/core/tool-output-budget.js";
+
+describe("applyToolOutputBudget", () => {
+  it("keeps an output that exactly fits the budget without cloning history", () => {
+    const messages = [
+      { role: "toolResult", toolName: "read", content: "12345678" },
+      { role: "assistant", content: "consumed" },
+    ];
+
+    const result = applyToolOutputBudget(messages, 2);
+
+    expect(result.messages).toBe(messages);
+    expect(result.retainedTokens).toBe(2);
+    expect(result.omittedCount).toBe(0);
+  });
+
+  it("masks shell output while retaining execution metadata", () => {
+    const messages = [
+      {
+        role: "bashExecution",
+        command: "build",
+        output: "x".repeat(8),
+        exitCode: 1,
+      },
+      { role: "assistant", content: "consumed" },
+    ];
+
+    const result = applyToolOutputBudget(messages, 1);
+
+    expect(result.messages[0]).toMatchObject({
+      role: "bashExecution",
+      command: "build",
+      exitCode: 1,
+    });
+    expect(result.messages[0].output).toContain("omitted from active context");
+    expect(messages[0].output).toBe("xxxxxxxx");
+  });
+
+  it("replaces text while preserving non-text tool-result content", () => {
+    const image = { type: "image", data: "encoded", mimeType: "image/png" };
+    const messages = [
+      {
+        role: "toolResult",
+        toolCallId: "call-1",
+        toolName: "capture",
+        content: [{ type: "text", text: "x".repeat(8) }, image],
+      },
+      { role: "assistant", content: "consumed" },
+    ];
+
+    const result = applyToolOutputBudget(messages, 1, new Map([[0, 4]]));
+
+    expect(result.messages[0].content[0].text).toContain("recall #4");
+    expect(result.messages[0].content[1]).toBe(image);
+    expect(messages[0].content[0].text).toBe("xxxxxxxx");
+  });
+
+  it("protects outputs when no successful assistant has consumed them", () => {
+    const messages = [
+      { role: "bashExecution", command: "build", output: "x".repeat(20) },
+    ];
+
+    const result = applyToolOutputBudget(messages, 1);
+
+    expect(result.messages).toBe(messages);
+    expect(result.pendingCount).toBe(1);
+  });
+
+  it("does not treat errored or aborted assistants as consumption boundaries", () => {
+    for (const stopReason of ["error", "aborted"]) {
+      const messages = [
+        { role: "toolResult", toolName: "read", content: "x".repeat(20) },
+        { role: "assistant", stopReason, content: [] },
+      ];
+
+      const result = applyToolOutputBudget(messages, 1);
+
+      expect(result.messages).toBe(messages);
+      expect(result.pendingCount).toBe(1);
+    }
+  });
+
+  it("leaves image-only results unchanged after the text budget is exhausted", () => {
+    const image = { type: "image", data: "encoded", mimeType: "image/png" };
+    const messages = [
+      { role: "toolResult", toolName: "capture", content: [image] },
+      { role: "toolResult", toolName: "old", content: "x".repeat(8) },
+      { role: "assistant", content: "consumed" },
+    ];
+
+    const result = applyToolOutputBudget(messages, 1);
+
+    expect(result.messages[0]).toBe(messages[0]);
+    expect(result.messages[1].content).toContain("text omitted");
+  });
+});


### PR DESCRIPTION
## What

Add a dedicated token budget for historical tool and shell output in provider-visible context.

Consumed tool outputs are scanned newest-first and kept at full fidelity while budget remains. Once budget is exhausted, older output text is replaced with compact recall #N references where a stable transcript index is available.

Pending tool results and non-text content remain visible. Raw session history, compaction inputs, and recall data stay unchanged.

## Why

Large tool outputs can consume a significant part of context after model has already used them, leaving less room for conversation and working state.

This adapts Gemini CLI's newest-first tool-output budgeting approach to Blackhole. Instead of creating a separate archive, omitted output remains available through Blackhole's existing session history and recall.

## Behavior

- Prioritizes newest consumed tool outputs
- Replaces budget-crossing and older output text with recall markers
- Handles both tool results and shell output
- Preserves shell metadata and non-text content such as images
- Protects results that have not yet been consumed by a successful assistant turn
- Falls back to generic recall markers when a stable transcript index cannot be proven
- Adds retainedToolOutputMaxTokens, defaulting to 20k tokens

## Validation

Added coverage for:

- newest-first retention and budget cutoff
- exact budget fits and oversized outputs
- shell metadata preservation
- non-text content preservation
- pending results and failed/aborted assistant turns
- recall references
- context projection integration
- config, environment, and session persistence