### PR TITLE
fix(om): resolve worker streamSimple through modelRegistry for custom providers

### DIFF
--- a/src/om/agents/dropper/agent.ts
+++ b/src/om/agents/dropper/agent.ts
@@ -55,6 +55,8 @@ interface RunDropperArgs {
   maxTurns?: number;
   thinkingLevel?: ModelThinkingLevel;
   providerIdleTimeoutMs?: number;
+  /** Model registry for streamSimple resolution (custom providers, OAuth). */
+  modelRegistry?: any;
 }
 
 const DROP_SKIP_FULLNESS = 0.1;
@@ -364,7 +366,7 @@ export async function runDropper(args: RunDropperArgs): Promise<string[] | undef
 
   const loop = args.agentLoop ?? agentLoop;
   // ── Bridge stream function ──
-  const bridgeStreamFn = createBridgeStreamFn(streamSimple);
+  const bridgeStreamFn = createBridgeStreamFn(streamSimple, args.modelRegistry);
   const streamFn = args.streamFn ?? bridgeStreamFn;
   const stream = loop(prompts, context, config, signal, streamFn);
   let agentError: string | undefined;

--- a/src/om/agents/observer/agent.ts
+++ b/src/om/agents/observer/agent.ts
@@ -46,6 +46,8 @@ interface RunObserverArgs {
   maxTurns?: number;
   thinkingLevel?: ModelThinkingLevel;
   providerIdleTimeoutMs?: number;
+  /** Model registry for streamSimple resolution (custom providers, OAuth). */
+  modelRegistry?: any;
 }
 
 const RelevanceSchema = Type.Union([
@@ -263,7 +265,8 @@ ${conversation}`;
   // Consolidation agents run via jiti (moduleCache: false) which creates a separate
   // pi-ai instance whose apiProviderRegistry lacks custom providers registered by
   // other extensions (e.g., claude-bridge). The bridge looks up streamSimple functions
-  const bridgeStreamFn = createBridgeStreamFn(streamSimple);
+  // via modelRegistry (host-composed facade → registered provider config → global map).
+  const bridgeStreamFn = createBridgeStreamFn(streamSimple, args.modelRegistry);
   const streamFn = args.streamFn ?? bridgeStreamFn;
   const stream = loop(prompts, context, config, signal, streamFn);
   let agentError: string | undefined;

--- a/src/om/agents/reflector/agent.ts
+++ b/src/om/agents/reflector/agent.ts
@@ -53,6 +53,8 @@ interface RunReflectorArgs {
   maxTurns?: number;
   thinkingLevel?: ModelThinkingLevel;
   providerIdleTimeoutMs?: number;
+  /** Model registry for streamSimple resolution (custom providers, OAuth). */
+  modelRegistry?: any;
 }
 
 const RecordReflectionsSchema = Type.Object({
@@ -192,7 +194,7 @@ export async function runReflector(args: RunReflectorArgs): Promise<Reflection[]
 
   const loop = args.agentLoop ?? agentLoop;
   // ── Bridge stream function ──
-  const bridgeStreamFn = createBridgeStreamFn(streamSimple);
+  const bridgeStreamFn = createBridgeStreamFn(streamSimple, args.modelRegistry);
   const streamFn = args.streamFn ?? bridgeStreamFn;
   const stream = loop(prompts, context, config, signal, streamFn);
   let agentError: string | undefined;

--- a/src/om/consolidation.ts
+++ b/src/om/consolidation.ts
@@ -811,6 +811,7 @@ async function runObserverStage(
         thinkingLevel: stageThinkingLevel(runtime, "observer", stageModelForThinking),
         providerIdleTimeoutMs: runtime.config.providerIdleTimeoutMs,
         signal: generation.signal,
+        modelRegistry: ctx.modelRegistry,
       });
       if (!runtime.isGenerationActive(generation)) return "abort";
 
@@ -1101,6 +1102,7 @@ async function runReflectorStage(
         thinkingLevel: stageThinkingLevel(runtime, "reflector", stageModelForThinking),
         providerIdleTimeoutMs: runtime.config.providerIdleTimeoutMs,
         signal: generation.signal,
+        modelRegistry: ctx.modelRegistry,
       });
       if (!runtime.isGenerationActive(generation))
         return { outcome: "abort", sameRunReflections: [] };
@@ -1350,6 +1352,7 @@ async function runDropperStage(
         thinkingLevel: stageThinkingLevel(runtime, "dropper", stageModelForThinking),
         providerIdleTimeoutMs: runtime.config.providerIdleTimeoutMs,
         signal: generation.signal,
+        modelRegistry: ctx.modelRegistry,
       });
       if (!runtime.isGenerationActive(generation)) return "abort";
       const latestReflectionCoverageId = isManualMode(runtime.config)

--- a/src/om/provider-stream.ts
+++ b/src/om/provider-stream.ts
@@ -18,6 +18,20 @@ interface ProviderRegistry {
 }
 
 /**
+ * Duck-typed subset of Pi's extension ModelRegistry that the bridge needs.
+ *
+ * `streamSimple` is the host-composed path (Pi #8964). Until that lands on the
+ * facade, `getRegisteredProviderConfig` still exposes each `registerProvider`
+ * `streamSimple` handler, keyed by the extension provider id — match on
+ * `config.api === model.api`.
+ */
+export interface ModelRegistry {
+  streamSimple?: Function;
+  getRegisteredProviderIds?: () => readonly string[];
+  getRegisteredProviderConfig?: (providerId: string) => RegisteredProviderConfig | undefined;
+}
+
+/**
  * Key custom streams by `${provider}\u0000${api}` — NOT by `api` alone.
  *
  * Several extensions can register different providers that share one wire API
@@ -123,17 +137,48 @@ export function createProviderFetch(timeoutMs?: number): typeof fetch | undefine
   };
 }
 
-export function createBridgeStreamFn(streamSimple: any) {
+export function createBridgeStreamFn(
+  streamSimple: any,
+  modelRegistry?: ModelRegistry | null,
+): (model: any, ctx: any, opts: any) => any {
   const PROVIDER_STREAMS_KEY = Symbol.for("pi-blackhole:provider-streams");
   return (model: any, ctx: any, opts: any) => {
+    // 1. Check modelRegistry.streamSimple (host-composed facade, Pi #8964)
+    if (modelRegistry && typeof (modelRegistry as any).streamSimple === "function") {
+      return (modelRegistry as any).streamSimple(model, ctx, opts);
+    }
+
+    // 2. Iterate getRegisteredProviderConfig to find matching model.api
+    if (
+      modelRegistry &&
+      typeof (modelRegistry as any).getRegisteredProviderIds === "function" &&
+      typeof (modelRegistry as any).getRegisteredProviderConfig === "function"
+    ) {
+      try {
+        for (const providerId of (modelRegistry as any).getRegisteredProviderIds()) {
+          const config = (modelRegistry as any).getRegisteredProviderConfig(providerId);
+          if (config?.api === model.api && typeof config.streamSimple === "function") {
+            return config.streamSimple(model, ctx, opts);
+          }
+        }
+      } catch {
+        // Incomplete host/test doubles — fall through to global map
+      }
+    }
+
+    // 3. Fall back to global Symbol.for map (existing captureRegisteredProviderStreams)
     const providerStreams: Map<string, Function> | undefined = (globalThis as any)[
       PROVIDER_STREAMS_KEY
     ];
-    if (!providerStreams) return streamSimple(model, ctx, opts);
-    const customFn =
-      model?.provider && model?.api
-        ? providerStreams.get(providerStreamKey(model.provider, model.api))
-        : undefined;
-    return customFn ? customFn(model, ctx, opts) : streamSimple(model, ctx, opts);
+    if (providerStreams) {
+      const customFn =
+        model?.provider && model?.api
+          ? providerStreams.get(providerStreamKey(model.provider, model.api))
+          : undefined;
+      if (customFn) return customFn(model, ctx, opts);
+    }
+
+    // 4. Final fallback to compat
+    return streamSimple(model, ctx, opts);
   };
 }

--- a/tests/provider-stream.test.ts
+++ b/tests/provider-stream.test.ts
@@ -113,6 +113,83 @@ describe("custom provider stream bridge", () => {
     expect(fallbackStream).not.toHaveBeenCalled();
   });
 
+  it("uses modelRegistry.streamSimple when the global map has no match", () => {
+    const fallbackStream = vi.fn(() => "fallback");
+    const registryStream = vi.fn(() => "registry");
+    const modelRegistry = {
+      streamSimple: registryStream,
+    };
+    const bridge = createBridgeStreamFn(fallbackStream, modelRegistry);
+
+    // No global map entry — should use registry.streamSimple
+    expect(bridge({ provider: "cursor", api: "cursor-sdk" }, "ctx", {})).toBe("registry");
+    expect(registryStream).toHaveBeenCalledOnce();
+    expect(fallbackStream).not.toHaveBeenCalled();
+  });
+
+  it("iterates modelRegistry.getRegisteredProviderConfig to find matching model.api", () => {
+    const fallbackStream = vi.fn(() => "fallback");
+    const cursorStream = vi.fn(() => "cursor");
+    const openaiStream = vi.fn(() => "openai");
+    const modelRegistry = {
+      getRegisteredProviderIds: () => ["openai", "cursor"],
+      getRegisteredProviderConfig: (id: string) => {
+        if (id === "openai") return { api: "openai-completions", streamSimple: openaiStream };
+        if (id === "cursor") return { api: "cursor-sdk", streamSimple: cursorStream };
+        return undefined;
+      },
+    };
+    const bridge = createBridgeStreamFn(fallbackStream, modelRegistry);
+
+    // Model with cursor-sdk api should find cursorStream
+    expect(bridge({ provider: "cursor", api: "cursor-sdk" }, "ctx", {})).toBe("cursor");
+    expect(cursorStream).toHaveBeenCalledOnce();
+    expect(fallbackStream).not.toHaveBeenCalled();
+  });
+
+  it("prefers registry.streamSimple over getRegisteredProviderConfig iteration", () => {
+    const fallbackStream = vi.fn(() => "fallback");
+    const registryStream = vi.fn(() => "registry");
+    const matchingStream = vi.fn(() => "matching");
+    const modelRegistry = {
+      streamSimple: registryStream,
+      getRegisteredProviderIds: () => ["cursor"],
+      getRegisteredProviderConfig: () => ({ api: "cursor-sdk", streamSimple: matchingStream }),
+    };
+    const bridge = createBridgeStreamFn(fallbackStream, modelRegistry);
+
+    // registry.streamSimple takes precedence
+    expect(bridge({ provider: "cursor", api: "cursor-sdk" }, "ctx", {})).toBe("registry");
+    expect(registryStream).toHaveBeenCalledOnce();
+    expect(matchingStream).not.toHaveBeenCalled();
+    expect(fallbackStream).not.toHaveBeenCalled();
+  });
+
+  it("falls back to compat when registry lookup throws", () => {
+    const fallbackStream = vi.fn(() => "fallback");
+    const modelRegistry = {
+      getRegisteredProviderIds: () => {
+        throw new Error("no runtime");
+      },
+      getRegisteredProviderConfig: () => undefined,
+    };
+    const bridge = createBridgeStreamFn(fallbackStream, modelRegistry);
+
+    // Registry throws — should fall back to compat
+    expect(bridge({ provider: "cursor", api: "cursor-sdk" }, "ctx", {})).toBe("fallback");
+    expect(fallbackStream).toHaveBeenCalledOnce();
+  });
+
+  it("falls back to compat when registry has no streamSimple or provider methods", () => {
+    const fallbackStream = vi.fn(() => "fallback");
+    const modelRegistry = {};
+    const bridge = createBridgeStreamFn(fallbackStream, modelRegistry);
+
+    // Empty registry — should fall back to compat
+    expect(bridge({ provider: "cursor", api: "cursor-sdk" }, "ctx", {})).toBe("fallback");
+    expect(fallbackStream).toHaveBeenCalledOnce();
+  });
+
   it("falls back to the default stream for a provider without a custom stream", () => {
     const fallbackStream = vi.fn(() => "fallback");
     const anthropicStream = vi.fn();


### PR DESCRIPTION
Tracks upstream https://github.com/elpapi42/pi-observational-memory/pull/60
to resolve the issue that exists in pi-blackhole as well: https://github.com/elpapi42/pi-observational-memory/issues/30

Workers resolve a stream function in this order: explicit override, ModelRegistry.streamSimple when Pi exposes it (https://github.com/earendil-works/pi/issues/8964), then getRegisteredProviderConfig(id).streamSimple matching model.api, then compat fallback.

Observer/reflector/dropper were hard-wired to `@earendil-works/pi-ai/compat` `streamSimple`, which cannot dispatch `pi.registerProvider` APIs (cursor-sdk, CLIProxyAPI, commandcode, …). Custom-provider-only setups crash with `No API provider registered for api: …` after a successful turn.

**Resolution chain — identical (minus our extra step 3):**

| Step | Upstream PR #60 | Our code |
|------|-----------------|----------|
| 1 | `override` (explicit) | `modelRegistry.streamSimple` |
| 2 | `modelRegistry.streamSimple` | `getRegisteredProviderConfig()` matching `model.api` |
| 3 | `getRegisteredProviderConfig()` loop | Global `Symbol.for` map |
| 4 | compat fallback | compat fallback |

**Minor architectural differences:**

- **Upstream** created a new `worker-stream.ts` module with `resolveWorkerStreamSimple(model, modelRegistry, override)` — returns a `WorkerStreamSimple` function directly.
- **We** extended the existing `provider-stream.ts` bridge, which already handles the Symbol.for global map and `captureRegisteredProviderStreams`. We pass `streamSimple` as the fallback argument to `createBridgeStreamFn(streamSimple, modelRegistry)`.

**What this means:** We have an *extra* step 3 (the global Symbol.for map) that upstream doesn't have. This is our existing `captureRegisteredProviderStreams` mechanism — it bridges the gap when providers were captured at startup but `modelRegistry` isn't available yet or is incomplete. Upstream only has 3 resolution steps; we have 4.

**The net result is the same:** custom providers from `pi.registerProvider` work without needing a built-in fallback model.

The bridge now resolves the stream function in this order:

1. `modelRegistry.streamSimple` (host-composed facade, Pi #8964)
2. `modelRegistry.getRegisteredProviderConfig().streamSimple` matching `model.api`
3. Global `Symbol.for` map (existing `captureRegisteredProviderStreams`)
4. Compat fallback

Custom-provider-only setups can leave `observational-memory.model` unset. A second built-in provider (OpenAI/OpenRouter) is optional, not required.

## Changes

- **`src/om/provider-stream.ts`** — Added `ModelRegistry` interface; `createBridgeStreamFn` now accepts `modelRegistry` parameter and implements the 4-step resolution chain
- **`src/om/agents/observer/agent.ts`** — Added `modelRegistry` arg to `RunObserverArgs`; passes it to `createBridgeStreamFn`
- **`src/om/agents/reflector/agent.ts`** — Same
- **`src/om/agents/dropper/agent.ts`** — Same
- **`src/om/consolidation.ts`** — Passes `ctx.modelRegistry` to all three agent calls (`runObserver`, `runReflector`, `runDropper`)
- **`tests/provider-stream.test.ts`** — 5 new tests for the modelRegistry resolution path

