### PR TITLE
fix(om): key custom provider streams by provider+api, not api alone

### DIFF
--- a/src/om/provider-stream.ts
+++ b/src/om/provider-stream.ts
@@ -17,6 +17,21 @@ interface ProviderRegistry {
   registeredProviders?: Map<string, RegisteredProviderConfig>;
 }
 
+/**
+ * Key custom streams by `${provider}\u0000${api}` — NOT by `api` alone.
+ *
+ * Several extensions can register different providers that share one wire API
+ * (e.g. `anthropic` and `databricks` both declare `api: "anthropic-messages"`).
+ * Keying by api alone let the first-registered provider hijack every model that
+ * spoke the same protocol, routing Databricks-hosted Claude through the Anthropic
+ * transport (wrong URL/auth) and vice versa. Mirror pi core's rule: a custom
+ * streamSimple applies only to models of *that* provider whose `model.api`
+ * equals the provider's declared `api`.
+ */
+export function providerStreamKey(provider: string, api: string): string {
+  return `${provider}\u0000${api}`;
+}
+
 export function captureRegisteredProviderStreams(
   registry: ProviderRegistry,
   providerStreams: Map<string, Function>,
@@ -24,16 +39,17 @@ export function captureRegisteredProviderStreams(
   if (registry.getRegisteredProviderIds && registry.getRegisteredProviderConfig) {
     for (const providerId of registry.getRegisteredProviderIds()) {
       const config = registry.getRegisteredProviderConfig(providerId);
-      if (config?.streamSimple && config.api && !providerStreams.has(config.api)) {
-        providerStreams.set(config.api, config.streamSimple);
+      if (config?.streamSimple && config.api) {
+        // Always overwrite: providers may re-register (e.g. after async model refresh).
+        providerStreams.set(providerStreamKey(providerId, config.api), config.streamSimple);
       }
     }
     return;
   }
 
-  registry.registeredProviders?.forEach((config) => {
-    if (config.streamSimple && config.api && !providerStreams.has(config.api)) {
-      providerStreams.set(config.api, config.streamSimple);
+  registry.registeredProviders?.forEach((config, providerId) => {
+    if (config.streamSimple && config.api && typeof providerId === "string") {
+      providerStreams.set(providerStreamKey(providerId, config.api), config.streamSimple);
     }
   });
 }
@@ -114,7 +130,10 @@ export function createBridgeStreamFn(streamSimple: any) {
       PROVIDER_STREAMS_KEY
     ];
     if (!providerStreams) return streamSimple(model, ctx, opts);
-    const customFn = model?.api ? providerStreams.get(model.api) : undefined;
+    const customFn =
+      model?.provider && model?.api
+        ? providerStreams.get(providerStreamKey(model.provider, model.api))
+        : undefined;
     return customFn ? customFn(model, ctx, opts) : streamSimple(model, ctx, opts);
   };
 }

--- a/tests/provider-stream.test.ts
+++ b/tests/provider-stream.test.ts
@@ -4,6 +4,7 @@ import {
   captureRegisteredProviderStreams,
   createBridgeStreamFn,
   createProviderFetch,
+  providerStreamKey,
 } from "../src/om/provider-stream.js";
 
 const dispatcherSymbol = Symbol.for("undici.globalDispatcher.2");
@@ -33,19 +34,97 @@ describe("custom provider stream bridge", () => {
 
     captureRegisteredProviderStreams(registry as any, providerStreams);
 
-    expect(providerStreams.get("custom-api")).toBe(customStream);
+    expect(providerStreams.get(providerStreamKey("custom-provider", "custom-api"))).toBe(
+      customStream,
+    );
   });
 
-  it("uses the discovered stream for a custom API", () => {
+  it("keeps separate streams for providers that share the same api", () => {
+    // Real-world collision: `anthropic` (OAuth/attribution adapter) and
+    // `databricks` (bearer-auth gateway) both declare api "anthropic-messages".
+    const anthropicStream = vi.fn();
+    const databricksStream = vi.fn();
+    const configs: Record<string, { api: string; streamSimple: Function }> = {
+      anthropic: { api: "anthropic-messages", streamSimple: anthropicStream },
+      databricks: { api: "anthropic-messages", streamSimple: databricksStream },
+    };
+    const registry = {
+      getRegisteredProviderIds: () => Object.keys(configs),
+      getRegisteredProviderConfig: (id: string) => configs[id],
+    };
+    const providerStreams = new Map<string, Function>();
+
+    captureRegisteredProviderStreams(registry as any, providerStreams);
+
+    expect(providerStreams.get(providerStreamKey("anthropic", "anthropic-messages"))).toBe(
+      anthropicStream,
+    );
+    expect(providerStreams.get(providerStreamKey("databricks", "anthropic-messages"))).toBe(
+      databricksStream,
+    );
+  });
+
+  it("refreshes a provider's stream when it re-registers", () => {
+    const first = vi.fn();
+    const second = vi.fn();
+    const make = (streamSimple: Function) => ({
+      getRegisteredProviderIds: () => ["p"],
+      getRegisteredProviderConfig: () => ({ api: "a", streamSimple }),
+    });
+    const providerStreams = new Map<string, Function>();
+
+    captureRegisteredProviderStreams(make(first) as any, providerStreams);
+    captureRegisteredProviderStreams(make(second) as any, providerStreams);
+
+    expect(providerStreams.get(providerStreamKey("p", "a"))).toBe(second);
+  });
+
+  it("uses the discovered stream for a custom provider/api pair", () => {
     const fallbackStream = vi.fn();
     const customStream = vi.fn(() => "custom-result");
     const key = Symbol.for("pi-blackhole:provider-streams");
-    (globalThis as any)[key] = new Map([["custom-api", customStream]]);
+    (globalThis as any)[key] = new Map([
+      [providerStreamKey("custom-provider", "custom-api"), customStream],
+    ]);
     const bridge = createBridgeStreamFn(fallbackStream);
 
-    expect(bridge({ api: "custom-api" }, "context", {})).toBe("custom-result");
+    expect(bridge({ provider: "custom-provider", api: "custom-api" }, "context", {})).toBe(
+      "custom-result",
+    );
     expect(customStream).toHaveBeenCalledOnce();
     expect(fallbackStream).not.toHaveBeenCalled();
+  });
+
+  it("routes a model to its own provider's stream, not another provider with the same api", () => {
+    const fallbackStream = vi.fn();
+    const anthropicStream = vi.fn(() => "anthropic");
+    const databricksStream = vi.fn(() => "databricks");
+    const key = Symbol.for("pi-blackhole:provider-streams");
+    (globalThis as any)[key] = new Map([
+      [providerStreamKey("anthropic", "anthropic-messages"), anthropicStream],
+      [providerStreamKey("databricks", "anthropic-messages"), databricksStream],
+    ]);
+    const bridge = createBridgeStreamFn(fallbackStream);
+
+    expect(bridge({ provider: "databricks", api: "anthropic-messages" }, "ctx", {})).toBe(
+      "databricks",
+    );
+    expect(anthropicStream).not.toHaveBeenCalled();
+    expect(fallbackStream).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the default stream for a provider without a custom stream", () => {
+    const fallbackStream = vi.fn(() => "fallback");
+    const anthropicStream = vi.fn();
+    const key = Symbol.for("pi-blackhole:provider-streams");
+    (globalThis as any)[key] = new Map([
+      [providerStreamKey("anthropic", "anthropic-messages"), anthropicStream],
+    ]);
+    const bridge = createBridgeStreamFn(fallbackStream);
+
+    // Built-in provider speaking the same api must not be hijacked either.
+    expect(bridge({ provider: "other", api: "anthropic-messages" }, "ctx", {})).toBe("fallback");
+    expect(anthropicStream).not.toHaveBeenCalled();
   });
 
   it("returns undefined when no timeout is configured (inherit pi default)", async () => {


### PR DESCRIPTION
## Problem

`captureRegisteredProviderStreams` (`src/om/provider-stream.ts`) stores custom `streamSimple` functions in a map keyed only by wire **API**, first-wins.

When two extensions register providers that share an API — e.g. one extension registering provider `anthropic` and another registering provider `databricks`, both with `api: "anthropic-messages"` — every model on the second provider is routed through the first provider's transport. Every observer/reflector attempt then fails with:

```
Anthropic attribution could not delegate non-target provider "databricks"
```

which surfaces to the user as `Observer: all model candidates exhausted` once the retry budget is spent (all retries hit the same deterministic failure, so cooldown/fallback never helps).

Pi core avoids this: `provider-composer` checks both provider and api before delegating. The blackhole bridge did not.

## Fix

Key the map by `provider + api`, and look up by `model.provider + model.api`. Behaviour for setups with a single provider per API is unchanged.

## Tests

- Updated existing tests to the new key shape.
- Added regression tests: two providers on the same API are captured independently, and a model resolves to its own provider's stream rather than the first-registered one.
- Verified end-to-end in a live pi session with both extensions loaded: after the fix the observer reaches the second provider's model (debug log shows real API responses instead of the delegation error).
