### PR TITLE
fix(compaction): skip ineligible proactive auto-compaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+### Fixed
+
+- **Skip ineligible proactive auto-compaction before core `prepareCompaction` failure.** When provider context reaches the auto-compaction threshold (e.g. via large system prompts, tool definitions, or memory projections) but available session entries after the latest boundary remain below Pi's configured `keepRecentTokens` budget (default 20,000), `prepareCompaction()` returns `undefined`, which previously caused Pi's `AgentSession.compact()` to throw `"Nothing to compact (session too small)"` before extension hooks ran. Settled (`agent_end`) and mid-run (`turn_end` in resume and pause modes) auto-compaction now evaluate session eligibility using Pi's `prepareCompaction` and the captured `AgentSession`'s effective compaction settings, suppressing premature trigger notices, inline failure backoff loops, and unhandled compaction errors while cleanly resuming once session history grows past the keep budget.
+
 ---
 
 ## [0.5.3] - 2026-09-10

--- a/src/om/compaction-trigger.ts
+++ b/src/om/compaction-trigger.ts
@@ -7,6 +7,7 @@ import { RETRYABLE_ERROR_RE } from "./retryable-error.js";
 import {
   compactInlineAtTurnBoundary,
   InlineCompactionUnavailableError,
+  isCompactionEligible,
   type InlineCompaction,
 } from "./inline-compaction.js";
 
@@ -203,6 +204,15 @@ async function handleTurnEnd(
     return;
   }
 
