### PR TITLE
perf: load memory workers and optional commands on demand

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -4,6 +4,23 @@ pi-blackhole merges deterministic algorithmic compaction with session-surviving 
 
 The entry point is `index.ts` (default export factory registered via `pi.extensions`).
 
+## Startup loading
+
+Startup registers commands, tools and lifecycle hooks, scaffolds configuration,
+and installs the host inline-compaction adapter before Pi binds the session.
+The adapter must remain eager so it can capture the correct host session identity.
+
+Optional implementations load on first use: each memory worker is imported only
+after its stage is due and a usable model passes the context-budget check;
+settings, changelog and cleanup modules load when their subcommands run. Export
+modules load after output-path validation, and the formatter is not loaded for an
+empty corpus. Normal module caching reuses these imports on later calls.
+
+No new setting is needed. Worker thresholds, fallback behavior, configuration
+precedence, command discovery and compaction semantics are unchanged. First use
+pays the deferred module-loading cost; this does not defer the host adapter or
+all shared runtime modules.
+
 ## Design philosophy
 
 The core insight: Pi's native LLM compaction erodes detail after repeated cycles. pi-blackhole replaces it with deterministic extraction plus a surviving memory layer.

--- a/src/commands/blackhole-export.ts
+++ b/src/commands/blackhole-export.ts
@@ -7,9 +7,6 @@ import { writeFileSync } from "node:fs";
 import { basename, isAbsolute, join, relative, resolve } from "node:path";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { getAgentDir } from "@earendil-works/pi-coding-agent";
-import { buildProjectMemoryCorpusAsync } from "../project-recall/corpus.js";
-import { buildExportMarkdownAsync } from "../project-recall/format-export.js";
-import { findGitRoot } from "../project-recall/session-dir.js";
 
 function defaultOutPath(cwd: string, now: Date): string {
   const iso = now.toISOString();
@@ -55,6 +52,7 @@ export const registerBlackholeExportCommand = (pi: ExtensionAPI) => {
         }
       }
 
+      const { findGitRoot } = await import("../project-recall/session-dir.js");
       const { root: gitRoot, warning: gitWarning } = await findGitRoot(ctx.cwd);
       if (gitWarning) {
         ctx.ui.notify(gitWarning, "warning");
@@ -85,6 +83,7 @@ export const registerBlackholeExportCommand = (pi: ExtensionAPI) => {
         }
       };
 