+  if (!isCompactionEligible(ctx.sessionManager, entries)) {
+    dbg("compaction_trigger.turn_end.skip", {
+      reason: "not_eligible",
+      tokens,
+      threshold,
+    });
+    return;
+  }
+
   const hasUI = ctx.hasUI;
   const ui = ctx.ui;
   dbg("compaction_trigger.turn_end.threshold_reached", {
@@ -392,6 +402,15 @@ function handleAgentEnd(event: any, ctx: any, runtime: Runtime): void {
     return;
   }
 
+  if (!isCompactionEligible(ctx.sessionManager, entries)) {
+    dbg("compaction_trigger.skip", {
+      reason: "not_eligible",
+      tokens,
+      threshold,
+    });
+    return;
+  }
+
   // Capture ctx properties synchronously — the deferred callback below
   // may outlive the extension ctx (stale after session replacement/reload).
   const hasUI = ctx.hasUI;
@@ -518,6 +537,17 @@ function handleAgentEnd(event: any, ctx: any, runtime: Runtime): void {
           ui,
           "Observational memory: compaction skipped — another compaction already ran before deferred compaction",
         );
+        return;
+      }
+
+      if (!isCompactionEligible(ctx.sessionManager, currentEntries)) {
+        runtime.compactInFlight = false;
+        runtime.autoCompactionController = null;
+        dbg("compaction_trigger.microtask.bail", {
+          reason: "not_eligible",
+          currentTokens,
+          threshold,
+        });
         return;
       }
 

--- a/src/om/inline-compaction.ts
+++ b/src/om/inline-compaction.ts
@@ -2,6 +2,7 @@ import { AgentSession, type CompactionResult } from "@earendil-works/pi-coding-a
 import { existsSync, readFileSync, realpathSync } from "node:fs";
 import { dirname, join, parse } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
+import { debugLog } from "./debug-log.js";
 
 const REGISTRY_KEY = Symbol.for("pi-blackhole:inline-compaction-adapter:v1");
 
@@ -33,9 +34,25 @@ interface SessionManagerLike {
   buildSessionContext(): { messages: unknown[] };
 }
 
+export interface CompactionSettingsLike {
+  enabled?: boolean;
+  reserveTokens?: number;
+  keepRecentTokens?: number;
+}
+
+export type PrepareCompactionLike = (
+  pathEntries: unknown[],
+  settings: CompactionSettingsLike,
+) => unknown | undefined;
+
+interface SettingsManagerLike {
+  getCompactionSettings?(): CompactionSettingsLike;
+}
+
 interface PatchableSession {
   agent: AgentLike;
   sessionManager: SessionManagerLike;
+  settingsManager?: SettingsManagerLike;
   abort(): Promise<void>;
   compact(customInstructions?: string): Promise<CompactionResult>;
   _bindExtensionCore(runner: unknown): unknown;
@@ -79,6 +96,9 @@ interface AdapterRegistry {
   compactionInFlight: WeakSet<object>;
   hostCandidateCount?: number;
   capturedSessionCount?: number;
+  prepareCompaction?: PrepareCompactionLike;
+  prepareCompactionSource?: string;
+  prepareCompactionFailure?: string;
 }
 
 export interface InlineCompactionAdapterStatus {
@@ -88,11 +108,19 @@ export interface InlineCompactionAdapterStatus {
 
 export interface InlineCompactionInstallOptions {
   sessionClass?: PatchableSessionClass;
+  prepareCompaction?: PrepareCompactionLike;
 }
 
 export interface HostInlineCompactionInstallOptions {
   entrypoint?: string;
   stack?: string;
+  prepareCompaction?: PrepareCompactionLike;
+}
+
+export interface PrepareCompactionStatus {
+  resolved: boolean;
+  source?: string;
+  failure?: string;
 }
 
 export type InlineCompaction = (
@@ -445,6 +473,59 @@ function findBundledRuntimeModule(entrypoint: string, packageRoot: string): stri
   return undefined;
 }
 
+async function resolveHostPrepareCompaction(
+  packageRoots: Iterable<string>,
+  registry: AdapterRegistry,
+): Promise<void> {
+  if (registry.prepareCompaction && registry.prepareCompactionSource !== "injected") return;
+
+  const failureReasons: string[] = [];
+  let attemptedPaths = false;
+  for (const packageRoot of packageRoots) {
+    for (const subpath of [
+      join("dist", "core", "compaction", "index.js"),
+      join("dist", "core", "compaction", "compaction.js"),
+    ]) {
+      const fullPath = join(packageRoot, subpath);
+      if (existsSync(fullPath)) {
+        attemptedPaths = true;
+        try {
+          const compModule = (await import(pathToFileURL(fullPath).href)) as {
+            prepareCompaction?: PrepareCompactionLike;
+          };
+          if (typeof compModule.prepareCompaction === "function") {
+            registry.prepareCompaction = compModule.prepareCompaction;
+            registry.prepareCompactionSource = fullPath;
+            registry.prepareCompactionFailure = undefined;
+            debugLog("inline_compaction.prepare_compaction", {
+              resolved: true,
+              source: fullPath,
+            });
+            return;
+          }
+          failureReasons.push(`${fullPath}: prepareCompaction is not a function`);
+        } catch (error) {
+          failureReasons.push(
+            `${fullPath}: ${error instanceof Error ? error.message : String(error)}`,
+          );
+        }
+      }
+    }
+  }
+
+  const failure =
+    failureReasons.length > 0
+      ? failureReasons.join("; ")
+      : attemptedPaths
+        ? "compaction module found but prepareCompaction was not exported"
+        : "no candidate compaction module paths found";
+  registry.prepareCompactionFailure = failure;
+  debugLog("inline_compaction.prepare_compaction", {
+    resolved: false,
+    failure,
+  });
+}
+
 export async function installHostInlineCompactionAdapter(
   options: HostInlineCompactionInstallOptions = {},
 ): Promise<InlineCompactionAdapterStatus> {
@@ -460,6 +541,15 @@ export async function installHostInlineCompactionAdapter(
     const root = findPiPackageRoot(hostPath);
     if (root) packageRoots.add(root);
   }
+
+  const registry = getRegistry();
+  if ("prepareCompaction" in options) {
+    registry.prepareCompaction = options.prepareCompaction;
+    registry.prepareCompactionSource = options.prepareCompaction ? "injected" : undefined;
+    registry.prepareCompactionFailure = undefined;
+  }
+
+  await resolveHostPrepareCompaction(packageRoots, registry);
 
   // Collect fast candidates first: per package root, pi's already-loaded
   // bundled runtime chunk (cache-hit, ~0-10ms). A root that resolves a chunk
@@ -524,6 +614,11 @@ export function installInlineCompactionAdapter(
   const sessionClass = options.sessionClass ?? (AgentSession as unknown as PatchableSessionClass);
   const prototype = sessionClass.prototype;
   const registry = getRegistry();
+  if ("prepareCompaction" in options) {
+    registry.prepareCompaction = options.prepareCompaction;
+    registry.prepareCompactionSource = options.prepareCompaction ? "injected" : undefined;
+    registry.prepareCompactionFailure = undefined;
+  }
   const existing = registry.installs.get(prototype);
   if (existing) return existing.status;
 
@@ -733,4 +828,50 @@ export async function compactInlineAtTurnBoundary(
     );
   }
   return result;
+}
+
+export function getCapturedCompactionSettings(
+  sessionManager: object,
+): CompactionSettingsLike | undefined {
+  const registry = getRegistry();
+  const record = registry.sessions.get(sessionManager);
+  if (record?.session?.settingsManager?.getCompactionSettings) {
+    return record.session.settingsManager.getCompactionSettings();
+  }
+  return undefined;
+}
+
+export function getPrepareCompactionStatus(): PrepareCompactionStatus {
+  const registry = getRegistry();
+  return {
+    resolved: typeof registry.prepareCompaction === "function",
+    source: registry.prepareCompactionSource,
+    failure: registry.prepareCompactionFailure,
+  };
+}
+
+export function isCompactionEligible(
+  sessionManager: object,
+  entries: unknown[],
+  customSettings?: CompactionSettingsLike,
+): boolean {
+  const prepare = getRegistry().prepareCompaction;
+  if (typeof prepare !== "function") {
+    // Unknown host capability: do not permanently disable compaction.
+    return true;
+  }
+
+  try {
+    const settings = customSettings ?? getCapturedCompactionSettings(sessionManager);
+    if (!settings) {
+      // Session not captured / settings unavailable: unknown host capability, do not block.
+      return true;
+    }
+
+    const prep = prepare(entries, settings);
+    return prep !== undefined;
+  } catch {
+    // Fail-open on unexpected error during settings resolution or preparation check so compaction is not blocked.
+    return true;
+  }
 }

--- a/tests/compaction-trigger.test.ts
+++ b/tests/compaction-trigger.test.ts
@@ -8,6 +8,7 @@
  *   - Uses await flushAll() instead of vi.runAllTimersAsync()
  *   - Skipped "does not await observer/reflect promises" test (not applicable)
  */
+import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
@@ -15,7 +16,11 @@ import {
   registerCompactionTrigger,
   resetMidRunRetry,
 } from "../src/om/compaction-trigger.js";
-import { InlineCompactionUnavailableError } from "../src/om/inline-compaction.js";
+import {
+  InlineCompactionUnavailableError,
+  installHostInlineCompactionAdapter,
+  installInlineCompactionAdapter,
+} from "../src/om/inline-compaction.js";
 import { compactionEntry, textCustomMessage, type TestEntry } from "./fixtures/session.js";
 
 /** Flush microtasks AND fire pending fake timers (setTimeout callbacks).
@@ -1114,5 +1119,298 @@ describe("Context-window-derived threshold (issue #60)", () => {
     await flushAll();
     expect(runtime.compactInFlight).toBe(false);
     expect(ctx.compact).not.toHaveBeenCalled();
+  });
+});
+
+describe("Eligibility guard (proactive auto-compaction Nothing to compact / session too small)", () => {
+  beforeEach(async () => {
+    vi.useFakeTimers();
+    const cliPath = join(
+      process.cwd(),
+      "node_modules",
+      "@earendil-works",
+      "pi-coding-agent",
+      "dist",
+      "bundle",
+      "cli.js",
+    );
+    await installHostInlineCompactionAdapter({ entrypoint: cliPath, stack: "" });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  const smallIneligibleBranch: TestEntry[] = [
+    {
+      type: "message",
+      id: "small-user-1",
+      parentId: null,
+      timestamp: "2026-05-02T10:00:00.000Z",
+      message: {
+        role: "user",
+        content: [{ type: "text", text: "a".repeat(4000) }],
+      },
+    },
+    {
+      type: "message",
+      id: "small-assistant-2",
+      parentId: null,
+      timestamp: "2026-05-02T10:00:00.000Z",
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "b".repeat(4000) }],
+        usage: { totalTokens: 85_000, inputTokens: 84_000, outputTokens: 1_000 },
+      },
+    },
+  ];
+
+  function makeLargeBranch(): TestEntry[] {
+    const branch: TestEntry[] = [];
+    for (let i = 0; i < 8; i++) {
+      branch.push({
+        type: "message",
+        id: `large-msg-${i}`,
+        parentId: null,
+        timestamp: "2026-05-02T10:00:00.000Z",
+        message: {
+          role: i % 2 === 0 ? "user" : "assistant",
+          content: [{ type: "text", text: "x".repeat(16_000) }],
+          ...(i === 7
+            ? { usage: { totalTokens: 85_000, inputTokens: 84_000, outputTokens: 1_000 } }
+            : {}),
+        },
+      });
+    }
+    return branch;
+  }
+
+  class TriggerTestSession {
+    settingsManager: {
+      getCompactionSettings: () => {
+        enabled: boolean;
+        reserveTokens: number;
+        keepRecentTokens: number;
+      };
+    };
+    sessionManager: {
+      buildSessionContext: () => { messages: unknown[] };
+      getBranch: () => TestEntry[];
+      getSessionId: () => string;
+    };
+    agent = { state: { messages: [] } };
+
+    constructor(
+      getBranchFn: () => TestEntry[],
+      settings: { enabled?: boolean; reserveTokens?: number; keepRecentTokens?: number },
+    ) {
+      this.settingsManager = {
+        getCompactionSettings: () => ({
+          enabled: settings.enabled ?? true,
+          reserveTokens: settings.reserveTokens ?? 1000,
+          keepRecentTokens: settings.keepRecentTokens ?? 20_000,
+        }),
+      };
+      this.sessionManager = {
+        buildSessionContext: () => ({ messages: [] }),
+        getBranch: getBranchFn,
+        getSessionId: () => "test-session-settings",
+      };
+    }
+
+    async compact() {
+      await this.abort();
+      (this as any).sessionManager.appendCompaction?.();
+      this.agent.state.messages = [];
+    }
+
+    async abort() {}
+
+    _bindExtensionCore(runner: unknown) {
+      void runner;
+    }
+  }
+
+  function ctxWithSettings(
+    branchOrBranches: TestEntry[] | TestEntry[][],
+    settings: { enabled?: boolean; reserveTokens?: number; keepRecentTokens?: number } = {
+      enabled: true,
+      reserveTokens: 1000,
+      keepRecentTokens: 20_000,
+    },
+    overrides: Record<string, unknown> = {},
+  ) {
+    const branches =
+      Array.isArray(branchOrBranches[0]) && "type" in (branchOrBranches[0] as any) === false
+        ? (branchOrBranches as TestEntry[][])
+        : [branchOrBranches as TestEntry[]];
+    let branchIndex = 0;
+    const getBranch = vi.fn(() => branches[Math.min(branchIndex++, branches.length - 1)]);
+
+    installInlineCompactionAdapter({ sessionClass: TriggerTestSession as never });
+    const session = new TriggerTestSession(getBranch, settings);
+    session._bindExtensionCore({});
+
+    return fakeCtx(branches, {
+      sessionManager: session.sessionManager,
+      ...overrides,
+    });
+  }
+
+  it("skips settled auto-compaction initially when provider threshold is reached but session entries are ineligible", async () => {
+    const { handler, runtime } = captureHandler({ compactAfterTokens: 81_000 });
+    const ctx = ctxWithSettings(smallIneligibleBranch);
+
+    handler(agentEnd(), ctx);
+    expect(runtime.compactInFlight).toBe(false);
+    await flushAll();
+
+    expect(ctx.compact).not.toHaveBeenCalled();
+    const infoNotices = ctx.ui.notify.mock.calls.filter((call) => call[1] === "info");
+    expect(
+      infoNotices.some((call) => String(call[0]).includes("compaction threshold reached")),
+    ).toBe(false);
+  });
+
+  it("deferred recheck skips compaction when session becomes ineligible before agent settles", async () => {
+    const { handler, runtime } = captureHandler({ compactAfterTokens: 81_000 });
+    const largeBranch = makeLargeBranch();
+    let idle = false;
+    const branches = [largeBranch, smallIneligibleBranch];
+    const ctx = ctxWithSettings(
+      branches,
+      {
+        enabled: true,
+        reserveTokens: 1000,
+        keepRecentTokens: 20_000,
+      },
+      {
+        isIdle: vi.fn(() => idle),
+      },
+    );
+
+    handler(agentEnd(), ctx);
+    // Initial check on large branch passes and marks compactInFlight
+    expect(runtime.compactInFlight).toBe(true);
+
+    // Agent becomes idle, but now the branch has switched to smallIneligibleBranch
+    idle = true;
+    await flushAll();
+    await advanceRetryTicks(1);
+
+    expect(runtime.compactInFlight).toBe(false);
+    expect(ctx.compact).not.toHaveBeenCalled();
+  });
+
+  it("resumes auto-compaction after history grows past keepRecentTokens", async () => {
+    const { handler, runtime } = captureHandler({ compactAfterTokens: 81_000 });
+    const ineligibleCtx = ctxWithSettings(smallIneligibleBranch);
+
+    // Turn 1: ineligible -> skipped
+    handler(agentEnd(), ineligibleCtx);
+    await flushAll();
+    expect(ineligibleCtx.compact).not.toHaveBeenCalled();
+    expect(runtime.compactInFlight).toBe(false);
+
+    // Turn 2: history grew to largeBranch -> eligible
+    const eligibleCtx = ctxWithSettings(makeLargeBranch());
+    handler(agentEnd(), eligibleCtx);
+    expect(runtime.compactInFlight).toBe(true);
+    await flushAll();
+
+    expect(eligibleCtx.compact).toHaveBeenCalledTimes(1);
+  });
+
+  it("respects effective configured keepRecentTokens rather than a hardcoded 20k", async () => {
+    const { handler, runtime } = captureHandler({ compactAfterTokens: 81_000 });
+    // Small branch has ~2k tokens. Under keepRecentTokens: 500, it IS eligible!
+    const ctx = ctxWithSettings(smallIneligibleBranch, {
+      enabled: true,
+      reserveTokens: 500,
+      keepRecentTokens: 500,
+    });
+
+    handler(agentEnd(), ctx);
+    expect(runtime.compactInFlight).toBe(true);
+    await flushAll();
+
+    expect(ctx.compact).toHaveBeenCalledTimes(1);
+  });
+
+  it("mid-run mode (resume): skips inline compaction when threshold reached but session is ineligible", async () => {
+    const { turnHandler, runtime, inlineCompact } = captureHandler({
+      compactAfterTokens: 81_000,
+      midRunCompaction: "resume",
+    });
+    const ctx = ctxWithSettings(smallIneligibleBranch);
+
+    await turnHandler(turnEnd(), ctx);
+
+    expect(inlineCompact).not.toHaveBeenCalled();
+    expect(runtime.midRunCompactionRetry.failures).toBe(0);
+    const infoNotices = ctx.ui.notify.mock.calls.filter((call) => call[1] === "info");
+    expect(
+      infoNotices.some((call) => String(call[0]).includes("compaction threshold reached mid-run")),
+    ).toBe(false);
+  });
+
+  it("mid-run mode (pause): skips pause compaction when threshold reached but session is ineligible", async () => {
+    const { turnHandler, runtime } = captureHandler({
+      compactAfterTokens: 81_000,
+      midRunCompaction: "pause",
+    });
+    const ctx = ctxWithSettings(smallIneligibleBranch);
+
+    await turnHandler(turnEnd(), ctx);
+
+    expect(ctx.compact).not.toHaveBeenCalled();
+    expect(runtime.midRunCompactionRetry.failures).toBe(0);
+    const infoNotices = ctx.ui.notify.mock.calls.filter((call) => call[1] === "info");
+    expect(
+      infoNotices.some((call) => String(call[0]).includes("compaction threshold reached mid-run")),
+    ).toBe(false);
+  });
+
+  it("genuine compaction errors remain visible when eligible compaction fails", async () => {
+    const { handler } = captureHandler({ compactAfterTokens: 81_000 });
+    const ctx = ctxWithSettings(makeLargeBranch(), undefined, {
+      compact: vi.fn((options: any) => {
+        options?.onError?.(new Error("API rate limit exceeded: quota 0"));
+      }),
+    });
+
+    handler(agentEnd(), ctx);
+    await flushAll();
+
+    expect(ctx.compact).toHaveBeenCalledTimes(1);
+    const errorNotices = ctx.ui.notify.mock.calls.filter((call) => call[1] === "error");
+    expect(errorNotices.length).toBeGreaterThan(0);
+    expect(errorNotices.some((call) => String(call[0]).includes("API rate limit exceeded"))).toBe(
+      true,
+    );
+  });
+
+  it("fails open and proceeds with compaction when settings are unavailable (session not captured)", async () => {
+    const { handler, runtime } = captureHandler({ compactAfterTokens: 3 });
+    // Bare mock session with no settingsManager captured
+    const ctx = fakeCtx([dueBranch]);
+
+    handler(agentEnd(), ctx);
+    expect(runtime.compactInFlight).toBe(true);
+    await flushAll();
+
+    expect(ctx.compact).toHaveBeenCalledTimes(1);
+  });
+
+  it("fails open and proceeds with compaction when prepareCompaction is unavailable", async () => {
+    installInlineCompactionAdapter({ prepareCompaction: undefined });
+    const { handler, runtime } = captureHandler({ compactAfterTokens: 81_000 });
+    const ctx = ctxWithSettings(smallIneligibleBranch);
+
+    handler(agentEnd(), ctx);
+    expect(runtime.compactInFlight).toBe(true);
+    await flushAll();
+
+    expect(ctx.compact).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/inline-compaction.test.ts
+++ b/tests/inline-compaction.test.ts
@@ -10,9 +10,12 @@ import { convertToLlm } from "@earendil-works/pi-coding-agent";
 
 import {
   compactInlineAtTurnBoundary,
+  getCapturedCompactionSettings,
+  getPrepareCompactionStatus,
   InlineCompactionUnavailableError,
   installHostInlineCompactionAdapter,
   installInlineCompactionAdapter,
+  isCompactionEligible,
   parseHostFramePaths,
 } from "../src/om/inline-compaction.js";
 import { createPiAgentSessionHarness } from "./fixtures/pi-agent-session.js";
@@ -829,5 +832,149 @@ describe("Blackhole inline compaction adapter", () => {
       supported: true,
     });
     expect(SessionClass.prototype._bindExtensionCore).toBe(patchedBind);
+  });
+
+  it("captures compaction settings from the session settingsManager", () => {
+    const SessionClass = createSessionClass({ legacyDisconnect: false });
+    installInlineCompactionAdapter({ sessionClass: SessionClass as never });
+    const session = new SessionClass();
+    (session as any).settingsManager = {
+      getCompactionSettings: () => ({
+        enabled: true,
+        reserveTokens: 2048,
+        keepRecentTokens: 5000,
+      }),
+    };
+    session._bindExtensionCore({});
+
+    const settings = getCapturedCompactionSettings(session.sessionManager);
+    expect(settings).toEqual({
+      enabled: true,
+      reserveTokens: 2048,
+      keepRecentTokens: 5000,
+    });
+  });
+
+  it("returns false from isCompactionEligible when prepareCompaction yields undefined (ineligible)", () => {
+    const SessionClass = createSessionClass({ legacyDisconnect: false });
+    installInlineCompactionAdapter({
+      sessionClass: SessionClass as never,
+      prepareCompaction: () => undefined,
+    });
+    const session = new SessionClass();
+    (session as any).settingsManager = {
+      getCompactionSettings: () => ({
+        enabled: true,
+        reserveTokens: 1000,
+        keepRecentTokens: 20000,
+      }),
+    };
+    session._bindExtensionCore({});
+
+    expect(isCompactionEligible(session.sessionManager, [])).toBe(false);
+  });
+
+  it("returns true from isCompactionEligible when prepareCompaction returns a preparation (eligible)", () => {
+    const SessionClass = createSessionClass({ legacyDisconnect: false });
+    installInlineCompactionAdapter({
+      sessionClass: SessionClass as never,
+      prepareCompaction: () => ({ firstKeptEntryId: "entry-1" }),
+    });
+    const session = new SessionClass();
+    (session as any).settingsManager = {
+      getCompactionSettings: () => ({
+        enabled: true,
+        reserveTokens: 1000,
+        keepRecentTokens: 20000,
+      }),
+    };
+    session._bindExtensionCore({});
+
+    expect(isCompactionEligible(session.sessionManager, [])).toBe(true);
+  });
+
+  it("fails open (returns true) from isCompactionEligible when prepareCompaction throws", () => {
+    const SessionClass = createSessionClass({ legacyDisconnect: false });
+    installInlineCompactionAdapter({
+      sessionClass: SessionClass as never,
+      prepareCompaction: () => {
+        throw new Error("unexpected error");
+      },
+    });
+    const session = new SessionClass();
+    (session as any).settingsManager = {
+      getCompactionSettings: () => ({
+        enabled: true,
+        reserveTokens: 1000,
+        keepRecentTokens: 20000,
+      }),
+    };
+    session._bindExtensionCore({});
+
+    expect(isCompactionEligible(session.sessionManager, [])).toBe(true);
+  });
+
+  it("fails open (returns true) from isCompactionEligible when prepareCompaction is unavailable", () => {
+    const SessionClass = createSessionClass({ legacyDisconnect: false });
+    installInlineCompactionAdapter({
+      sessionClass: SessionClass as never,
+      prepareCompaction: undefined,
+    });
+    const session = new SessionClass();
+    (session as any).settingsManager = {
+      getCompactionSettings: () => ({
+        enabled: true,
+        reserveTokens: 1000,
+        keepRecentTokens: 20000,
+      }),
+    };
+    session._bindExtensionCore({});
+
+    expect(isCompactionEligible(session.sessionManager, [])).toBe(true);
+  });
+
+  it("fails open (returns true) from isCompactionEligible when settings are unavailable (session not captured)", () => {
+    installInlineCompactionAdapter({
+      prepareCompaction: () => undefined,
+    });
+    const uncapturedSessionManager = { buildSessionContext: () => ({ messages: [] }) };
+    expect(isCompactionEligible(uncapturedSessionManager, [])).toBe(true);
+  });
+
+  it("fails open (returns true) from isCompactionEligible when settingsManager getter throws", () => {
+    const SessionClass = createSessionClass({ legacyDisconnect: false });
+    installInlineCompactionAdapter({
+      sessionClass: SessionClass as never,
+      prepareCompaction: () => undefined,
+    });
+    const session = new SessionClass();
+    (session as any).settingsManager = {
+      getCompactionSettings: () => {
+        throw new Error("corrupt settings");
+      },
+    };
+    session._bindExtensionCore({});
+
+    expect(isCompactionEligible(session.sessionManager, [])).toBe(true);
+  });
+
+  it("resolves prepareCompaction from the host package root via installHostInlineCompactionAdapter", async () => {
+    const cliPath = join(
+      process.cwd(),
+      "node_modules",
+      "@earendil-works",
+      "pi-coding-agent",
+      "dist",
+      "bundle",
+      "cli.js",
+    );
+    const status = await installHostInlineCompactionAdapter({
+      entrypoint: cliPath,
+      stack: "",
+    });
+    expect(status.supported).toBe(true);
+    const prepareStatus = getPrepareCompactionStatus();
+    expect(prepareStatus.resolved).toBe(true);
+    expect(prepareStatus.source).toContain("compaction");
   });
 });


### PR DESCRIPTION
## Problem

Provider context usage can exceed Blackhole's proactive compaction threshold while the removable conversation history remains below Pi's `keepRecentTokens` budget. Pi then returns no preparation and rejects `compact()` with `Nothing to compact (session too small)` before extension hooks run. Repeated proactive attempts produce trigger notices and duplicate errors without freeing context.

Related report: https://github.com/earendil-works/pi/issues/6751

## Change

- Use the host Pi's native `prepareCompaction()` and the effective settings from the already-captured `AgentSession` to check eligibility.
- Check before settled and mid-run proactive triggers, and again after the settled trigger's deferred idle wait.
- Skip known-ineligible attempts without notices, retry failures, or a persistent suppression latch; re-evaluate as history grows.
- Fail open when host preparation/settings are unavailable or throw. Keep manual compaction, native overflow recovery, provider-usage accounting, and threshold presets unchanged.
- Share host-module discovery and expose its resolution status for inspection.

## Verification

- Regression tests reproduced the premature attempts before the guard was added.
- Capture-path tests exercise `installInlineCompactionAdapter` and `_bindExtensionCore`, rather than a test-only settings fallback.
- Covered settled/deferred/mid-run paths, growth resumption, custom keep budgets, genuine errors, unavailable capabilities, throwing getters, and production module discovery.
- `pnpm build`, `pnpm typecheck`, `pnpm lint`, `pnpm format:check`: passed (existing lint warnings only).
- `pnpm test`: **103 files, 1,817 tests passed**.
- Isolated installed Pi **0.85.1** startup smoke loaded the packaged extension, captured the real host settings, rejected small histories, and accepted large histories. Synthetic data only; no model calls or user-session writes.
- Independent Fable 5-1 high review approved after remediation.

## Compatibility notes

Pi does not publicly export `prepareCompaction`, so this uses the host's modular compaction entrypoint. Unavailable internals preserve the previous fail-open behavior. Initial discovery is awaited for deterministic readiness (approximately 209 ms in one cold installed-host measurement); subsequent calls reuse the cached function.

Startup discovery debug-log calls are not emitted without a debug context; the status accessor and normal event-scoped skip logs remain available. No new settings or dependencies are introduced.