+      const { buildProjectMemoryCorpusAsync } = await import("../project-recall/corpus.js");
       const corpus = await buildProjectMemoryCorpusAsync(
         {
           cwd: ctx.cwd,
@@ -115,6 +114,7 @@ export const registerBlackholeExportCommand = (pi: ExtensionAPI) => {
         await new Promise<void>((resolve) => setImmediate(resolve));
       }
 
+      const { buildExportMarkdownAsync } = await import("../project-recall/format-export.js");
       const { markdown, stats } = await buildExportMarkdownAsync(corpus, {
         now: now.getTime(),
         title: basename(corpus.projectRoot),

--- a/src/commands/pi-vcc.ts
+++ b/src/commands/pi-vcc.ts
@@ -19,9 +19,6 @@ import {
   OM_OBSERVATIONS_RECORDED,
   OM_REFLECTIONS_RECORDED,
 } from "../om/ledger/index.js";
-import { handleCleanup } from "./cleanup.js";
-import { openBlackholeSettings, config, GLOBAL_CONFIG_DIR } from "../pi-base/blackhole-settings.js";
-import { openChangelogView } from "../changelog/changelog.js";
 
 export const registerPiVccCommand = (pi: ExtensionAPI, runtime: Runtime) => {
   const prefixMatch = (value: string, prefix: string): boolean => {
@@ -65,18 +62,22 @@ export const registerPiVccCommand = (pi: ExtensionAPI, runtime: Runtime) => {
       const trimmed = (typeof args === "string" ? args : "").trim();
       if (trimmed === "configure" || trimmed === "settings") {
         // Open the config overlay ("configure" kept as a hidden alias)
+        const { openBlackholeSettings } = await import("../pi-base/blackhole-settings.js");
         await openBlackholeSettings(ctx);
         return;
       }
       if (trimmed === "changelog") {
+        const { openChangelogView } = await import("../changelog/changelog.js");
         await openChangelogView(ctx);
         return;
       }
       if (trimmed === "cleanup") {
+        const { handleCleanup } = await import("./cleanup.js");
         await handleCleanup(ctx);
         return;
       }
       if (trimmed === "om-off") {
+        const { config, GLOBAL_CONFIG_DIR } = await import("../pi-base/blackhole-settings.js");
         try {
           config.save(
             { ...config.load(ctx.cwd, GLOBAL_CONFIG_DIR), memory: false },
@@ -99,6 +100,7 @@ export const registerPiVccCommand = (pi: ExtensionAPI, runtime: Runtime) => {
         return;
       }
       if (trimmed === "om-on") {
+        const { config, GLOBAL_CONFIG_DIR } = await import("../pi-base/blackhole-settings.js");
         try {
           config.save(
             { ...config.load(ctx.cwd, GLOBAL_CONFIG_DIR), memory: true },

--- a/src/om/consolidation.ts
+++ b/src/om/consolidation.ts
@@ -9,9 +9,6 @@
  */
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { matchesSkippedProvider } from "../core/provider-skip.js";
-import { runDropper } from "./agents/dropper/agent.js";
-import { runObserver } from "./agents/observer/agent.js";
-import { runReflector } from "./agents/reflector/agent.js";
 import type { ModelThinkingLevel } from "@earendil-works/pi-ai";
 import type { ConfiguredModel } from "./config.js";
 import { debugLog, withDebugLogContext } from "./debug-log.js";
@@ -763,6 +760,7 @@ async function runObserverStage(
     }
 
     try {
+      const { runObserver } = await import("./agents/observer/agent.js");
       const result = await runObserver({
         model: resolved.model as any,
         apiKey: resolved.apiKey,
@@ -1046,6 +1044,7 @@ async function runReflectorStage(
         Math.floor(runtime.config.reflectorInputMaxTokens * 0.15),
       );
 
+      const { runReflector } = await import("./agents/reflector/agent.js");
       const reflections = await runReflector({
         model: resolved.model as any,
         apiKey: resolved.apiKey,
@@ -1285,6 +1284,7 @@ async function runDropperStage(
         continue;
       }
 
+      const { runDropper } = await import("./agents/dropper/agent.js");
       const droppedIds = await runDropper({
         model: resolved.model as any,
         apiKey: resolved.apiKey,

--- a/tests/lazy-command-imports.test.ts
+++ b/tests/lazy-command-imports.test.ts
@@ -1,0 +1,126 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../src/hooks/before-compact.js", () => ({
+  PI_VCC_COMPACT_INSTRUCTION: "__pi_vcc__",
+  notifyMigrationReminder: vi.fn(),
+  formatCompactionStats: vi.fn(),
+}));
+vi.mock("../src/om/pending.js", () => ({
+  readPendingState: vi.fn(),
+  clearPendingState: vi.fn(),
+  hasPendingData: () => false,
+}));
+
+let imports: string[];
+let openSettings: ReturnType<typeof vi.fn>;
+let openChangelog: ReturnType<typeof vi.fn>;
+let cleanup: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  vi.resetModules();
+  imports = [];
+  openSettings = vi.fn(async () => {});
+  openChangelog = vi.fn(async () => {});
+  cleanup = vi.fn(async () => {});
+  vi.doMock("../src/pi-base/blackhole-settings.js", () => {
+    imports.push("settings");
+    return { openBlackholeSettings: openSettings };
+  });
+  vi.doMock("../src/changelog/changelog.js", () => {
+    imports.push("changelog");
+    return { openChangelogView: openChangelog };
+  });
+  vi.doMock("../src/commands/cleanup.js", () => {
+    imports.push("cleanup");
+    return { handleCleanup: cleanup };
+  });
+  vi.doMock("../src/project-recall/session-dir.js", () => {
+    imports.push("session-dir");
+    return { findGitRoot: vi.fn(async () => ({ root: "/project" })) };
+  });
+  vi.doMock("../src/project-recall/corpus.js", () => {
+    imports.push("corpus");
+    return {
+      buildProjectMemoryCorpusAsync: vi.fn(async () => ({
+        projectRoot: "/project",
+        sessionsConsidered: 0,
+        observations: [],
+        reflections: [],
+        droppedIds: new Set(),
+      })),
+    };
+  });
+  vi.doMock("../src/project-recall/format-export.js", () => {
+    imports.push("export-formatter");
+    return { buildExportMarkdownAsync: vi.fn() };
+  });
+});
+
+async function fixture() {
+  const { registerPiVccCommand } = await import("../src/commands/pi-vcc.js");
+  let command: any;
+  const ctx = {
+    sessionManager: { getSessionId: () => "test" },
+    compact: vi.fn(),
+    ui: { notify: vi.fn() },
+  };
+  registerPiVccCommand(
+    {
+      registerCommand: (_name: string, def: any) => {
+        command = def;
+      },
+    } as any,
+    { config: {} } as any,
+  );
+  return { command, ctx };
+}
+
+describe("lazy command imports", () => {
+  it("does not load optional command modules for registration, completion or manual compaction", async () => {
+    const { command, ctx } = await fixture();
+    expect(imports).toEqual([]);
+    expect(command.getArgumentCompletions("set")).toHaveLength(1);
+    await command.handler("", ctx);
+    await command.handler("settings extra", ctx);
+    expect(ctx.compact).toHaveBeenCalledOnce();
+    expect(imports).toEqual([]);
+  });
+
+  it.each(["settings", "configure", "changelog", "cleanup"])(
+    "loads only the requested %s implementation",
+    async (name) => {
+      const { command, ctx } = await fixture();
+      await command.handler(name, ctx);
+      const expected = name === "configure" ? "settings" : name;
+      expect(imports).toEqual([expected]);
+      const called =
+        expected === "settings" ? openSettings : expected === "changelog" ? openChangelog : cleanup;
+      expect(called).toHaveBeenCalledWith(ctx);
+      expect(ctx.compact).not.toHaveBeenCalled();
+    },
+  );
+
+  it("does not load the export pipeline before validation or its formatter for empty data", async () => {
+    const { registerBlackholeExportCommand } = await import("../src/commands/blackhole-export.js");
+    let command: any;
+    registerBlackholeExportCommand({
+      registerCommand: (_name: string, def: any) => {
+        command = def;
+      },
+    } as any);
+    const ctx = {
+      cwd: "/project",
+      ui: { notify: vi.fn() },
+      sessionManager: { getSessionFile: () => undefined },
+    };
+    expect(imports).toEqual([]);
+    await command.handler("out:invalid.txt", ctx);
+    expect(imports).toEqual([]);
+    await command.handler("", ctx);
+    expect(imports).toEqual(["session-dir", "corpus"]);
+    expect(ctx.ui.notify).toHaveBeenCalledWith(
+      expect.stringContaining("No observational memory"),
+      "warning",
+    );
+  });
+});

--- a/tests/lazy-workers.test.ts
+++ b/tests/lazy-workers.test.ts
@@ -1,0 +1,142 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { Runtime } from "../src/om/runtime.js";
+
+let imports: string[];
+let runObserver: ReturnType<typeof vi.fn>;
+let runReflector: ReturnType<typeof vi.fn>;
+let runDropper: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  vi.resetModules();
+  imports = [];
+  runObserver = vi.fn(async () => ({ observations: [] }));
+  runReflector = vi.fn(async () => []);
+  runDropper = vi.fn(async () => []);
+  vi.doMock("../src/om/agents/observer/agent.js", () => {
+    imports.push("observer");
+    return { runObserver };
+  });
+  vi.doMock("../src/om/agents/reflector/agent.js", () => {
+    imports.push("reflector");
+    return { runReflector };
+  });
+  vi.doMock("../src/om/agents/dropper/agent.js", () => {
+    imports.push("dropper");
+    return { runDropper };
+  });
+});
+
+function fixture() {
+  const runtime = new Runtime();
+  runtime.configLoaded = true;
+  runtime.config.observeAfterTokens = 1;
+  runtime.config.reflectAfterTokens = 1;
+  runtime.loadCursorsFromPending = vi.fn();
+  runtime.scheduleCursorFlush = vi.fn();
+  runtime.resolveModel = vi.fn(async () => ({
+    ok: true as const,
+    model: { provider: "test", id: "model", contextWindow: 1_000_000 },
+    apiKey: "test",
+  }));
+  runtime.recordRetryableError = vi.fn();
+  const entries: any[] = [
+    { type: "compaction", id: "c0", summary: "prior work", firstKeptEntryId: "m1" },
+    {
+      type: "message",
+      id: "m1",
+      message: { role: "user", content: "new source text ".repeat(100) },
+    },
+  ];
+  const handlers = new Map<string, Function>();
+  const pi = {
+    on: (name: string, handler: Function) => handlers.set(name, handler),
+    appendEntry: (customType: string, data: unknown) =>
+      entries.push({
+        type: "custom",
+        id: `entry-${entries.length}`,
+        customType,
+        data,
+      }),
+  } as any;
+  const ctx = {
+    cwd: "/project",
+    hasUI: false,
+    model: undefined,
+    modelRegistry: {},
+    sessionManager: { getBranch: () => entries, getSessionId: () => "lazy-workers" },
+  };
+  return { runtime, entries, pi, ctx, handlers };
+}
+
+describe("lazy worker imports", () => {
+  it("does not load workers for registration, disabled memory or below-threshold turns", async () => {
+    const { registerConsolidationTrigger } = await import("../src/om/consolidation.js");
+    const f = fixture();
+    registerConsolidationTrigger(f.pi, f.runtime);
+    expect(imports).toEqual([]);
+    f.runtime.config.memory = false;
+    f.handlers.get("agent_start")!({}, f.ctx);
+    expect(imports).toEqual([]);
+    f.runtime.config.memory = true;
+    f.runtime.config.observeAfterTokens = 1_000_000;
+    f.runtime.config.reflectAfterTokens = 1_000_000;
+    f.handlers.get("turn_end")!({}, f.ctx);
+    expect(imports).toEqual([]);
+    expect(f.runtime.consolidationInFlight).toBe(false);
+  });
+
+  it("does not import a worker when no model can run it", async () => {
+    const { runConsolidationPipeline } = await import("../src/om/consolidation.js");
+    const f = fixture();
+    f.runtime.resolveModel = vi.fn(async () => ({ ok: false, reason: "no model" }));
+    await runConsolidationPipeline(f.pi, f.runtime, f.ctx);
+    expect(imports).toEqual([]);
+  });
+
+  it("loads only the due worker and reuses it on retry", async () => {
+    const { runConsolidationPipeline } = await import("../src/om/consolidation.js");
+    const f = fixture();
+    f.runtime.config.reflectAfterTokens = 1_000_000;
+    runObserver.mockRejectedValueOnce(new Error("temporary provider failure"));
+    await runConsolidationPipeline(f.pi, f.runtime, f.ctx);
+    expect(imports).toEqual(["observer"]);
+    expect(runObserver).toHaveBeenCalledTimes(2);
+    expect(f.runtime.recordRetryableError).toHaveBeenCalledOnce();
+    expect(runReflector).not.toHaveBeenCalled();
+    expect(runDropper).not.toHaveBeenCalled();
+  });
+
+  it("loads all stages on demand without changing their ledger output", async () => {
+    const { runConsolidationPipeline } = await import("../src/om/consolidation.js");
+    const f = fixture();
+    runObserver.mockResolvedValue({
+      observations: [
+        {
+          id: "aaaaaaaaaaaa",
+          content: "Keep the established project convention.",
+          timestamp: "2026-09-01 12:00",
+          relevance: "high",
+          sourceEntryIds: ["m1"],
+          tokenCount: 10,
+        },
+      ],
+    });
+    runReflector.mockResolvedValue([
+      {
+        id: "bbbbbbbbbbbb",
+        content: "The convention is settled.",
+        supportingObservationIds: ["aaaaaaaaaaaa"],
+        tokenCount: 6,
+      },
+    ]);
+    runDropper.mockResolvedValue(["aaaaaaaaaaaa"]);
+    await runConsolidationPipeline(f.pi, f.runtime, f.ctx);
+    expect(imports).toEqual(["observer", "reflector", "dropper"]);
+    expect(
+      f.entries.filter((entry) => entry.type === "custom").map((entry) => entry.customType),
+    ).toEqual(["om.observations.recorded", "om.reflections.recorded", "om.observations.dropped"]);
+    expect(runDropper.mock.calls[0][0].reflections).toEqual(
+      expect.arrayContaining([expect.objectContaining({ id: "bbbbbbbbbbbb" })]),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Defer optional worker and command implementation imports from the TypeScript startup path. No new setting, dependency or packaging change is required.

Currently `index.ts` transitively imports all three OM agents (including their SDK/provider dependencies), the settings UI, changelog, cleanup and project-export implementations before any of those features are used.

## Changes

- Import each OM worker only immediately before its stage executes, after the existing due/model/context-budget checks.
- Import settings, changelog and cleanup only in their matching `/blackhole` subcommands. Command registration, autocomplete and manual compaction remain immediate.
- Import the export corpus pipeline after output-path validation, and the formatter only for nonempty memory.
- Keep host inline-compaction adapter installation eager: it must capture the real host session before binding. Provider capture, thresholds, fallback chains, configuration semantics and vendored `pi-base` remain unchanged.
- Add import-boundary regression tests and document the startup behavior.

The first invocation pays the deferred module-loading cost; subsequent calls reuse normal module caching. This targets the `index.ts` entry currently declared by `pi.extensions`, not a redesign of the optional bundled entry.

## Validation

- `pnpm build`: passed.
- `pnpm typecheck`: passed.
- `pnpm lint`: passed.
- `pnpm format:check`: passed.
- Full suite with environment normalization described below: **1518 tests passed across 94 files**, no skips.
- Regression tests cover registration, inactive/below-threshold/unavailable-model workers, worker retry, all three stages' ledger output, settings/configure/changelog/cleanup dispatch, export validation and empty-corpus behavior.
- Real Pi 0.85.1 TUI startup via `PI_STARTUP_BENCHMARK=1`, a disposable agent root and explicit local extension: passed. No model calls or real memory data.

### Existing environment-dependent tests

The unmodified `dev` baseline (`731e2b8`) reproduces the same three failures as the ordinary run on this root/Node 24.19.0 environment:

- The read-only filesystem test in `config-simplification.test.ts` still writes successfully with root's DAC override capability.
- Two `provider-stream.test.ts` cases mock Undici's global dispatcher before the first `Response` initializes Node's lazy Undici globals, overwriting the mock and making teardown attempt to delete a non-configurable property.

No unrelated production/test fixes or skips are included. Dropping the DAC override capabilities and initializing `Response` before test imports makes the full suite pass:

```bash
NODE_OPTIONS='--import=data:text/javascript,new%20Response()' \
  setpriv --bounding-set=-dac_override,-dac_read_search -- pnpm test
```

## Startup measurements

Three sequential runs before and after, same checkout path/dependencies on GPFS, Node 24.19.0 and Pi 0.85.1. Each run used a fresh disposable `PI_CODING_AGENT_DIR` and:

```bash
PI_TIMING=1 PI_STARTUP_BENCHMARK=1 pi --no-approve --no-session --offline \
  --no-extensions --no-context-files --no-skills --no-prompt-templates \
  --no-themes -e /path/to/pi-blackhole/index.ts
```

Run in a pseudo-terminal (`script -q -e -c '...' /dev/null`). Medians:

| Metric | Before | After |
| --- | ---: | ---: |
| Extension module import | 649ms | 430ms |
| Extension factory | 6ms | 7ms |
| Pi internal startup total | 819ms | 599ms |
| Benchmark process wall time | 1687ms | 1417ms |

These are warm/mixed-cache samples, not controlled cold-cache guarantees. The regression tests establish the import boundary independently of timing noise. Factory work is deliberately preserved rather than deferred past host session binding.
